### PR TITLE
Add Engine abstraction

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,12 @@
+use types::StratisResult;
+
+pub trait Pool {
+    fn add_blockdev(&mut self, path: &str) -> StratisResult<()>;
+    fn add_cachedev(&mut self, path: &str) -> StratisResult<()>;
+    fn destroy(&mut self) -> StratisResult<()>;
+}
+
+pub trait Engine {
+    fn create_pool(&self, name: &str, blockdev_paths: &[&str]) -> StratisResult<Box<Pool>>;
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ use std::error::Error;
 use std::process::exit;
 use std::path::{Path, PathBuf};
 use std::borrow::Cow;
+use std::rc::Rc;
+use std::cell::RefCell;
 
 use bytesize::ByteSize;
 use dbus::{Connection, BusType, Message, MessageItem, FromMessageItem, Props};
@@ -394,7 +396,7 @@ fn teardown(args: &ArgMatches) -> StratisResult<()> {
     Ok(())
 }
 
-fn dbus_server() -> StratisResult<()> {
+fn dbus_server(engine: Rc<RefCell<Engine>>) -> StratisResult<()> {
 
     let c = try!(Connection::stratis_connect());
 
@@ -402,7 +404,7 @@ fn dbus_server() -> StratisResult<()> {
     // register two trees, one with Create and Destroy and another for
     // querying/changing active Stratisdevs/
 
-    let base_tree = try!(dbus_api::get_base_tree(&c));
+    let base_tree = try!(dbus_api::get_base_tree(&c, engine));
 
     // TODO: event loop needs to handle dbus and also dm events (or polling)
     // so we can extend/reshape/delay/whatever in a timely fashion
@@ -443,10 +445,10 @@ fn write_err(err: StratisError) -> StratisResult<()> {
 
 fn main() {
 
-    let engine = SimEngine::new();
+    let engine = Rc::new(RefCell::new(SimEngine::new()));
     // TODO: add cmdline option to specify engine
 
-    let r = dbus_server();
+    let r = dbus_server(engine);
 
     if let Err(r) = r {
         if let Err(e) = write_err(r) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,8 @@ mod util;
 mod dbus_api;
 mod blockdev;
 mod filesystem;
+mod engine;
+mod sim_engine;
 
 use std::io::Write;
 use std::error::Error;
@@ -55,7 +57,8 @@ use dbus_consts::DBUS_TIMEOUT;
 use consts::SECTOR_SIZE;
 //use stratis::Stratis;
 use clap::ArgMatches;
-
+use engine::Engine;
+use sim_engine::SimEngine;
 
 // We are given BlockDevs to start.
 // We allocate LinearDevs from each for the meta and data devices.
@@ -439,6 +442,9 @@ fn write_err(err: StratisError) -> StratisResult<()> {
 }
 
 fn main() {
+
+    let engine = SimEngine::new();
+    // TODO: add cmdline option to specify engine
 
     let r = dbus_server();
 

--- a/src/sim_engine.rs
+++ b/src/sim_engine.rs
@@ -1,0 +1,53 @@
+
+use types::StratisResult;
+use engine::{Engine, Pool};
+
+
+pub struct SimEngine {
+
+}
+
+impl SimEngine {
+    pub fn new() -> SimEngine {
+        SimEngine {
+        }
+    }
+}
+
+impl Engine for SimEngine {
+    fn create_pool(&self, name: &str, blockdev_paths: &[&str]) -> StratisResult<Box<Pool>> {
+        println!("sim: pool created");
+
+        Ok(Box::new(SimPool::new()))
+    }
+
+}
+
+struct SimPool {
+    tmp: u32,
+}
+
+impl SimPool {
+    fn new() -> SimPool {
+        SimPool {
+            tmp: 4,
+        }
+    }
+}
+
+impl Pool for SimPool {
+    fn add_blockdev(&mut self, path: &str) -> StratisResult<()> {
+        println!("sim: pool::add_blockdev");
+        Ok(())
+    }
+
+    fn add_cachedev(&mut self, path: &str) -> StratisResult<()> {
+        println!("sim: pool::add_cachedev");
+        Ok(())
+    }
+
+    fn destroy(&mut self) -> StratisResult<()> {
+        println!("sim: pool::destroy");
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds an abstraction to a backend "engine" that will service requests that come in over DBus. The exact format and number of methods in `Engine` and `Pool` traits, as well as additional traits that may be added, are expected to grow and change significantly.

The second commit hooks a single DBus method handler up to the engine as an example for when @trgill deems it time to hook up the rest of the API to the engine.