### PR TITLE
Use &Path rather than PathBuf for blockdev paths

### DIFF
--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -46,7 +46,7 @@ impl BlockDev {
 pub struct BlockDevs(pub BTreeMap<String, BlockMember>);
 
 impl BlockDevs {
-    pub fn new(blockdev_paths: &[PathBuf]) -> StratisResult<BlockDevs> {
+    pub fn new(blockdev_paths: &[&Path]) -> StratisResult<BlockDevs> {
         let mut block_devs = BlockDevs(BTreeMap::new());
 
         let stratis_id = Uuid::new_v4().to_simple_string();

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt::Display;
-use std::path::PathBuf;
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -97,8 +97,8 @@ fn create_pool(m: &Message, engine: &Rc<RefCell<Engine>>) -> MethodResult {
                 .map(|i| i.to_owned())
         }));
 
-    let blockdevs = devs.into_iter()
-        .map(|x| PathBuf::from(x.inner::<&str>().unwrap()))
+    let blockdevs = devs.iter()
+        .map(|x| Path::new(x.inner::<&str>().unwrap()))
         .collect::<Vec<_>>();
 
     let result = engine.borrow_mut().create_pool(&name, &blockdevs, raid_level);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::cell::RefCell;
-use std::path::PathBuf;
+use std::path::Path;
 use std::collections::HashMap;
 use std::collections::BTreeMap;
 
@@ -14,7 +14,7 @@ use pool::{Pool, StratisPool};
 pub trait Engine {
     fn create_pool(&mut self,
                    name: &str,
-                   blockdev_paths: &[PathBuf],
+                   blockdev_paths: &[&Path],
                    raid_level: u16)
                    -> StratisResult<()>;
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use types::StratisResult;
 use blockdev::BlockDevs;
@@ -26,7 +26,7 @@ pub struct Pool {
 }
 
 impl Pool {
-    pub fn new_pool(name: &str, blockdev_paths: &[PathBuf], raid_level: u16) -> Box<StratisPool> {
+    pub fn new_pool(name: &str, blockdev_paths: &[&Path], raid_level: u16) -> Box<StratisPool> {
 
         let status = BlockDevs::new(blockdev_paths);
 

--- a/src/sim_engine.rs
+++ b/src/sim_engine.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::collections::BTreeMap;
 use types::StratisResult;
 use engine::Engine;
@@ -23,7 +23,7 @@ impl SimEngine {
 impl Engine for SimEngine {
     fn create_pool(&mut self,
                    name: &str,
-                   blockdev_paths: &[PathBuf],
+                   blockdev_paths: &[&Path],
                    raid_level: u16)
                    -> StratisResult<()> {
 
@@ -63,7 +63,7 @@ pub struct SimPool {
 }
 
 impl SimPool {
-    pub fn new_pool(name: &str, blockdev_paths: &[PathBuf], raid_level: u16) -> Box<StratisPool> {
+    pub fn new_pool(name: &str, blockdev_paths: &[&Path], raid_level: u16) -> Box<StratisPool> {
 
         let status = BlockDevs::new(blockdev_paths);
 


### PR DESCRIPTION
We don't strictly need owned paths, since we're not moving, modifying,
or extending them, so we can just take borrowed paths, &Path. The only
substantive change this needs is that in dbus_api.rs create_pool(), instead
of creating a Vec of PathBufs, we create a Vec of &Paths (they still
reference entries in 'devs', thus saving us some memory allocations.

fixes #53

Signed-off-by: Andy Grover <agrover@redhat.com>