### PR TITLE
Update to dbus-rs 0.4 and use new features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Todd Gill <tgill@redhat.com>", "Andy Grover <agrover@redhat.com>"]
 
 
 [dependencies]
-dbus = "0.3"
+dbus = "0.4"
 clap = "1"
 nix = "0"
 devicemapper = "0.4.0"


### PR DESCRIPTION
Instead of closing over local variables to access dbus context and engine
in each dbus method, dbus-rs 0.4 passes a MethodInfo struct that contains
data defined by us. This simplifies get_base_tree a lot.

Add engine to DbusContext. But, since engine doesn't implement Debug, we
can no longer derive Debug for DbusContext and need to implement it.

Signed-off-by: Andy Grover <agrover@redhat.com>