### PR TITLE
Changes to dbus api methods

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -99,13 +99,14 @@ fn list_pools(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         Ok(pool_tree) => {
             let msg_vec =
                 pool_tree.keys().map(|key| MessageItem::Str(format!("{}", key))).collect();
-            let item_array = MessageItem::Array(msg_vec, Cow::Borrowed("s"));
+            let item_array = MessageItem::Array(msg_vec, "s".into());
             let (rc, rs) = code_to_message_items(StratisErrorEnum::STRATIS_OK);
             return_message.append3(item_array, rc, rs)
         }
         Err(x) => {
+            let item_array = MessageItem::Array(vec![], "s".into());
             let (rc, rs) = code_to_message_items(internal_to_dbus_err(&x));
-            return_message.append3(MessageItem::ObjectPath("/".into()), rc, rs)
+            return_message.append3(item_array, rc, rs)
         }
     };
     Ok(vec![msg])

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -206,10 +206,10 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let name: &str = try!(iter.read::<&str>().map_err(|_| MethodErr::invalid_arg(&0)));
 
     if iter.arg_type() == 0 { return Err(MethodErr::no_arg()) }
-    let devs: Array<&str, _> = try!(iter.read::<Array<&str, _>>().map_err(|_| MethodErr::invalid_arg(&1)));
+    let raid_level: u16 = try!(iter.read::<u16>().map_err(|_| MethodErr::invalid_arg(&1)));
 
     if iter.arg_type() == 0 { return Err(MethodErr::no_arg()) }
-    let raid_level: u16 = try!(iter.read::<u16>().map_err(|_| MethodErr::invalid_arg(&2)));
+    let devs: Array<&str, _> = try!(iter.read::<Array<&str, _>>().map_err(|_| MethodErr::invalid_arg(&2)));
 
     let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
@@ -317,8 +317,8 @@ fn get_base_tree<'a>(dbus_context: Rc<RefCell<DbusContext>>)
 
     let createpool_method = f.method(CREATE_POOL, (), create_pool)
         .in_arg(("pool_name", "s"))
-        .in_arg(("dev_list", "as"))
         .in_arg(("raid_type", "q"))
+        .in_arg(("dev_list", "as"))
         .out_arg(("object_path", "o"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -87,6 +87,10 @@ fn code_to_message_items(code: StratisErrorEnum) -> (MessageItem, MessageItem) {
     (MessageItem::UInt16(code.get_error_int()), MessageItem::Str(code.get_error_string().into()))
 }
 
+fn default_object_path<'a>() -> dbus::Path<'a> {
+    dbus::Path::new(DEFAULT_OBJECT_PATH).unwrap()
+}
+
 fn list_pools(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let dbus_context = m.path.get_data();
@@ -231,8 +235,9 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(MessageItem::ObjectPath(object_path), rc, rs)
         }
         Err(x) => {
+            let object_path: dbus::Path = default_object_path();
             let (rc, rs) = code_to_message_items(internal_to_dbus_err(&x));
-            return_message.append3(MessageItem::ObjectPath("/".into()), rc, rs)
+            return_message.append3(MessageItem::ObjectPath(object_path), rc, rs)
         }
     };
     Ok(vec![msg])

--- a/src/dbus_consts.rs
+++ b/src/dbus_consts.rs
@@ -16,6 +16,8 @@ pub const STRATIS_DEV_BASE_INTERFACE: &'static str = "org.storage.stratis1.dev";
 pub const STRATIS_CACHE_BASE_INTERFACE: &'static str = "org.storage.stratis1.cache";
 pub const STRATIS_POOL_BASE_PATH: &'static str = "/org/storage/stratis/pool";
 
+pub const DEFAULT_OBJECT_PATH: &'static str = "/";
+
 // Manager Methods
 pub const LIST_POOLS: &'static str = "ListPools";
 pub const CREATE_POOL: &'static str = "CreatePool";


### PR DESCRIPTION
Uses the recommended approach for extracting data from message.

Distinguishes between missing args and invalid types of args.

If invalid type of arg, gives the _index_ of the argument, not its actual value, which I think is just as good.

Also, swaps the order of devs and raidtype in create_pool.