### PR TITLE
Add the standard license header for rust files.

### DIFF
--- a/license-headers/rust.txt
+++ b/license-headers/rust.txt
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Signed-off-by: mulhern <amulhern@redhat.com>