### PR TITLE
Rename volume to filesystem / Minor Cleanup

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -120,16 +120,16 @@ fn list_pools(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 }
 
 
-fn create_volumes(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     Ok(vec![m.msg.method_return().append3("/dbus/cache/path", 0, "Ok")])
 }
 
-fn destroy_volumes(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     Ok(vec![m.msg.method_return().append3("/dbus/cache/path", 0, "Ok")])
 }
 
-fn list_volumes(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+fn list_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     Ok(vec![m.msg.method_return().append3("/dbus/cache/path", 0, "Ok")])
 }
 
@@ -165,11 +165,11 @@ fn create_dbus_pool<'a>(dbus_context: Rc<RefCell<DbusContext>>) -> dbus::Path<'a
 
     let f = Factory::new_fn();
 
-    let create_volumes_method = f.method(CREATE_VOLUMES, (), create_volumes);
+    let create_filesystems_method = f.method(CREATE_FILESYSTEMS, (), create_filesystems);
 
-    let destroy_volumes_method = f.method(DESTROY_VOLUMES, (), destroy_volumes);
+    let destroy_filesystems_method = f.method(DESTROY_FILESYSTEMS, (), destroy_filesystems);
 
-    let list_volumes_method = f.method(LIST_VOLUMES, (), list_volumes);
+    let list_filesystems_method = f.method(LIST_FILESYSTEMS, (), list_filesystems);
 
     let list_devs_method = f.method(LIST_DEVS, (), list_devs);
 
@@ -190,9 +190,9 @@ fn create_dbus_pool<'a>(dbus_context: Rc<RefCell<DbusContext>>) -> dbus::Path<'a
     let object_path = f.object_path(object_name, dbus_context.clone())
         .introspectable()
         .add(f.interface(STRATIS_MANAGER_INTERFACE, ())
-            .add_m(create_volumes_method)
-            .add_m(destroy_volumes_method)
-            .add_m(list_volumes_method)
+            .add_m(create_filesystems_method)
+            .add_m(destroy_filesystems_method)
+            .add_m(list_filesystems_method)
             .add_m(list_devs_method)
             .add_m(list_cache_devs_method)
             .add_m(add_cache_devs_method)
@@ -285,8 +285,8 @@ fn get_pool_object_path(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     Ok(vec![m.msg.method_return().append3("/dbus/pool/path", 0, "Ok")])
 }
 
-fn get_volume_object_path(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
-    Ok(vec![m.msg.method_return().append3("/dbus/volume/path", 0, "Ok")])
+fn get_filesystem_object_path(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+    Ok(vec![m.msg.method_return().append3("/dbus/filesystem/path", 0, "Ok")])
 }
 
 fn get_dev_object_path(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -356,12 +356,13 @@ fn get_base_tree<'a>(dbus_context: Rc<RefCell<DbusContext>>)
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let getvolumeobjectpath_method = f.method(GET_VOLUME_OBJECT_PATH, (), get_volume_object_path)
-        .in_arg(("pool_name", "s"))
-        .in_arg(("volume_name", "s"))
-        .out_arg(("object_path", "o"))
-        .out_arg(("return_code", "q"))
-        .out_arg(("return_string", "s"));
+    let getfilesystemobjectpath_method =
+        f.method(GET_FILESYSTEM_OBJECT_PATH, (), get_filesystem_object_path)
+            .in_arg(("pool_name", "s"))
+            .in_arg(("filesystem_name", "s"))
+            .out_arg(("object_path", "o"))
+            .out_arg(("return_code", "q"))
+            .out_arg(("return_string", "s"));
 
     let getdevobjectpath_method = f.method(GET_DEV_OBJECT_PATH, (), get_dev_object_path)
         .in_arg(("dev_name", "s"))
@@ -390,7 +391,7 @@ fn get_base_tree<'a>(dbus_context: Rc<RefCell<DbusContext>>)
             .add_m(createpool_method)
             .add_m(destroypool_method)
             .add_m(getpoolobjectpath_method)
-            .add_m(getvolumeobjectpath_method)
+            .add_m(getfilesystemobjectpath_method)
             .add_m(getdevobjectpath_method)
             .add_m(getcacheobjectpath_method)
             .add_m(geterrorcodes_method)

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -332,7 +332,7 @@ fn get_base_tree<'a>(dbus_context: Rc<RefCell<DbusContext>>)
 
     let base_tree = f.tree();
 
-    let createpool_method = f.method(CREATE_POOL, (), create_pool)
+    let create_pool_method = f.method(CREATE_POOL, (), create_pool)
         .in_arg(("pool_name", "s"))
         .in_arg(("raid_type", "q"))
         .in_arg(("dev_list", "as"))
@@ -340,23 +340,23 @@ fn get_base_tree<'a>(dbus_context: Rc<RefCell<DbusContext>>)
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let destroypool_method = f.method(DESTROY_POOL, (), destroy_pool)
+    let destroy_pool_method = f.method(DESTROY_POOL, (), destroy_pool)
         .in_arg(("pool_name", "s"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let listpools_method = f.method(LIST_POOLS, (), list_pools)
+    let list_pools_method = f.method(LIST_POOLS, (), list_pools)
         .out_arg(("pool_names", "as"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let getpoolobjectpath_method = f.method(GET_POOL_OBJECT_PATH, (), get_pool_object_path)
+    let get_pool_object_path_method = f.method(GET_POOL_OBJECT_PATH, (), get_pool_object_path)
         .in_arg(("pool_name", "s"))
         .out_arg(("object_path", "o"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let getfilesystemobjectpath_method =
+    let get_filesystem_object_path_method =
         f.method(GET_FILESYSTEM_OBJECT_PATH, (), get_filesystem_object_path)
             .in_arg(("pool_name", "s"))
             .in_arg(("filesystem_name", "s"))
@@ -364,39 +364,39 @@ fn get_base_tree<'a>(dbus_context: Rc<RefCell<DbusContext>>)
             .out_arg(("return_code", "q"))
             .out_arg(("return_string", "s"));
 
-    let getdevobjectpath_method = f.method(GET_DEV_OBJECT_PATH, (), get_dev_object_path)
+    let get_dev_object_path_method = f.method(GET_DEV_OBJECT_PATH, (), get_dev_object_path)
         .in_arg(("dev_name", "s"))
         .out_arg(("object_path", "o"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let getcacheobjectpath_method = f.method(GET_CACHE_OBJECT_PATH, (), get_cache_object_path)
+    let get_cache_object_path_method = f.method(GET_CACHE_OBJECT_PATH, (), get_cache_object_path)
         .in_arg(("cache_dev_name", "s"))
         .out_arg(("object_path", "o"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let geterrorcodes_method = f.method(GET_ERROR_CODES, (), get_error_codes)
+    let get_error_codes_method = f.method(GET_ERROR_CODES, (), get_error_codes)
         .out_arg(("error_codes", "a(sqs)"));
 
-    let getraidlevels_method = f.method(GET_RAID_LEVELS, (), get_raid_levels)
+    let get_raid_levels_method = f.method(GET_RAID_LEVELS, (), get_raid_levels)
         .out_arg(("error_codes", "a(sqs)"));
 
-    let getdevtypes_method = f.method(GET_DEV_TYPES, (), get_dev_types);
+    let get_dev_types_method = f.method(GET_DEV_TYPES, (), get_dev_types);
 
     let obj_path = f.object_path(STRATIS_BASE_PATH, dbus_context)
         .introspectable()
         .add(f.interface(STRATIS_MANAGER_INTERFACE, ())
-            .add_m(listpools_method)
-            .add_m(createpool_method)
-            .add_m(destroypool_method)
-            .add_m(getpoolobjectpath_method)
-            .add_m(getfilesystemobjectpath_method)
-            .add_m(getdevobjectpath_method)
-            .add_m(getcacheobjectpath_method)
-            .add_m(geterrorcodes_method)
-            .add_m(getraidlevels_method)
-            .add_m(getdevtypes_method));
+            .add_m(list_pools_method)
+            .add_m(create_pool_method)
+            .add_m(destroy_pool_method)
+            .add_m(get_pool_object_path_method)
+            .add_m(get_filesystem_object_path_method)
+            .add_m(get_dev_object_path_method)
+            .add_m(get_cache_object_path_method)
+            .add_m(get_error_codes_method)
+            .add_m(get_raid_levels_method)
+            .add_m(get_dev_types_method));
 
 
     let base_tree = base_tree.add(obj_path);

--- a/src/dbus_consts.rs
+++ b/src/dbus_consts.rs
@@ -11,7 +11,7 @@ pub const STRATIS_BASE_SERVICE: &'static str = "org.storage.stratis1";
 pub const STRATIS_BASE_MANAGER: &'static str = "/org/storage/stratis1/Manager";
 pub const STRATIS_MANAGER_INTERFACE: &'static str = "org.storage.stratis1.Manager";
 pub const STRATIS_POOL_BASE_INTERFACE: &'static str = "org.storage.stratis1.pool";
-pub const STRATIS_VOLUME_BASE_INTERFACE: &'static str = "org.storage.stratis1.volume";
+pub const STRATIS_FILESYSTEM_BASE_INTERFACE: &'static str = "org.storage.stratis1.filesystem";
 pub const STRATIS_DEV_BASE_INTERFACE: &'static str = "org.storage.stratis1.dev";
 pub const STRATIS_CACHE_BASE_INTERFACE: &'static str = "org.storage.stratis1.cache";
 pub const STRATIS_POOL_BASE_PATH: &'static str = "/org/storage/stratis/pool";
@@ -23,7 +23,7 @@ pub const LIST_POOLS: &'static str = "ListPools";
 pub const CREATE_POOL: &'static str = "CreatePool";
 pub const DESTROY_POOL: &'static str = "DestroyPool";
 pub const GET_POOL_OBJECT_PATH: &'static str = "GetPoolObjectPath";
-pub const GET_VOLUME_OBJECT_PATH: &'static str = "GetVolumeObjectPath";
+pub const GET_FILESYSTEM_OBJECT_PATH: &'static str = "GetFilesystemObjectPath";
 pub const GET_DEV_OBJECT_PATH: &'static str = "GetDevObjectPath";
 pub const GET_CACHE_OBJECT_PATH: &'static str = "GetCacheObjectPath";
 pub const GET_ERROR_CODES: &'static str = "GetErrorCodes";
@@ -31,9 +31,9 @@ pub const GET_RAID_LEVELS: &'static str = "GetRaidLevels";
 pub const GET_DEV_TYPES: &'static str = "GetDevTypes";
 
 // Pool Methods
-pub const CREATE_VOLUMES: &'static str = "CreateVolumes";
-pub const DESTROY_VOLUMES: &'static str = "DestroyVolumes";
-pub const LIST_VOLUMES: &'static str = "ListVolumes";
+pub const CREATE_FILESYSTEMS: &'static str = "CreateFilesystems";
+pub const DESTROY_FILESYSTEMS: &'static str = "DestroyFilesystems";
+pub const LIST_FILESYSTEMS: &'static str = "ListFilesystems";
 pub const LIST_DEVS: &'static str = "ListDevs";
 pub const LIST_CACHE_DEVS: &'static str = "ListCacheDevs";
 pub const ADD_CACHE_DEVS: &'static str = "AddCacheDevs";
@@ -59,7 +59,7 @@ custom_derive! {
         STRATIS_NULL,
         STRATIS_NOTFOUND,
         STRATIS_POOL_NOTFOUND,
-        STRATIS_VOLUME_NOTFOUND,
+        STRATIS_FILESYSTEM_NOTFOUND,
         STRATIS_DEV_NOTFOUND,
         STRATIS_CACHE_NOTFOUND,
         STRATIS_BAD_PARAM,
@@ -82,7 +82,7 @@ impl HasCodes for StratisErrorEnum {
             StratisErrorEnum::STRATIS_NULL => "Null parameter was supplied",
             StratisErrorEnum::STRATIS_NOTFOUND => "Not found",
             StratisErrorEnum::STRATIS_POOL_NOTFOUND => "Pool not found",
-            StratisErrorEnum::STRATIS_VOLUME_NOTFOUND => "Volume not found",
+            StratisErrorEnum::STRATIS_FILESYSTEM_NOTFOUND => "Filesystem not found",
             StratisErrorEnum::STRATIS_CACHE_NOTFOUND => "Cache not found",
             StratisErrorEnum::STRATIS_BAD_PARAM => "Bad parameter",
             StratisErrorEnum::STRATIS_DEV_NOTFOUND => "Dev not found",

--- a/src/sim_engine.rs
+++ b/src/sim_engine.rs
@@ -84,12 +84,12 @@ impl SimPool {
 }
 
 impl Pool for SimPool {
-    fn add_blockdev(&mut self, path: &str) -> StratisResult<()> {
+    fn add_blockdev(&mut self, _path: &str) -> StratisResult<()> {
         println!("sim: pool::add_blockdev");
         Ok(())
     }
 
-    fn add_cachedev(&mut self, path: &str) -> StratisResult<()> {
+    fn add_cachedev(&mut self, _path: &str) -> StratisResult<()> {
         println!("sim: pool::add_cachedev");
         Ok(())
     }


### PR DESCRIPTION

 - Use Filesystem instead of Volume. Per decision made at F2F
 - Added "_" between words in variable names to make them easier to read.
 - Silenced compiler warning by adding an "_" before un-used variables.