### PR TITLE
Initial implementation of list_filesystems

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -197,9 +197,8 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         return Err(MethodErr::no_arg());
     }
 
-    let mut filesystems: Array<(&str, &str, u64), _> =
-        try!(iter.read::<Array<(&str, &str, u64), _>>()
-            .map_err(|_| MethodErr::invalid_arg(&0)));
+    let filesystems: Array<(&str, &str, u64), _> = try!(iter.read::<Array<(&str, &str, u64), _>>()
+        .map_err(|_| MethodErr::invalid_arg(&0)));
 
     let dbus_context = m.path.get_data();
     let object_path = m.path.get_name();
@@ -233,7 +232,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let mut vec = Vec::new();
 
-    for (name, mountpoint, size) in filesystems.next() {
+    for (name, mountpoint, size) in filesystems {
         let result = pool.create_filesystem(name, mountpoint, size);
 
         match result {
@@ -323,6 +322,7 @@ fn list_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let msg = match result {
         Ok(filesystem_tree) => {
+            println!("filesystems size = {}", filesystem_tree.len());
             let msg_vec =
                 filesystem_tree.keys().map(|key| MessageItem::Str(format!("{}", key))).collect();
             let item_array = MessageItem::Array(msg_vec, "s".into());

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -55,7 +55,6 @@ pub trait Pool: Debug {
     fn add_blockdev(&mut self, path: &str) -> EngineResult<()>;
     fn add_cachedev(&mut self, path: &str) -> EngineResult<()>;
     fn destroy(&mut self) -> EngineResult<()>;
-    fn get_name(&mut self) -> String;
     fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>>;
     fn copy(&self) -> Box<Pool>;
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -42,6 +42,10 @@ pub enum EngineError {
 
 pub type EngineResult<T> = Result<T, EngineError>;
 
+pub trait Filesystem: Debug {
+    fn copy(&self) -> Box<Filesystem>;
+}
+
 pub trait Pool: Debug {
     fn create_filesystem(&mut self,
                          filesystem_name: &str,
@@ -52,6 +56,7 @@ pub trait Pool: Debug {
     fn add_cachedev(&mut self, path: &str) -> EngineResult<()>;
     fn destroy(&mut self) -> EngineResult<()>;
     fn get_name(&mut self) -> String;
+    fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>>;
     fn copy(&self) -> Box<Pool>;
 }
 

--- a/src/sim_engine/engine.rs
+++ b/src/sim_engine/engine.rs
@@ -70,7 +70,7 @@ impl Engine for SimEngine {
             None => {}
         }
 
-        let pool = SimPool::new_pool(name, devs.as_slice(), raid_level);
+        let pool = SimPool::new_pool(devs.as_slice(), raid_level);
 
         if self.rng.gen_weighted_bool(8) {
             return Err(EngineError::Stratis(ErrorEnum::Error("X".into())));

--- a/src/sim_engine/filesystem.rs
+++ b/src/sim_engine/filesystem.rs
@@ -6,15 +6,29 @@ use engine::Filesystem;
 
 #[derive(Debug, Clone)]
 pub struct SimFilesystem {
+    pub name: String,
+    pub mount_point: String,
+    pub size: u64,
 }
 impl SimFilesystem {
-    pub fn new_filesystem() -> Box<SimFilesystem> {
-        Box::new(SimFilesystem {})
+    pub fn new_filesystem(filesystem_name: &str,
+                          mount_point: &str,
+                          size: u64)
+                          -> Box<SimFilesystem> {
+        Box::new(SimFilesystem {
+            name: filesystem_name.to_owned(),
+            mount_point: mount_point.to_owned(),
+            size: size,
+        })
     }
 }
 impl Filesystem for SimFilesystem {
     fn copy(&self) -> Box<Filesystem> {
-        let filesystem_copy = SimFilesystem {};
+        let filesystem_copy = SimFilesystem {
+            name: self.name.clone(),
+            mount_point: self.mount_point.clone(),
+            size: self.size,
+        };
         Box::new(filesystem_copy)
     }
 }

--- a/src/sim_engine/filesystem.rs
+++ b/src/sim_engine/filesystem.rs
@@ -6,17 +6,12 @@ use engine::Filesystem;
 
 #[derive(Debug, Clone)]
 pub struct SimFilesystem {
-    pub name: String,
     pub mount_point: String,
     pub size: u64,
 }
 impl SimFilesystem {
-    pub fn new_filesystem(filesystem_name: &str,
-                          mount_point: &str,
-                          size: u64)
-                          -> Box<SimFilesystem> {
+    pub fn new_filesystem(mount_point: &str, size: u64) -> Box<SimFilesystem> {
         Box::new(SimFilesystem {
-            name: filesystem_name.to_owned(),
             mount_point: mount_point.to_owned(),
             size: size,
         })
@@ -25,7 +20,6 @@ impl SimFilesystem {
 impl Filesystem for SimFilesystem {
     fn copy(&self) -> Box<Filesystem> {
         let filesystem_copy = SimFilesystem {
-            name: self.name.clone(),
             mount_point: self.mount_point.clone(),
             size: self.size,
         };

--- a/src/sim_engine/filesystem.rs
+++ b/src/sim_engine/filesystem.rs
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use engine::Filesystem;
+
+#[derive(Debug, Clone)]
+pub struct SimFilesystem {
+}
+impl SimFilesystem {
+    pub fn new_filesystem() -> Box<SimFilesystem> {
+        Box::new(SimFilesystem {})
+    }
+}
+impl Filesystem for SimFilesystem {
+    fn copy(&self) -> Box<Filesystem> {
+        let filesystem_copy = SimFilesystem {};
+        Box::new(filesystem_copy)
+    }
+}

--- a/src/sim_engine/mod.rs
+++ b/src/sim_engine/mod.rs
@@ -3,4 +3,5 @@ pub use self::pool::SimPool;
 
 mod blockdev;
 mod engine;
+mod filesystem;
 mod pool;

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -75,10 +75,11 @@ impl Pool for SimPool {
 
     fn create_filesystem(&mut self,
                          filesystem_name: &str,
-                         _mount_point: &str,
-                         _size: u64)
+                         mount_point: &str,
+                         size: u64)
                          -> EngineResult<()> {
-        self.filesystems.insert(filesystem_name.to_owned(), SimFilesystem::new_filesystem());
+        self.filesystems.insert(filesystem_name.to_owned(),
+                                SimFilesystem::new_filesystem(filesystem_name, mount_point, size));
         Ok(())
     }
     fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>> {

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -3,22 +3,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::collections::BTreeMap;
+use std::iter::FromIterator;
 use std::vec::Vec;
 
 use engine::EngineResult;
+use engine::Filesystem;
 use engine::Pool;
 
 use super::blockdev::SimDev;
-
-#[derive(Debug, Clone)]
-pub struct SimFilesystem {
-}
-
-impl SimFilesystem {
-    pub fn new_filesystem() -> Box<SimFilesystem> {
-        Box::new(SimFilesystem {})
-    }
-}
+use super::filesystem::SimFilesystem;
 
 #[derive(Debug)]
 pub struct SimPool {
@@ -87,5 +80,8 @@ impl Pool for SimPool {
                          -> EngineResult<()> {
         self.filesystems.insert(filesystem_name.to_owned(), SimFilesystem::new_filesystem());
         Ok(())
+    }
+    fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>> {
+        Ok(BTreeMap::from_iter(self.filesystems.iter().map(|x| (x.0.clone(), x.1.copy()))))
     }
 }

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -15,7 +15,6 @@ use super::filesystem::SimFilesystem;
 
 #[derive(Debug)]
 pub struct SimPool {
-    pub name: String,
     pub block_devs: Vec<Box<SimDev>>,
     pub filesystems: BTreeMap<String, Box<SimFilesystem>>,
     pub raid_level: u16,
@@ -24,12 +23,11 @@ pub struct SimPool {
 }
 
 impl SimPool {
-    pub fn new_pool(name: &str, blockdevs: &[Box<SimDev>], raid_level: u16) -> Box<Pool> {
+    pub fn new_pool(blockdevs: &[Box<SimDev>], raid_level: u16) -> Box<Pool> {
 
         let mut vec = Vec::new();
         vec.extend_from_slice(blockdevs);
         let new_pool = SimPool {
-            name: name.to_owned(),
             block_devs: vec,
             filesystems: BTreeMap::new(),
             raid_level: raid_level,
@@ -57,13 +55,8 @@ impl Pool for SimPool {
         Ok(())
     }
 
-    fn get_name(&mut self) -> String {
-        self.name.clone()
-    }
-
     fn copy(&self) -> Box<Pool> {
         let pool_copy = SimPool {
-            name: self.name.clone(),
             block_devs: self.block_devs.clone(),
             filesystems: self.filesystems.clone(),
             raid_level: self.raid_level.clone(),
@@ -79,7 +72,7 @@ impl Pool for SimPool {
                          size: u64)
                          -> EngineResult<()> {
         self.filesystems.insert(filesystem_name.to_owned(),
-                                SimFilesystem::new_filesystem(filesystem_name, mount_point, size));
+                                SimFilesystem::new_filesystem(mount_point, size));
         Ok(())
     }
     fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>> {


### PR DESCRIPTION
Added Filesystem trait to engine.rs
Created filesystem.rs in sim_engine/
Added filesystem to mod.rs
Added list_filesystem to the sim_engine/pool.rs
Added name, mount_point, and size to the SimFilesystem
Loop on the items in filesystems (not filesystems.next())
Remove mut from filesystems (not needed)
Add object_manager() to the base interface
Remove "name" field from Pool and Filesystem

Signed-off-by: Todd Gill <tgill@redhat.com>