### PR TITLE
Initial implementation of add_devs/cachedevs for a pool / correct old use of "volume"

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -447,19 +447,19 @@ fn create_dbus_pool<'a>(mut dbus_context: DbusContext) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
     let create_filesystems_method = f.method(CREATE_FILESYSTEMS, (), create_filesystems)
-        .in_arg(("volumes", "a(sst)"))
+        .in_arg(("filesystems", "a(sst)"))
         .out_arg(("results", "a(oqs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
     let destroy_filesystems_method = f.method(DESTROY_FILESYSTEMS, (), destroy_filesystems)
-        .in_arg(("volumes", "a(sqs)"))
+        .in_arg(("filesystems", "a(sqs)"))
         .out_arg(("results", "a(qs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
     let list_filesystems_method = f.method(LIST_FILESYSTEMS, (), list_filesystems)
-        .out_arg(("volumes", "as"))
+        .out_arg(("filesystems", "as"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -48,6 +48,7 @@ pub struct DbusContext {
     pub engine: Rc<RefCell<Engine>>,
     pub action_list: Rc<RefCell<Vec<DeferredAction>>>,
     pub filesystems: Rc<RefCell<BTreeMap<String, (String, String)>>>,
+    pub block_devs: Rc<RefCell<BTreeMap<String, (String, String)>>>,
 }
 
 impl DbusContext {
@@ -56,6 +57,7 @@ impl DbusContext {
             action_list: Rc::new(RefCell::new(Vec::new())),
             engine: engine.clone(),
             filesystems: Rc::new(RefCell::new(BTreeMap::new())),
+            block_devs: Rc::new(RefCell::new(BTreeMap::new())),
             next_index: Rc::new(Cell::new(0)),
             pools: Rc::new(RefCell::new(BTreeMap::new())),
         }
@@ -351,8 +353,89 @@ fn remove_cache_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     Ok(vec![m.msg.method_return().append3("/dbus/cache/path", 0, "Ok")])
 }
 
+fn create_dbus_blockdev<'a>(mut dbus_context: DbusContext) -> dbus::Path<'a> {
+
+    let f = Factory::new_fn();
+
+    let object_name = format!("{}/{}",
+                              STRATIS_BASE_PATH,
+                              dbus_context.get_next_id().to_string());
+
+    let object_path = f.object_path(object_name, dbus_context.clone())
+        .introspectable()
+        .add(f.interface(STRATIS_DEV_BASE_INTERFACE, ())
+            .add_p(f.property::<i32, _>("Size", ())));
+
+    let path = object_path.get_name().to_owned();
+    dbus_context.action_list.borrow_mut().push(DeferredAction::Add(object_path));
+    path
+}
+
 fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
-    Ok(vec![m.msg.method_return().append3("/dbus/cache/path", 0, "Ok")])
+    let message: &Message = m.msg;
+    let mut iter = message.iter_init();
+
+    let devs: Array<(&str), _> = try!(iter.read::<Array<(&str), _>>()
+        .map_err(|_| MethodErr::invalid_arg(&0)));
+
+    let dbus_context = m.path.get_data();
+    let object_path = m.path.get_name();
+    let return_message = message.method_return();
+
+    let pool_name = match dbus_context.pools.borrow_mut().get(&object_path.to_string()) {
+        Some(pool) => pool.clone(),
+        None => {
+            let (rc, rs) = code_to_message_items(ErrorEnum::INTERNAL_ERROR,
+                                                 ErrorEnum::INTERNAL_ERROR.get_error_string()
+                                                     .into());
+            let message =
+                return_message.append3(MessageItem::Array(vec![], Cow::Borrowed("(oqs)")), rc, rs);
+            return Ok(vec![message]);
+        }
+    };
+
+    let mut b_engine = dbus_context.engine.borrow_mut();
+    let ref mut pool = match b_engine.get_pool(&pool_name) {
+        Ok(result) => result,
+        Err(x) => {
+            let (rc, rs) = engine_to_dbus_err(&x);
+            let (rc, rs) = code_to_message_items(rc, rs);
+
+            let entry = MessageItem::Array(vec![], Cow::Borrowed("(oqs)"));
+            return Ok(vec![return_message.append3(entry, rc, rs)]);
+        }
+    };
+
+    let ref mut list_rc = ErrorEnum::OK;
+    let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
+    let mut vec = Vec::new();
+
+    for dev in blockdevs {
+        let result = pool.add_blockdev(dev);
+        match result {
+            Ok(_) => {
+                let object_path: dbus::Path = create_dbus_blockdev(dbus_context.clone());
+                dbus_context.block_devs.borrow_mut().insert(object_path.to_string(),
+                                                            ((&pool_name).clone(),
+                                                             String::from(dev.to_str().unwrap())));
+                let (rc, rs) = ok_message_items();
+                let entry = MessageItem::Struct(vec![MessageItem::ObjectPath(object_path), rc, rs]);
+                vec.push(entry);
+
+            }
+            Err(x) => {
+                *list_rc = ErrorEnum::LIST_FAILURE;
+                let object_path: dbus::Path = default_object_path();
+                let (rc, rs) = engine_to_dbus_err(&x);
+                let (rc, rs) = code_to_message_items(rc, rs);
+                let entry = MessageItem::Struct(vec![MessageItem::ObjectPath(object_path), rc, rs]);
+                vec.push(entry);
+            }
+        };
+    }
+    let (rc, rs) = code_to_message_items(*list_rc, list_rc.get_error_string().into());
+
+    Ok(vec![return_message.append3(MessageItem::Array(vec, Cow::Borrowed("(oqs)")), rc, rs)])
 }
 
 fn remove_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -403,7 +486,7 @@ fn create_dbus_pool<'a>(mut dbus_context: DbusContext) -> dbus::Path<'a> {
         .out_arg(("return_string", "s"));
 
     let add_devs_method = f.method(ADD_DEVS, (), add_devs)
-        .in_arg(("cache_devs", "as"))
+        .in_arg(("devs", "as"))
         .out_arg(("results", "a(oqs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -52,8 +52,8 @@ pub trait Pool: Debug {
                          mount_point: &str,
                          size: u64)
                          -> EngineResult<()>;
-    fn add_blockdev(&mut self, path: &str) -> EngineResult<()>;
-    fn add_cachedev(&mut self, path: &str) -> EngineResult<()>;
+    fn add_blockdev(&mut self, path: &Path) -> EngineResult<()>;
+    fn add_cachedev(&mut self, path: &Path) -> EngineResult<()>;
     fn destroy(&mut self) -> EngineResult<()>;
     fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>>;
     fn copy(&self) -> Box<Pool>;

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -4,6 +4,7 @@
 
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
+use std::path::Path;
 use std::vec::Vec;
 
 use engine::EngineResult;
@@ -40,12 +41,12 @@ impl SimPool {
 }
 
 impl Pool for SimPool {
-    fn add_blockdev(&mut self, _path: &str) -> EngineResult<()> {
+    fn add_blockdev(&mut self, _path: &Path) -> EngineResult<()> {
         println!("sim: pool::add_blockdev");
         Ok(())
     }
 
-    fn add_cachedev(&mut self, _path: &str) -> EngineResult<()> {
+    fn add_cachedev(&mut self, _path: &Path) -> EngineResult<()> {
         println!("sim: pool::add_cachedev");
         Ok(())
     }


### PR DESCRIPTION
Implement AddBlockDev and AddCacheDev dbus methods
Change add_blockdev and add_cachedev to take a &Path
Correct a couple uses of volume (should be filesystem)
Added interfaces for devs and cache devs.  Currently they are just stubs (like C version).

Signed-off-by: Todd Gill <tgill@redhat.com>