### PR TITLE
Remove cache and devs

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -765,7 +765,7 @@ fn create_dbus_pool<'a>(mut dbus_context: DbusContext) -> dbus::Path<'a> {
 
     let create_filesystems_method = f.method(CREATE_FILESYSTEMS, (), create_filesystems)
         .in_arg(("filesystems", "a(sst)"))
-        .out_arg(("results", "a(oqs)"))
+        .out_arg(("filesystems", "a(oqs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -44,13 +44,13 @@ pub type EngineResult<T> = Result<T, EngineError>;
 pub trait Dev: Debug {
     fn copy(&self) -> Box<Dev>;
     fn get_id(&self) -> String;
-    fn eq(&self, other: &Path) -> bool;
+    fn has_same(&self, other: &Path) -> bool;
 }
 
 pub trait Cache: Debug {
     fn copy(&self) -> Box<Cache>;
     fn get_id(&self) -> String;
-    fn eq(&self, other: &Path) -> bool;
+    fn has_same(&self, other: &Path) -> bool;
 }
 
 pub trait Filesystem: Debug {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -44,15 +44,19 @@ pub type EngineResult<T> = Result<T, EngineError>;
 pub trait Dev: Debug {
     fn copy(&self) -> Box<Dev>;
     fn get_id(&self) -> String;
+    fn eq(&self, other: &Path) -> bool;
 }
 
 pub trait Cache: Debug {
     fn copy(&self) -> Box<Cache>;
     fn get_id(&self) -> String;
+    fn eq(&self, other: &Path) -> bool;
 }
 
 pub trait Filesystem: Debug {
     fn copy(&self) -> Box<Filesystem>;
+    fn get_id(&self) -> String;
+    fn eq(&self, other: &Filesystem) -> bool;
 }
 
 pub trait Pool: Debug {
@@ -63,6 +67,8 @@ pub trait Pool: Debug {
                          -> EngineResult<()>;
     fn add_blockdev(&mut self, path: &Path) -> EngineResult<()>;
     fn add_cachedev(&mut self, path: &Path) -> EngineResult<()>;
+    fn remove_blockdev(&mut self, path: &Path) -> EngineResult<()>;
+    fn remove_cachedev(&mut self, path: &Path) -> EngineResult<()>;
     fn destroy(&mut self) -> EngineResult<()>;
     fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>>;
     fn list_blockdevs(&self) -> EngineResult<Vec<Box<Dev>>>;

--- a/src/sim_engine/blockdev.rs
+++ b/src/sim_engine/blockdev.rs
@@ -53,6 +53,11 @@ impl Dev for SimDev {
             None => return String::from("Conversion Failure"),
         }
     }
+    fn eq(&self, other: &Path) -> bool {
+        self.get_id() ==
+        String::from(other.to_str()
+            .unwrap())
+    }
 }
 
 impl SimDev {

--- a/src/sim_engine/blockdev.rs
+++ b/src/sim_engine/blockdev.rs
@@ -36,6 +36,12 @@ impl fmt::Debug for SimDev {
     }
 }
 
+impl fmt::Display for SimDev {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.get_id())
+    }
+}
+
 impl Dev for SimDev {
     fn copy(&self) -> Box<Dev> {
         let simdev_copy = SimDev {
@@ -45,6 +51,7 @@ impl Dev for SimDev {
         };
         Box::new(simdev_copy)
     }
+
     fn get_id(&self) -> String {
         let id = self.name.to_str();
 
@@ -53,10 +60,9 @@ impl Dev for SimDev {
             None => return String::from("Conversion Failure"),
         }
     }
+
     fn eq(&self, other: &Path) -> bool {
-        self.get_id() ==
-        String::from(other.to_str()
-            .unwrap())
+        self.get_id() == String::from(other.to_str().unwrap())
     }
 }
 

--- a/src/sim_engine/blockdev.rs
+++ b/src/sim_engine/blockdev.rs
@@ -61,7 +61,7 @@ impl Dev for SimDev {
         }
     }
 
-    fn eq(&self, other: &Path) -> bool {
+    fn has_same(&self, other: &Path) -> bool {
         self.get_id() == String::from(other.to_str().unwrap())
     }
 }

--- a/src/sim_engine/cache.rs
+++ b/src/sim_engine/cache.rs
@@ -76,8 +76,6 @@ impl Cache for SimCacheDev {
         }
     }
     fn eq(&self, other: &Path) -> bool {
-        self.get_id() ==
-        String::from(other.to_str()
-            .unwrap())
+        self.get_id() == String::from(other.to_str().unwrap())
     }
 }

--- a/src/sim_engine/cache.rs
+++ b/src/sim_engine/cache.rs
@@ -75,4 +75,9 @@ impl Cache for SimCacheDev {
             None => return String::from("Conversion Failure"),
         }
     }
+    fn eq(&self, other: &Path) -> bool {
+        self.get_id() ==
+        String::from(other.to_str()
+            .unwrap())
+    }
 }

--- a/src/sim_engine/cache.rs
+++ b/src/sim_engine/cache.rs
@@ -75,7 +75,7 @@ impl Cache for SimCacheDev {
             None => return String::from("Conversion Failure"),
         }
     }
-    fn eq(&self, other: &Path) -> bool {
-        self.get_id() == String::from(other.to_str().unwrap())
+    fn has_same(&self, other: &Path) -> bool {
+        self.name == other
     }
 }

--- a/src/sim_engine/filesystem.rs
+++ b/src/sim_engine/filesystem.rs
@@ -25,4 +25,11 @@ impl Filesystem for SimFilesystem {
         };
         Box::new(filesystem_copy)
     }
+    fn get_id(&self) -> String {
+        self.mount_point.clone()
+    }
+
+    fn eq(&self, other: &Filesystem) -> bool {
+        self.get_id() == other.get_id()
+    }
 }

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -101,4 +101,34 @@ impl Pool for SimPool {
     fn list_cachedevs(&self) -> EngineResult<Vec<Box<Cache>>> {
         Ok(Vec::from_iter(self.cache_devs.iter().map(|x| (x.copy()))))
     }
+    fn remove_blockdev(&mut self, path: &Path) -> EngineResult<()> {
+        let index = self.block_devs.iter().position(|x| x.eq(path));
+        match index {
+            Some(index) => {
+                self.block_devs.remove(index);
+                return Ok(());
+            }
+            None => {
+                return Err(EngineError::Stratis(ErrorEnum::NotFound(String::from(path.to_str()
+                    .unwrap()))))
+            }
+        }
+        Ok(())
+    }
+
+    fn remove_cachedev(&mut self, path: &Path) -> EngineResult<()> {
+        let index = self.cache_devs.iter().position(|x| x.eq(path));
+
+        match index {
+            Some(index) => {
+                self.cache_devs.remove(index);
+                return Ok(());
+            }
+            None => {
+                return Err(EngineError::Stratis(ErrorEnum::NotFound(String::from(path.to_str()
+                    .unwrap()))))
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -102,7 +102,7 @@ impl Pool for SimPool {
         Ok(Vec::from_iter(self.cache_devs.iter().map(|x| (x.copy()))))
     }
     fn remove_blockdev(&mut self, path: &Path) -> EngineResult<()> {
-        let index = self.block_devs.iter().position(|x| x.eq(path));
+        let index = self.block_devs.iter().position(|x| x.has_same(path));
         match index {
             Some(index) => {
                 self.block_devs.remove(index);
@@ -117,7 +117,7 @@ impl Pool for SimPool {
     }
 
     fn remove_cachedev(&mut self, path: &Path) -> EngineResult<()> {
-        let index = self.cache_devs.iter().position(|x| x.eq(path));
+        let index = self.cache_devs.iter().position(|x| x.has_same(path));
 
         match index {
             Some(index) => {


### PR DESCRIPTION
Change block_devs and cache_devs maps to not store the pool. It isn't needed
Added code to create dbus objects for devs when a pool is created
Changed DeferredAction::Remove to take a string
Added remove_dbus_object_path
Implemented remove_cache_devs and remove_devs
Added eq method to Cache and Dev traits to facilitate remove from vec
Added remove_blockdev and remove_cachedev to Pool trait
Added get_id and eq to Filesystem
Implemented remove_blockdev and remove_cachedev in sim_engine
Correct output name of create_filesystems_method to "filesystems"
implement fmt::Display for SimDev
reformat eq code to be more readable for blockdev and cache