### PR TITLE
Implement dbus DestroyFilesystems call

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -374,7 +374,55 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 }
 
 fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
-    Ok(vec![m.msg.method_return().append3("/dbus/cache/path", 0, "Ok")])
+    let message: &Message = m.msg;
+    let mut iter = message.iter_init();
+
+    let filesystems: Array<&str, _> = try!(get_next_arg(&mut iter, 0));
+
+    let dbus_context = m.path.get_data();
+    let object_path = m.path.get_name();
+    let return_message = message.method_return();
+    let return_sig = "(qs)";
+    let default_return = MessageItem::Array(vec![], return_sig.into());
+
+    let pool_name = dbus_try!(
+        object_path_to_pool_name(dbus_context, &object_path.to_string());
+        default_return; return_message);
+
+    let mut b_engine = dbus_context.engine.borrow_mut();
+    let ref mut pool = engine_try!(b_engine.get_pool(&pool_name);
+                                   default_return;
+                                   return_message);
+
+    let ref mut list_rc = ErrorEnum::OK;
+    let mut vec = Vec::new();
+
+    for filesystem in filesystems {
+        let filesystem_name = String::from(filesystem);
+        let result = pool.destroy_filesystem(&filesystem_name);
+        match result {
+            Ok(_) => {
+                let result = fs_name_to_object_path(dbus_context,
+                                                    &pool_name.to_string(),
+                                                    &filesystem_name.to_string());
+                let object_path = dbus_try!(result; default_return; return_message);
+                remove_dbus_object_path(dbus_context, object_path.clone());
+                let (rc, rs) = ok_message_items();
+                let entry = MessageItem::Struct(vec![rc, rs]);
+                vec.push(entry);
+            }
+            Err(x) => {
+                *list_rc = ErrorEnum::LIST_FAILURE;
+                let (rc, rs) = engine_to_dbus_err(&x);
+                let (rc, rs) = code_to_message_items(rc, rs);
+                let entry = MessageItem::Struct(vec![rc, rs]);
+                vec.push(entry);
+            }
+        };
+    }
+    let (rc, rs) = code_to_message_items(*list_rc, list_rc.get_error_string().into());
+
+    Ok(vec![return_message.append3(MessageItem::Array(vec, return_sig.into()), rc, rs)])
 }
 
 fn list_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -978,7 +1026,7 @@ fn configure_simulator(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         Ok(_) => {
             let (rc, rs) = ok_message_items();
             return_message.append2(rc, rs)
-        },
+        }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err(&err);
             let (rc, rs) = code_to_message_items(rc, rs);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -69,7 +69,7 @@ pub trait Pool: Debug {
     fn add_cachedev(&mut self, path: &Path) -> EngineResult<()>;
     fn remove_blockdev(&mut self, path: &Path) -> EngineResult<()>;
     fn remove_cachedev(&mut self, path: &Path) -> EngineResult<()>;
-    fn destroy(&mut self) -> EngineResult<()>;
+    fn destroy_filesystem(&mut self, filesystem: &String) -> EngineResult<()>;
     fn list_filesystems(&self) -> EngineResult<BTreeMap<String, Box<Filesystem>>>;
     fn list_blockdevs(&self) -> EngineResult<Vec<Box<Dev>>>;
     fn list_cachedevs(&self) -> EngineResult<Vec<Box<Cache>>>;

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -62,9 +62,13 @@ impl Pool for SimPool {
         Ok(())
     }
 
-    fn destroy(&mut self) -> EngineResult<()> {
-        println!("sim: pool::destroy");
-        Ok(())
+    fn destroy_filesystem(&mut self, filesystem: &String) -> EngineResult<()> {
+        match self.filesystems.remove(filesystem) {
+            Some(_fs) => {
+                return Ok(());
+            }
+            None => return Err(EngineError::Stratis(ErrorEnum::NotFound(String::from(filesystem.to_string())))),
+        }
     }
 
     fn copy(&self) -> Box<Pool> {


### PR DESCRIPTION
Update the engine to include destroy_filesystems in the Pool trait
Implement destroy_filesystems in the sim_engin/pool.rs
rustfmt made a small formatting change it list_filesystems:dbus_api.rs

Signed-off-by: Todd Gill <tgill@redhat.com>