### PR TITLE
Replace BlockDev::new() with BlockDev::initialize()

### DIFF
--- a/src/strat_engine/blockdev.rs
+++ b/src/strat_engine/blockdev.rs
@@ -8,8 +8,6 @@ use std::path::{Path, PathBuf};
 use std::io;
 use std::str::{FromStr, from_utf8};
 use std::cmp::Ordering;
-use std::fs;
-use std::os::unix::fs::FileTypeExt;
 
 use time::Timespec;
 use devicemapper::Device;
@@ -113,14 +111,6 @@ impl BlockDev {
     fn dev_info(paths: &[&Path], force: bool) -> EngineResult<Vec<(Device, u64)>> {
         let mut dev_infos = Vec::new();
         for path in paths {
-            let metadata = try!(fs::metadata(path));
-
-            if !metadata.file_type().is_block_device() {
-                return Err(EngineError::Io(io::Error::new(ErrorKind::InvalidInput,
-                                                          format!("{} is not a block device",
-                                                                  path.display()))));
-            }
-
             let dev = try!(Device::from_str(&path.to_string_lossy()));
 
             let mut f = try!(OpenOptions::new()

--- a/src/strat_engine/engine.rs
+++ b/src/strat_engine/engine.rs
@@ -43,20 +43,8 @@ impl Engine for StratEngine {
             return Err(EngineError::Stratis(ErrorEnum::AlreadyExists(name.into())));
         }
 
-        let mut devs = Vec::new();
-        for path in blockdev_paths {
-            match BlockDev::new(name, path, MIN_MDA_SIZE, true) {
-                Ok(bd) => devs.push(bd),
-                Err(e) => {
-                    for mut dev in devs {
-                        let _dontcare = dev.wipe_sigblock();
-                    }
-                    return Err(e);
-                }
-            }
-        }
-
-        let pool = StratPool::new(name, &devs, raid_level);
+        let bds = try!(BlockDev::initialize(name, blockdev_paths, MIN_MDA_SIZE, true));
+        let pool = StratPool::new(name, &bds, raid_level);
 
         self.pools.insert(name.to_owned(), pool);
         Ok(())

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -56,7 +56,9 @@ impl Pool for StratPool {
     }
 
     fn add_blockdev(&mut self, path: &Path) -> EngineResult<()> {
-        let bd = try!(BlockDev::new(&self.uuid, Path::new(path), MIN_MDA_SIZE, true));
+        let bd = try!(BlockDev::initialize(&self.uuid, &[path], MIN_MDA_SIZE, true))
+            .pop()
+            .unwrap();
         self.block_devs.push(bd);
         Ok(())
     }


### PR DESCRIPTION
If we are creating a pool from multiple blockdevs and there's something
wrong with one of the later ones, we will abort but already have written
Stratis headers to the earlier ones. This new function takes multiple
paths to create blockdevs on at once. This allows it to check all of them
first for min size, is it a blockdev, etc before overwriting the initial
data on any of them.

Make BlockDev::new() use batch_new() internally.

Signed-off-by: Andy Grover <agrover@redhat.com>