### PR TITLE
Blockdev improvements

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -917,11 +917,12 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let name: &str = try!(get_next_arg(&mut iter, 0));
     let raid_level: u16 = try!(get_next_arg(&mut iter, 1));
     let devs: Array<&str, _> = try!(get_next_arg(&mut iter, 2));
+    let force: bool = try!(get_next_arg(&mut iter, 3));
 
     let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
     let dbus_context = m.path.get_data();
-    let result = dbus_context.engine.borrow_mut().create_pool(name, &blockdevs, raid_level, true);
+    let result = dbus_context.engine.borrow_mut().create_pool(name, &blockdevs, raid_level, force);
 
     let return_message = message.method_return();
 
@@ -1084,6 +1085,7 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> StratisResult<Tree<MTFn<TData
         .in_arg(("pool_name", "s"))
         .in_arg(("raid_type", "q"))
         .in_arg(("dev_list", "as"))
+        .in_arg(("force", "b"))
         .out_arg(("object_path", "o"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -921,7 +921,7 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
     let dbus_context = m.path.get_data();
-    let result = dbus_context.engine.borrow_mut().create_pool(name, &blockdevs, raid_level);
+    let result = dbus_context.engine.borrow_mut().create_pool(name, &blockdevs, raid_level, true);
 
     let return_message = message.method_return();
 

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -679,7 +679,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut vec = Vec::new();
 
     for dev in devs {
-        let result = pool.add_blockdev(Path::new(dev));
+        let result = pool.add_blockdev(Path::new(dev), true);
         match result {
             Ok(_) => {
                 let object_path: dbus::Path = create_dbus_blockdev(dbus_context.clone());

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -659,6 +659,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut iter = message.iter_init();
 
     let devs: Array<&str, _> = try!(get_next_arg(&mut iter, 0));
+    let force: bool = try!(get_next_arg(&mut iter, 1));
 
     let dbus_context = m.path.get_data();
     let object_path = m.path.get_name();
@@ -679,7 +680,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut vec = Vec::new();
 
     for dev in devs {
-        let result = pool.add_blockdev(Path::new(dev), true);
+        let result = pool.add_blockdev(Path::new(dev), force);
         match result {
             Ok(_) => {
                 let object_path: dbus::Path = create_dbus_blockdev(dbus_context.clone());
@@ -878,6 +879,7 @@ fn create_dbus_pool<'a>(mut dbus_context: DbusContext) -> dbus::Path<'a> {
 
     let add_devs_method = f.method(ADD_DEVS, (), add_devs)
         .in_arg(("devs", "as"))
+        .in_arg(("force", "b"))
         .out_arg(("results", "a(oqs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -74,7 +74,7 @@ impl From<nix::Error> for EngineError {
 
 pub trait Pool: Debug {
     fn create_filesystem(&mut self, name: &str, mount_point: &str, size: u64) -> EngineResult<()>;
-    fn add_blockdev(&mut self, path: &Path) -> EngineResult<()>;
+    fn add_blockdev(&mut self, path: &Path, force: bool) -> EngineResult<()>;
     fn add_cachedev(&mut self, path: &Path) -> EngineResult<()>;
     fn remove_blockdev(&mut self, path: &Path) -> EngineResult<()>;
     fn remove_cachedev(&mut self, path: &Path) -> EngineResult<()>;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -90,7 +90,8 @@ pub trait Engine: Debug {
     fn create_pool(&mut self,
                    name: &str,
                    blockdev_paths: &[&Path],
-                   raid_level: u16)
+                   raid_level: u16,
+                   force: bool)
                    -> EngineResult<()>;
     fn destroy_pool(&mut self, name: &str) -> EngineResult<()>;
     fn get_pool(&mut self, name: &str) -> EngineResult<&mut Pool>;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -87,12 +87,13 @@ pub trait Pool: Debug {
 }
 
 pub trait Engine: Debug {
+    /// Create a Stratis pool. Returns the number of blockdevs the pool contains.
     fn create_pool(&mut self,
                    name: &str,
                    blockdev_paths: &[&Path],
                    raid_level: u16,
                    force: bool)
-                   -> EngineResult<()>;
+                   -> EngineResult<usize>;
     fn destroy_pool(&mut self, name: &str) -> EngineResult<()>;
     fn get_pool(&mut self, name: &str) -> EngineResult<&mut Pool>;
     fn pools(&mut self) -> BTreeMap<&str, &mut Pool>;

--- a/src/sim_engine/engine.rs
+++ b/src/sim_engine/engine.rs
@@ -41,7 +41,8 @@ impl Engine for SimEngine {
     fn create_pool(&mut self,
                    name: &str,
                    blockdev_paths: &[&Path],
-                   raid_level: u16)
+                   raid_level: u16,
+                   _force: bool)
                    -> EngineResult<()> {
 
         if self.pools.contains_key(name) {

--- a/src/sim_engine/engine.rs
+++ b/src/sim_engine/engine.rs
@@ -43,7 +43,7 @@ impl Engine for SimEngine {
                    blockdev_paths: &[&Path],
                    raid_level: u16,
                    _force: bool)
-                   -> EngineResult<()> {
+                   -> EngineResult<usize> {
 
         if self.pools.contains_key(name) {
             return Err(EngineError::Stratis(ErrorEnum::AlreadyExists(name.into())));
@@ -68,8 +68,10 @@ impl Engine for SimEngine {
             return Err(EngineError::Stratis(ErrorEnum::Error("X".into())));
         }
 
+        let num_bdevs = pool.block_devs.len();
         self.pools.insert(name.to_owned(), pool);
-        Ok(())
+
+        Ok(num_bdevs)
     }
 
     fn destroy_pool(&mut self, name: &str) -> EngineResult<()> {

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -54,7 +54,7 @@ impl SimPool {
 }
 
 impl Pool for SimPool {
-    fn add_blockdev(&mut self, path: &Path) -> EngineResult<()> {
+    fn add_blockdev(&mut self, path: &Path, _force: bool) -> EngineResult<()> {
         self.block_devs.push(SimDev::new_dev(self.rdm.clone(), path));
         Ok(())
     }

--- a/src/strat_engine/blockdev.rs
+++ b/src/strat_engine/blockdev.rs
@@ -383,6 +383,6 @@ impl BlockDev {
 
     /// Get the "x:y" device string for this blockdev
     pub fn dstr(&self) -> String {
-        format!("{}:{}", self.dev.major, self.dev.minor)
+        self.dev.dstr()
     }
 }

--- a/src/strat_engine/blockdev.rs
+++ b/src/strat_engine/blockdev.rs
@@ -404,4 +404,11 @@ impl BlockDev {
     pub fn dstr(&self) -> String {
         self.dev.dstr()
     }
+
+    /// List the available-for-upper-layer-use range in this blockdev.
+    pub fn avail_range(&self) -> (SectorOffset, Sectors) {
+        let start = SectorOffset(*BDA_STATIC_HDR_SIZE + *self.mda_sectors + *self.reserved_sectors);
+        let length = Sectors(*self.sectors - *start - *BDA_STATIC_HDR_SIZE - *self.mda_sectors);
+        (start, length)
+    }
 }

--- a/src/strat_engine/engine.rs
+++ b/src/strat_engine/engine.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 
+use uuid::Uuid;
+
 use engine::Engine;
 use engine::EngineError;
 use engine::EngineResult;
@@ -43,8 +45,9 @@ impl Engine for StratEngine {
             return Err(EngineError::Stratis(ErrorEnum::AlreadyExists(name.into())));
         }
 
-        let bds = try!(BlockDev::initialize(name, blockdev_paths, MIN_MDA_SIZE, true));
-        let pool = StratPool::new(name, &bds, raid_level);
+        let pool_uuid = Uuid::new_v4();
+        let bds = try!(BlockDev::initialize(&pool_uuid, blockdev_paths, MIN_MDA_SIZE, true));
+        let pool = StratPool::new(name, pool_uuid, &bds, raid_level);
 
         self.pools.insert(name.to_owned(), pool);
         Ok(())

--- a/src/strat_engine/engine.rs
+++ b/src/strat_engine/engine.rs
@@ -70,7 +70,7 @@ impl Engine for StratEngine {
             }
         }
 
-        let pool = try!(StratPool::new(name, devices, raid_level));
+        let pool = try!(StratPool::new(name, devices, raid_level, true));
 
         self.pools.insert(name.to_owned(), pool);
         Ok(())

--- a/src/strat_engine/engine.rs
+++ b/src/strat_engine/engine.rs
@@ -40,7 +40,8 @@ impl Engine for StratEngine {
     fn create_pool(&mut self,
                    name: &str,
                    blockdev_paths: &[&Path],
-                   raid_level: u16)
+                   raid_level: u16,
+                   force: bool)
                    -> EngineResult<()> {
 
         if self.pools.contains_key(name) {
@@ -70,7 +71,7 @@ impl Engine for StratEngine {
             }
         }
 
-        let pool = try!(StratPool::new(name, devices, raid_level, true));
+        let pool = try!(StratPool::new(name, devices, raid_level, force));
 
         self.pools.insert(name.to_owned(), pool);
         Ok(())

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -26,7 +26,7 @@ pub struct StratFilesystem {
 #[derive(Debug)]
 pub struct StratPool {
     pub name: String,
-    pub uuid: String,
+    pub uuid: Uuid,
     pub cache_devs: Vec<BlockDev>,
     pub block_devs: Vec<BlockDev>,
     pub filesystems: BTreeMap<String, Box<StratFilesystem>>,
@@ -34,10 +34,10 @@ pub struct StratPool {
 }
 
 impl StratPool {
-    pub fn new(name: &str, blockdevs: &[BlockDev], raid_level: u16) -> StratPool {
+    pub fn new(name: &str, uuid: Uuid, blockdevs: &[BlockDev], raid_level: u16) -> StratPool {
         StratPool {
             name: name.to_owned(),
-            uuid: Uuid::new_v4().simple().to_string(),
+            uuid: uuid,
             cache_devs: Vec::new(),
             block_devs: blockdevs.to_owned(),
             filesystems: BTreeMap::new(),

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -40,9 +40,13 @@ pub struct StratPool {
 }
 
 impl StratPool {
-    pub fn new(name: &str, devices: BTreeSet<Device>, raid_level: u16) -> EngineResult<StratPool> {
+    pub fn new(name: &str,
+               devices: BTreeSet<Device>,
+               raid_level: u16,
+               force: bool)
+               -> EngineResult<StratPool> {
         let pool_uuid = Uuid::new_v4();
-        let bds = try!(BlockDev::initialize(&pool_uuid, devices, MIN_MDA_SIZE, true));
+        let bds = try!(BlockDev::initialize(&pool_uuid, devices, MIN_MDA_SIZE, force));
 
         Ok(StratPool {
             name: name.to_owned(),

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -26,7 +26,7 @@ pub struct StratFilesystem {
 #[derive(Debug)]
 pub struct StratPool {
     pub name: String,
-    pub uuid: Uuid,
+    pub pool_uuid: Uuid,
     pub cache_devs: Vec<BlockDev>,
     pub block_devs: Vec<BlockDev>,
     pub filesystems: BTreeMap<String, Box<StratFilesystem>>,
@@ -37,7 +37,7 @@ impl StratPool {
     pub fn new(name: &str, uuid: Uuid, blockdevs: &[BlockDev], raid_level: u16) -> StratPool {
         StratPool {
             name: name.to_owned(),
-            uuid: uuid,
+            pool_uuid: uuid,
             cache_devs: Vec::new(),
             block_devs: blockdevs.to_owned(),
             filesystems: BTreeMap::new(),
@@ -56,7 +56,7 @@ impl Pool for StratPool {
     }
 
     fn add_blockdev(&mut self, path: &Path) -> EngineResult<()> {
-        let bd = try!(BlockDev::initialize(&self.uuid, &[path], MIN_MDA_SIZE, true))
+        let bd = try!(BlockDev::initialize(&self.pool_uuid, &[path], MIN_MDA_SIZE, true))
             .pop()
             .unwrap();
         self.block_devs.push(bd);

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -68,7 +68,7 @@ impl Pool for StratPool {
         Ok(())
     }
 
-    fn add_blockdev(&mut self, path: &Path) -> EngineResult<()> {
+    fn add_blockdev(&mut self, path: &Path, force: bool) -> EngineResult<()> {
         let dev = try!(Device::from_str(&path.to_string_lossy()));
         let dev_set = BTreeSet::from_iter([dev].iter().map(|x| *x));
 
@@ -82,7 +82,7 @@ impl Pool for StratPool {
             }
         }
 
-        let (uuid, bd) = try!(BlockDev::initialize(&self.pool_uuid, dev_set, MIN_MDA_SIZE, true))
+        let (uuid, bd) = try!(BlockDev::initialize(&self.pool_uuid, dev_set, MIN_MDA_SIZE, force))
             .into_iter()
             .next()
             .unwrap();


### PR DESCRIPTION
* Use `uuid::Uuid` for blockdev uuids instead of `String`
* Add `BlockDev::avail_areas()` so higher layers can get the usable portion of a blockdev
* Try to ensure blockdevs are unused by this or other pools, and are unique
* Plumb `force` all the way up through the DBus API layer