### PR TITLE
Add support for putting option types on the D-Bus as tuples.

### DIFF
--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -357,8 +357,8 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let mut vec = Vec::new();
 
-    for (name, mountpoint, size) in filesystems {
-        let result = pool.create_filesystem(name, mountpoint, tuple_to_option(size));
+    for (name, mountpoint, quota_size) in filesystems {
+        let result = pool.create_filesystem(name, mountpoint, tuple_to_option(quota_size));
 
         match result {
             Ok(_) => {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -76,7 +76,7 @@ pub trait Pool: Debug {
     fn create_filesystem(&mut self,
                          name: &str,
                          mount_point: &str,
-                         size: Option<u64>)
+                         quota_size: Option<u64>)
                          -> EngineResult<()>;
     fn add_blockdev(&mut self, path: &Path, force: bool) -> EngineResult<()>;
     fn add_cachedev(&mut self, path: &Path, force: bool) -> EngineResult<()>;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -73,7 +73,11 @@ impl From<nix::Error> for EngineError {
 }
 
 pub trait Pool: Debug {
-    fn create_filesystem(&mut self, name: &str, mount_point: &str, size: u64) -> EngineResult<()>;
+    fn create_filesystem(&mut self,
+                         name: &str,
+                         mount_point: &str,
+                         size: Option<u64>)
+                         -> EngineResult<()>;
     fn add_blockdev(&mut self, path: &Path, force: bool) -> EngineResult<()>;
     fn add_cachedev(&mut self, path: &Path, force: bool) -> EngineResult<()>;
     fn remove_blockdev(&mut self, path: &Path) -> EngineResult<()>;

--- a/src/sim_engine/consts.rs
+++ b/src/sim_engine/consts.rs
@@ -2,4 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub const DEFAULT_FILESYSTEM_SIZE: u64 = 3;
+pub const DEFAULT_FILESYSTEM_QUOTA_SIZE: u64 = 3;

--- a/src/sim_engine/consts.rs
+++ b/src/sim_engine/consts.rs
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+pub const DEFAULT_FILESYSTEM_SIZE: u64 = 3;

--- a/src/sim_engine/filesystem.rs
+++ b/src/sim_engine/filesystem.rs
@@ -7,22 +7,22 @@ use engine::EngineResult;
 
 use uuid::Uuid;
 
-use super::consts::DEFAULT_FILESYSTEM_SIZE;
+use super::consts::DEFAULT_FILESYSTEM_QUOTA_SIZE;
 
 #[derive(Debug, Clone)]
 pub struct SimFilesystem {
     pub uuid: Uuid,
     pub name: String,
     pub mount_point: String,
-    pub size: u64,
+    pub quota_size: u64,
 }
 impl SimFilesystem {
-    pub fn new_filesystem(name: &str, mount_point: &str, size: Option<u64>) -> SimFilesystem {
+    pub fn new_filesystem(name: &str, mount_point: &str, quota_size: Option<u64>) -> SimFilesystem {
         SimFilesystem {
             name: name.to_owned(),
             uuid: Uuid::new_v4(),
             mount_point: mount_point.to_owned(),
-            size: size.unwrap_or(DEFAULT_FILESYSTEM_SIZE),
+            quota_size: quota_size.unwrap_or(DEFAULT_FILESYSTEM_QUOTA_SIZE),
         }
     }
 }

--- a/src/sim_engine/filesystem.rs
+++ b/src/sim_engine/filesystem.rs
@@ -7,6 +7,8 @@ use engine::EngineResult;
 
 use uuid::Uuid;
 
+use super::consts::DEFAULT_FILESYSTEM_SIZE;
+
 #[derive(Debug, Clone)]
 pub struct SimFilesystem {
     pub uuid: Uuid,
@@ -15,12 +17,12 @@ pub struct SimFilesystem {
     pub size: u64,
 }
 impl SimFilesystem {
-    pub fn new_filesystem(name: &str, mount_point: &str, size: u64) -> SimFilesystem {
+    pub fn new_filesystem(name: &str, mount_point: &str, size: Option<u64>) -> SimFilesystem {
         SimFilesystem {
             name: name.to_owned(),
             uuid: Uuid::new_v4(),
             mount_point: mount_point.to_owned(),
-            size: size,
+            size: size.unwrap_or(DEFAULT_FILESYSTEM_SIZE),
         }
     }
 }

--- a/src/sim_engine/mod.rs
+++ b/src/sim_engine/mod.rs
@@ -3,6 +3,7 @@ pub use self::pool::SimPool;
 
 mod blockdev;
 mod cache;
+mod consts;
 mod engine;
 mod filesystem;
 mod pool;

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -88,7 +88,7 @@ impl Pool for SimPool {
     fn create_filesystem(&mut self,
                          name: &str,
                          mount_point: &str,
-                         size: Option<u64>)
+                         quota_size: Option<u64>)
                          -> EngineResult<()> {
 
         match self.get_filesystem_id(name) {
@@ -98,7 +98,7 @@ impl Pool for SimPool {
             Err(_) => {}
         }
 
-        let new_filesystem = SimFilesystem::new_filesystem(name, mount_point, size);
+        let new_filesystem = SimFilesystem::new_filesystem(name, mount_point, quota_size);
 
         self.filesystems.insert(new_filesystem.get_id(), new_filesystem);
         Ok(())

--- a/src/sim_engine/pool.rs
+++ b/src/sim_engine/pool.rs
@@ -85,7 +85,11 @@ impl Pool for SimPool {
         Ok(())
     }
 
-    fn create_filesystem(&mut self, name: &str, mount_point: &str, size: u64) -> EngineResult<()> {
+    fn create_filesystem(&mut self,
+                         name: &str,
+                         mount_point: &str,
+                         size: Option<u64>)
+                         -> EngineResult<()> {
 
         match self.get_filesystem_id(name) {
             Ok(_) => {

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -63,7 +63,7 @@ impl Pool for StratPool {
     fn create_filesystem(&mut self,
                          _filesystem_name: &str,
                          _mount_point: &str,
-                         _size: u64)
+                         _size: Option<u64>)
                          -> EngineResult<()> {
         Ok(())
     }

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -63,7 +63,7 @@ impl Pool for StratPool {
     fn create_filesystem(&mut self,
                          _filesystem_name: &str,
                          _mount_point: &str,
-                         _size: Option<u64>)
+                         _quota_size: Option<u64>)
                          -> EngineResult<()> {
         Ok(())
     }


### PR DESCRIPTION
Use the support for the quota part of filesystem's spec.

Signed-off-by: mulhern <amulhern@redhat.com>