### PR TITLE
Initial version of create_snapshot

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -58,6 +58,7 @@ pub trait Filesystem: Debug {
     fn get_name(&self) -> String;
     fn has_same(&self, other: &str) -> bool;
     fn rename(&mut self, new_name: &str) -> EngineResult<()>;
+    fn add_ancestor(&mut self, parent: Uuid);
 }
 
 impl From<io::Error> for EngineError {
@@ -78,6 +79,7 @@ pub trait Pool: Debug {
                          mount_point: &str,
                          quota_size: Option<u64>)
                          -> EngineResult<()>;
+    fn create_snapshot(&mut self, snapshot_name: &str, source: &str) -> EngineResult<()>;
     fn add_blockdev(&mut self, path: &Path, force: bool) -> EngineResult<()>;
     fn add_cachedev(&mut self, path: &Path, force: bool) -> EngineResult<()>;
     fn remove_blockdev(&mut self, path: &Path) -> EngineResult<()>;
@@ -87,7 +89,8 @@ pub trait Pool: Debug {
     fn cachedevs(&mut self) -> Vec<&mut Cache>;
     fn destroy_filesystem(&mut self, name: &str) -> EngineResult<()>;
     fn get_filesystem(&mut self, id: &Uuid) -> EngineResult<&mut Filesystem>;
-    fn get_filesystem_id(&mut self, name: &str) -> EngineResult<Uuid>;
+    fn get_filesystem_id(&self, name: &str) -> EngineResult<Uuid>;
+    fn get_filesystem_by_name(&mut self, name: &str) -> EngineResult<&mut Filesystem>;
 }
 
 pub trait Engine: Debug {

--- a/src/sim_engine/filesystem.rs
+++ b/src/sim_engine/filesystem.rs
@@ -15,7 +15,9 @@ pub struct SimFilesystem {
     pub name: String,
     pub mount_point: String,
     pub quota_size: u64,
+    pub nearest_ancestor: Option<Uuid>,
 }
+
 impl SimFilesystem {
     pub fn new_filesystem(name: &str, mount_point: &str, quota_size: Option<u64>) -> SimFilesystem {
         SimFilesystem {
@@ -23,6 +25,7 @@ impl SimFilesystem {
             uuid: Uuid::new_v4(),
             mount_point: mount_point.to_owned(),
             quota_size: quota_size.unwrap_or(DEFAULT_FILESYSTEM_QUOTA_SIZE),
+            nearest_ancestor: None,
         }
     }
 }
@@ -46,5 +49,9 @@ impl Filesystem for SimFilesystem {
     fn rename(&mut self, new_name: &str) -> EngineResult<()> {
         self.name = String::from(new_name);
         Ok(())
+    }
+
+    fn add_ancestor(&mut self, parent: Uuid) {
+        self.nearest_ancestor = Some(parent);
     }
 }

--- a/src/strat_engine/pool.rs
+++ b/src/strat_engine/pool.rs
@@ -68,6 +68,10 @@ impl Pool for StratPool {
         Ok(())
     }
 
+    fn create_snapshot(&mut self, _snapshot_name: &str, _source: &str) -> EngineResult<()> {
+        unimplemented!()
+    }
+
     fn add_blockdev(&mut self, path: &Path, force: bool) -> EngineResult<()> {
         let dev = try!(Device::from_str(&path.to_string_lossy()));
         let dev_set = BTreeSet::from_iter([dev].iter().map(|x| *x));
@@ -122,7 +126,11 @@ impl Pool for StratPool {
         unimplemented!()
     }
 
-    fn get_filesystem_id(&mut self, _name: &str) -> EngineResult<Uuid> {
+    fn get_filesystem_id(&self, _name: &str) -> EngineResult<Uuid> {
+        unimplemented!()
+    }
+
+    fn get_filesystem_by_name(&mut self, _name: &str) -> EngineResult<&mut Filesystem> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
Remove &mut from get_filesystem_id it is not necessary
Add vector of ancestors to the SimFilesystem this is a placeholder
Add get_filesystem_by_name to lookup filesystem by name for a Pool

Signed-off-by: Todd Gill <tgill@redhat.com>