### PR TITLE
Add rustfmt.toml to set options for rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+format_strings = false
+reorder_imports = true

--- a/src/dbus_api.rs
+++ b/src/dbus_api.rs
@@ -4,31 +4,23 @@
 
 use bidir_map::BidirMap;
 
-use std::borrow::Cow;
-use std::cell::Cell;
-use std::cell::RefCell;
-use std::fmt::Display;
-use std::path::Path;
-use std::rc::Rc;
-use std::vec::Vec;
-
 use dbus;
-use dbus::Connection;
 use dbus::BusType;
+use dbus::Connection;
+use dbus::ConnectionItem;
 use dbus::Message;
 use dbus::MessageItem;
 use dbus::NameFlag;
 use dbus::arg::Array;
 use dbus::arg::Iter;
-use dbus::tree::Factory;
 use dbus::tree::DataType;
-use dbus::tree::MethodErr;
+use dbus::tree::Factory;
 use dbus::tree::MTFn;
-use dbus::tree::MethodResult;
+use dbus::tree::MethodErr;
 use dbus::tree::MethodInfo;
-use dbus::tree::Tree;
+use dbus::tree::MethodResult;
 use dbus::tree::ObjectPath;
-use dbus::ConnectionItem;
+use dbus::tree::Tree;
 
 use dbus_consts::*;
 
@@ -36,6 +28,14 @@ use engine;
 use engine::Engine;
 use engine::EngineError;
 use engine::RenameAction;
+
+use std::borrow::Cow;
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::fmt::Display;
+use std::path::Path;
+use std::rc::Rc;
+use std::vec::Vec;
 
 use types::StratisResult;
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+use nix;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
-
-use nix;
 
 use uuid::Uuid;
 

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fmt;
 
 use engine::Dev;
 
 use std::cell::RefCell;
+use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;

--- a/src/engine/sim_engine/cache.rs
+++ b/src/engine/sim_engine/cache.rs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+use engine::Cache;
 use std::cell::RefCell;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
-
-use engine::Cache;
 
 use super::randomization::Randomizer;
 

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -13,8 +13,8 @@ use engine::RenameAction;
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::collections::btree_map::Entry;
 use std::collections::BTreeSet;
+use std::collections::btree_map::Entry;
 use std::iter::FromIterator;
 use std::path::Path;
 use std::path::PathBuf;
@@ -108,16 +108,16 @@ impl Engine for SimEngine {
 #[cfg(test)]
 mod tests {
 
-    use std::path::Path;
-
-    use quickcheck::QuickCheck;
-
-    use super::SimEngine;
 
     use engine::Engine;
     use engine::EngineError;
     use engine::ErrorEnum;
     use engine::RenameAction;
+
+    use quickcheck::QuickCheck;
+    use std::path::Path;
+
+    use super::SimEngine;
 
     #[test]
     fn prop_configure_simulator_runs() {

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use engine::Filesystem;
 use engine::EngineResult;
-
-use uuid::Uuid;
+use engine::Filesystem;
 
 use super::consts::DEFAULT_FILESYSTEM_QUOTA_SIZE;
+
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct SimFilesystem {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -2,14 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cell::RefCell;
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
-use std::iter::FromIterator;
-use std::path::Path;
-use std::path::PathBuf;
-use std::rc::Rc;
-use std::vec::Vec;
 
 use engine::Cache;
 use engine::Dev;
@@ -18,6 +10,14 @@ use engine::EngineResult;
 use engine::ErrorEnum;
 use engine::Filesystem;
 use engine::Pool;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::iter::FromIterator;
+use std::path::Path;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::vec::Vec;
 
 use super::blockdev::SimDev;
 use super::cache::SimCacheDev;

--- a/src/engine/sim_engine/randomization.rs
+++ b/src/engine/sim_engine/randomization.rs
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fmt;
 
 use rand::Rng;
 use rand::ThreadRng;
 use rand::thread_rng;
+use std::fmt;
 
 pub struct Randomizer {
     rng: ThreadRng,

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -2,30 +2,30 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::io::{Read, Write, ErrorKind, Seek, SeekFrom};
-use std::fs::{OpenOptions, read_dir};
-use std::path::{Path, PathBuf};
-use std::io;
-use std::str::{FromStr, from_utf8};
+use byteorder::{LittleEndian, ByteOrder};
+use bytesize::ByteSize;
+
+use consts::*;
+use crc::crc32;
+use devicemapper::Device;
+use engine::{EngineResult, EngineError, ErrorEnum};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::fs::{OpenOptions, read_dir};
+use std::io;
+use std::io::{Read, Write, ErrorKind, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::str::{FromStr, from_utf8};
 
-use time::Timespec;
-use devicemapper::Device;
-use crc::crc32;
-use byteorder::{LittleEndian, ByteOrder};
-use uuid::Uuid;
-use bytesize::ByteSize;
-
-use types::{Sectors, SectorOffset};
-use engine::{EngineResult, EngineError, ErrorEnum};
-
-use consts::*;
+pub use super::BlockDevSave;
 use super::consts::*;
 use super::util::blkdev_size;
 
-pub use super::BlockDevSave;
+use time::Timespec;
+
+use types::{Sectors, SectorOffset};
+use uuid::Uuid;
 
 type PoolUuid = Uuid;
 type DevUuid = Uuid;

--- a/src/engine/strat_engine/consts.rs
+++ b/src/engine/strat_engine/consts.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use types::Sectors;
 
 use consts::*;
+use types::Sectors;
 
 pub const STRAT_MAGIC: &'static [u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -2,13 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::collections::BTreeMap;
-use std::collections::btree_map::Entry;
-use std::collections::BTreeSet;
-use std::iter::FromIterator;
-use std::path::Path;
-use std::path::PathBuf;
-use std::str::FromStr;
 
 use devicemapper::Device;
 
@@ -16,8 +9,15 @@ use engine::Engine;
 use engine::EngineError;
 use engine::EngineResult;
 use engine::ErrorEnum;
-use engine::RenameAction;
 use engine::Pool;
+use engine::RenameAction;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::btree_map::Entry;
+use std::iter::FromIterator;
+use std::path::Path;
+use std::path::PathBuf;
+use std::str::FromStr;
 
 use super::pool::StratPool;
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,6 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use devicemapper::Device;
+use engine::Cache;
+use engine::Dev;
+
+use engine::EngineResult;
+use engine::Filesystem;
+use engine::Pool;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -9,17 +16,10 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::vec::Vec;
 
-use uuid::Uuid;
-use devicemapper::Device;
-
-use engine::EngineResult;
-use engine::Pool;
-use engine::Filesystem;
-use engine::Dev;
-use engine::Cache;
-
 use super::blockdev::BlockDev;
 use super::consts::*;
+
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct StratFilesystem {

--- a/src/engine/strat_engine/util.rs
+++ b/src/engine/strat_engine/util.rs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::File;
-use std::os::unix::prelude::AsRawFd;
 
 use engine::{EngineResult, EngineError};
+use std::fs::File;
+use std::os::unix::prelude::AsRawFd;
 
 ioctl!(read blkgetsize64 with 0x12, 114; u64);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,17 +48,17 @@ mod stratis;
 mod dbus_api;
 mod engine;
 
-use std::io::Write;
-use std::error::Error;
-use std::process::exit;
-
-use types::{StratisResult, StratisError};
 
 use clap::{App, Arg};
 
 use engine::Engine;
 use engine::sim_engine::SimEngine;
 use engine::strat_engine::StratEngine;
+use std::error::Error;
+use std::io::Write;
+use std::process::exit;
+
+use types::{StratisResult, StratisError};
 
 
 fn write_err(err: StratisError) -> StratisResult<()> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,16 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::io;
-use std::fmt;
-use std::error::Error;
-use std::borrow::Cow;
-use std::ops::Add;
+use dbus;
 
 use nix;
-use term;
-use dbus;
 use serde;
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::ops::Add;
+use term;
 
 pub type StratisResult<T> = Result<T, StratisError>;
 


### PR DESCRIPTION
Initial version turns on ordering of imports.  This is just a proposal.  Seems like automatic ordering 
is a good idea.

Signed-off-by: Todd Gill <tgill@redhat.com>