### PR TITLE
build as a bin and lib.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "stratisd"
+name = "libstratis"
 version = "0.1.0"
 dependencies = [
  "bidir-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -10,10 +10,13 @@ dependencies = [
  "dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "devicemapper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -57,11 +60,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byteorder"
 version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -168,19 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -400,11 +385,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,7 +402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "29b2aa490a8f546381308d68fc79e6bd753cd3ad839f7a7172897f1feedfa175"
-"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum clap 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a430ed980b54e5e6f5249d67abd1e9251e95a5491fafb33639e71c9608d23361"
 "checksum crc 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a3f9159e74024e2cdb6f574e9117cdc2e91523a890930a022823d17abedc90a"
 "checksum custom_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1262be99f6e841c8ff80887a156a35fadec70b94011900364eaee73d5f8c26"
@@ -437,7 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
-"checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum post-expansion 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31a834a6060acaef74a8d878f6ca37a2b86fefe042bbfe70689ba587e42526f9"
 "checksum quickcheck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f17b21936cb2d1f11ffa6dff6ca237d22ee316976f1ed014bc863bd9e18ca6"
@@ -465,6 +443,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum vec_map 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1805118a0d7c72d427e9d9c8134b549ec9e88942c707b100deef357ec0948f02"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stratisd"
+name = "libstratis"
 version = "0.1.0"
 authors = ["Andy Grover <agrover@redhat.com>", "Mulhern <amulhern@redhat.com>", "Todd Gill <tgill@redhat.com>"]
 build = "build.rs"
@@ -29,3 +29,6 @@ features = ["v4"]
 
 [dev-dependencies]
 quickcheck = "0.4"
+rustc-serialize = "0.3.21"
+log = "0.3"
+env_logger="0.3.5"

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#![allow(dead_code)] // only temporary, until more stuff is filled in
+#[macro_use]
+extern crate libstratis;
 
 extern crate devicemapper;
 #[macro_use]
@@ -29,28 +30,17 @@ extern crate enum_derive;
 #[cfg(test)]
 extern crate quickcheck;
 
-mod types;
-mod consts;
-mod dbus_consts;
-#[macro_use]
-mod stratis;
-mod dbus_api;
-mod engine;
-
 use std::io::Write;
 use std::error::Error;
 use std::process::exit;
 
-use stratis::{DEBUG, VERSION};
-
-use types::{StratisResult, StratisError};
-
 use clap::{App, Arg};
 
-use engine::Engine;
-use engine::sim_engine::SimEngine;
-use engine::strat_engine::StratEngine;
-
+use libstratis::engine::Engine;
+use libstratis::engine::sim_engine::SimEngine;
+use libstratis::engine::strat_engine::StratEngine;
+use libstratis::stratis::VERSION;
+use libstratis::types::{StratisResult, StratisError};
 
 fn write_err(err: StratisError) -> StratisResult<()> {
     let mut out = term::stderr().expect("could not get stderr");
@@ -59,6 +49,17 @@ fn write_err(err: StratisError) -> StratisResult<()> {
     try!(writeln!(out, "{}", err.description()));
     try!(out.reset());
     Ok(())
+}
+
+pub static mut DEBUG: bool = false;
+
+macro_rules! dbgp {
+    ($($arg:tt)*) => (
+        unsafe {
+            if DEBUG {
+                println!($($arg)*)
+            }
+        })
 }
 
 fn main() {
@@ -87,7 +88,7 @@ fn main() {
         }
     };
 
-    let r = dbus_api::run(engine);
+    let r = libstratis::dbus_api::run(engine);
 
     if let Err(r) = r {
         if let Err(e) = write_err(r) {

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-mod blockdev;
-mod engine;
-mod filesystem;
-mod metadata;
-mod pool;
+pub mod blockdev;
+pub mod engine;
+pub mod metadata;
+pub mod filesystem;
+pub mod pool;
 
 mod serde_structs {
     include!(concat!(env!("OUT_DIR"), "/serde_structs.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,33 @@
+extern crate devicemapper;
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate nix;
+extern crate crc;
+extern crate bidir_map;
+extern crate byteorder;
+extern crate uuid;
+extern crate time;
+extern crate dbus;
+extern crate term;
+extern crate rand;
+extern crate serde;
+
+#[cfg(test)]
+extern crate quickcheck;
+
+pub mod types;
+pub mod consts;
+#[macro_use]
+pub mod stratis;
+pub mod engine;
+pub mod dbus_api;
+mod dbus_consts;
+
+
+#[macro_use]
+extern crate custom_derive;
+#[macro_use]
+extern crate newtype_derive;
+#[macro_use]
+extern crate enum_derive;

--- a/src/stratis.rs
+++ b/src/stratis.rs
@@ -18,15 +18,4 @@ pub enum StratisState {
     ThinFailed,
 }
 
-pub static mut DEBUG: bool = false;
-
-macro_rules! dbgp {
-    ($($arg:tt)*) => (
-        unsafe {
-            if DEBUG {
-                println!($($arg)*)
-            }
-        })
-}
-
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,18 @@
+# Integration Tests for stratisd
+
+A collection of tests intended to test the different layers of stratis
+
+## Organization
+
+Integration tests go in the stratisd/tests directory (unit tests go in each file
+they're testing).
+
+## Logging
+
+Integration test logging is done via the crate env_logger.  See : 
+https://doc.rust-lang.org/log/env_logger/ for details.
+
+Example: To enable logging for specific modules set:
+
+RUST_LOG=blockdev_tests=debug,pool_tests=debug,util::test_results=debug
+

--- a/tests/blockdev_tests.rs
+++ b/tests/blockdev_tests.rs
@@ -14,7 +14,7 @@ use libstratis::engine::strat_engine::metadata::MIN_MDA_SIZE;
 
 use std::path::Path;
 
-use util::blockdev_utils::clean_blockdevs_headers;
+use util::blockdev_utils::clean_blockdev_headers;
 use util::test_config::TestConfig;
 use util::test_consts::DEFAULT_CONFIG_FILE;
 use util::test_result::TestError::Framework;
@@ -87,8 +87,7 @@ pub fn test_blockdev_setup() {
 
     let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
-    try_clean_devs!(&device_paths);
-    info!("devices cleaned for test");
+    clean_blockdev_headers(&device_paths);
 
     assert!(match test_blockdev_force_flag(&device_paths) {
         Ok(_) => true,

--- a/tests/blockdev_tests.rs
+++ b/tests/blockdev_tests.rs
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#[macro_use]
+extern crate log;
+extern crate uuid;
+extern crate devicemapper;
+extern crate libstratis;
+#[macro_use]
+mod util;
+
+use libstratis::engine::strat_engine::blockdev;
+use libstratis::engine::strat_engine::metadata::MIN_MDA_SIZE;
+
+use std::path::Path;
+
+use util::blockdev_utils::clean_blockdevs_headers;
+use util::test_config::TestConfig;
+use util::test_consts::DEFAULT_CONFIG_FILE;
+use util::test_result::TestError::Framework;
+use util::test_result::TestErrorEnum::Error;
+use util::test_result::TestResult;
+
+use uuid::Uuid;
+
+// Test to make sure an initialized blockdev can't be re-initialized without
+// the force flag.
+pub fn test_blockdev_force_flag(blockdev_paths: &Vec<&Path>) -> TestResult<()> {
+
+    let unique_devices = match blockdev::resolve_devices(blockdev_paths) {
+        Ok(devs) => devs,
+        Err(e) => {
+            let message = format!("Failed to resolve blockdevs: {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    let devices_copy = unique_devices.clone();
+
+    // Initialzie devices with force = ture
+    match blockdev::initialize(&Uuid::new_v4(), unique_devices, MIN_MDA_SIZE, true) {
+        Ok(_) => {
+            debug!("Initialzied starting set of devices");
+        }
+        Err(e) => {
+            let message = format!("Failed to initialize starting set of devices: {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    }
+
+    // Try to initialzie again with different uuid, force = false - this should fail
+    match blockdev::initialize(&Uuid::new_v4(), devices_copy, MIN_MDA_SIZE, false) {
+        Ok(_) => {
+            let message = format!("initialize of already initialized blockdevs succeeded \
+                                        without force flag");
+            return Err(Framework(Error(message)));
+        }
+        Err(_) => {
+            info!("PASS: initialize of already initialzied blockdevs failed (intended)");
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+pub fn test_blockdev_setup() {
+    let mut test_config = TestConfig::new(DEFAULT_CONFIG_FILE);
+
+    let _ = test_config.init();
+
+    let safe_to_destroy_devs = match test_config.get_safe_to_destroy_devs() {
+        Ok(devs) => {
+            if devs.len() == 0 {
+                warn!("No devs availabe for testing.  Test not run");
+                return;
+            }
+            devs
+        }
+        Err(e) => {
+            error!("Failed : get_safe_to_destroy_devs : {:?}", e);
+            return;
+        }
+    };
+
+    info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
+
+    let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
+
+    try_clean_devs!(&device_paths);
+    info!("devices cleaned for test");
+
+    assert!(match test_blockdev_force_flag(&device_paths) {
+        Ok(_) => true,
+        Err(e) => {
+            error!("Failed : test_blockdev_force_flag : {:?}", e);
+            false
+        }
+    });
+
+}

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+extern crate libstratis;
+extern crate devicemapper;
+#[macro_use]
+extern crate log;
+#[macro_use]
+mod util;
+
+use libstratis::engine::Engine;
+use libstratis::engine::strat_engine::StratEngine;
+use libstratis::engine::strat_engine::engine::DevOwnership;
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use util::blockdev_utils::clean_blockdev_headers;
+use util::blockdev_utils::get_ownership;
+use util::test_config::TestConfig;
+use util::test_consts::DEFAULT_CONFIG_FILE;
+use util::test_result::TestResult;
+
+// Check to make sure the disks in blockdev_paths are no longer "Owned" by
+// Stratis
+pub fn validate_disks_released(blockdev_paths: &Vec<PathBuf>) -> TestResult<()> {
+
+    for path_name in blockdev_paths {
+        let path = PathBuf::from(path_name);
+
+        match get_ownership(&path) {
+            Ok(ownership) => {
+                match ownership {
+                    DevOwnership::Unowned => {
+                        debug!("Path confirmed {:?} Unowned | Theirs", path);
+                    }
+                    DevOwnership::Theirs => {
+                        error!("Path set to Theirs after pool delete.  {:?}", path);
+                        assert!(false);
+                    }
+                    DevOwnership::Ours(_) => {
+                        error!("Failed to release {:?}", path);
+                        assert!(false);
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to determine ownership of {:?} {:?}", path, e);
+                assert!(false);
+            }
+        }
+
+    }
+
+    Ok(())
+}
+
+// Validate that disks are "owned" by Stratis
+pub fn validate_disks_init(blockdev_paths: &Vec<PathBuf>) -> TestResult<()> {
+
+    for path_name in blockdev_paths {
+        let path = PathBuf::from(path_name);
+
+        match get_ownership(&path) {
+            Ok(ownership) => {
+                match ownership {
+                    DevOwnership::Unowned | DevOwnership::Theirs => {
+                        error!("Failed to initialize {:?}", path);
+                        assert!(false)
+                    }
+                    DevOwnership::Ours(_) => {
+                        debug!("Path {:?} is confirmed Ours.", path);
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to determine ownership of {:?} {:?}", path, e);
+                assert!(false)
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn test_create_and_delete(device_paths: &Vec<&Path>) -> TestResult<()> {
+
+    let pool_name = "test_pool";
+
+    let mut engine = StratEngine::new();
+
+    let blockdevs = try!(engine.create_pool(pool_name, &device_paths, Some(1), true));
+
+    try!(validate_disks_init(&blockdevs));
+
+    try!(engine.destroy_pool(pool_name));
+
+    try!(validate_disks_released(&blockdevs));
+
+    Ok(())
+}
+
+#[test]
+pub fn test_pools() {
+    let mut test_config = TestConfig::new(DEFAULT_CONFIG_FILE);
+
+    let _ = test_config.init();
+
+    let safe_to_destroy_devs = match test_config.get_safe_to_destroy_devs() {
+        Ok(devs) => {
+            if devs.len() == 0 {
+                warn!("No devs availabe for testing.  Test not run");
+                return;
+            }
+            devs
+        }
+        Err(e) => {
+            error!("Failed : get_safe_to_destroy_devs : {:?}", e);
+            return;
+        }
+    };
+    info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
+
+    let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
+
+    clean_blockdev_headers(&device_paths);
+
+    assert!(match test_create_and_delete(&device_paths) {
+        Ok(_) => true,
+        Err(_) => false,
+    });
+
+}

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -1,0 +1,4 @@
+{
+    "ok_to_destroy_dev_array_key": [
+    ]
+}

--- a/tests/util/blockdev_utils.rs
+++ b/tests/util/blockdev_utils.rs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+use libstratis::consts::SECTOR_SIZE;
+use libstratis::engine::strat_engine::engine::DevOwnership;
+use libstratis::engine::strat_engine::metadata::SigBlock;
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom};
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use util::test_result::TestError;
+use util::test_result::TestErrorEnum;
+
+use util::test_result::TestResult;
+
+pub fn get_ownership(path: &PathBuf) -> TestResult<DevOwnership> {
+
+    let mut f = try!(OpenOptions::new()
+        .read(true)
+        .open(&path));
+
+    let mut buf = [0u8; 4096];
+    try!(f.seek(SeekFrom::Start(0)));
+    try!(f.read(&mut buf));
+
+    let ownership = match SigBlock::determine_ownership(&buf) {
+        Ok(ownership) => ownership,
+        Err(err) => {
+            let error_message = format!("{} for device {:?}", err, path);
+            return Err(TestError::Framework(TestErrorEnum::Error(error_message)));
+        }
+    };
+
+    Ok(ownership)
+}
+
+pub fn clean_blockdevs_headers(blockdev_paths: &Vec<&Path>) -> TestResult<()> {
+
+    for path in blockdev_paths {
+        match wipe_header(path) {
+            Ok(_) => {}
+            Err(err) => {
+                panic!("Failed to clean signature on {:?} : {:?}", path, err);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn wipe_header(path: &Path) -> TestResult<()> {
+    let mut f = try!(OpenOptions::new().write(true).open(path));
+    let zeroed = [0u8; (SECTOR_SIZE * 8) as usize];
+
+    try!(f.write_all(&zeroed[..(SECTOR_SIZE * 8) as usize]));
+    try!(f.write_all(&zeroed[..(SECTOR_SIZE * 8) as usize]));
+
+    Ok(())
+}

--- a/tests/util/blockdev_utils.rs
+++ b/tests/util/blockdev_utils.rs
@@ -14,6 +14,8 @@ use util::test_result::TestErrorEnum;
 
 use util::test_result::TestResult;
 
+
+#[allow(dead_code)]
 pub fn get_ownership(path: &PathBuf) -> TestResult<DevOwnership> {
 
     let mut f = try!(OpenOptions::new()
@@ -35,7 +37,7 @@ pub fn get_ownership(path: &PathBuf) -> TestResult<DevOwnership> {
     Ok(ownership)
 }
 
-pub fn clean_blockdevs_headers(blockdev_paths: &Vec<&Path>) -> TestResult<()> {
+pub fn clean_blockdev_headers(blockdev_paths: &Vec<&Path>) {
 
     for path in blockdev_paths {
         match wipe_header(path) {
@@ -45,16 +47,14 @@ pub fn clean_blockdevs_headers(blockdev_paths: &Vec<&Path>) -> TestResult<()> {
             }
         }
     }
-
-    Ok(())
+    info!("devices cleaned for test");
 }
 
 fn wipe_header(path: &Path) -> TestResult<()> {
     let mut f = try!(OpenOptions::new().write(true).open(path));
-    let zeroed = [0u8; (SECTOR_SIZE * 8) as usize];
+    let zeroed = [0u8; (SECTOR_SIZE * 16) as usize];
 
-    try!(f.write_all(&zeroed[..(SECTOR_SIZE * 8) as usize]));
-    try!(f.write_all(&zeroed[..(SECTOR_SIZE * 8) as usize]));
+    try!(f.write_all(&zeroed[..(SECTOR_SIZE * 16) as usize]));
 
     Ok(())
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+pub mod test_result;
+pub mod test_consts;
+#[macro_use]
+pub mod test_config;
+#[macro_use]
+pub mod blockdev_utils;

--- a/tests/util/test_config.rs
+++ b/tests/util/test_config.rs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+extern crate rustc_serialize;
+extern crate env_logger;
+
+use self::rustc_serialize::json::Json;
+use std::env;
+use std::fs::File;
+use std::io::prelude::Read;
+use util::test_consts::OK_TO_DESTROY_DEV_KEY;
+use util::test_result::TestError;
+use util::test_result::TestErrorEnum;
+
+use util::test_result::TestResult;
+
+pub struct TestConfig {
+    filename: String,
+    config_string: Option<Json>,
+}
+
+impl TestConfig {
+    pub fn new(file: &str) -> TestConfig {
+        TestConfig {
+            filename: String::from(file),
+            config_string: None,
+        }
+    }
+
+    pub fn init(&mut self) -> TestResult<()> {
+
+        env_logger::init().unwrap();
+
+        match self.read_test_config() {
+            Ok(_) => return Ok(()),
+            Err(_) => {
+                return Err(TestError::Framework(TestErrorEnum::Error("Failed to read test config"
+                    .into())))
+            }
+        }
+
+    }
+
+    pub fn get_destroy_devs() {
+        match get_safe_to_destroy_devs() {
+            Ok(devs) => {
+                if devs.len() == 0 {
+                    warn!("Test not run.  No available devices.");
+                    return;
+                }
+                devs
+            }
+            Err(e) => {
+                error!("Failed to read safe to destroy device list from config file. {}",
+                       e);
+                assert!(false);
+                return;
+            }
+        }
+    }
+
+
+    fn get_safe_to_destroy_devs(&mut self) -> TestResult<Vec<String>> {
+
+        if self.config_string.is_none() {
+            return Err(TestError::Framework(TestErrorEnum::JsonError("Array not found".into())));
+        }
+
+        let json_str = self.config_string.as_ref().unwrap();
+
+        let json_path = match json_str.find_path(&[OK_TO_DESTROY_DEV_KEY]) {
+            Some(path) => path,
+            None => {
+                return Err(TestError::Framework(TestErrorEnum::JsonError("Array not found".into())))
+            }
+        };
+
+        let mut ok_to_destroy_dev_list = Vec::new();
+
+        match json_path.as_array() {
+            Some(array) => {
+                for path in array.iter() {
+                    match path.as_string() {
+                        Some(p) => ok_to_destroy_dev_list.push(String::from(p)),
+                        None => {
+                    return Err(TestError::Framework(TestErrorEnum::JsonError("Path conversion \
+                                                                              failed"
+                        .into())))
+                }
+                    }
+                }
+            }
+            None => {
+                return Err(TestError::Framework(TestErrorEnum::JsonError("Array conversion \
+                                                                          failed"
+                    .into())))
+            }
+        };
+
+        Ok(ok_to_destroy_dev_list)
+    }
+
+    // read the JSON from the config file and store in config_string
+    fn read_test_config(&mut self) -> TestResult<()> {
+
+        debug!("start read_test_config() {} {}",
+               &self.filename,
+               env::current_dir().unwrap().display());
+
+        let mut file = try!(File::open(self.filename.clone()));
+        let mut data = String::new();
+        try!(file.read_to_string(&mut data));
+        debug!("{}", &data);
+        self.config_string = match Json::from_str(&data) {
+            Ok(j) => Some(j),
+            Err(e) => {
+                let message = format!("Failed to read JSON {:?}", e);
+                return Err(TestError::Framework(TestErrorEnum::JsonError(message)));
+            }
+
+        };
+
+        Ok(())
+    }
+}

--- a/tests/util/test_config.rs
+++ b/tests/util/test_config.rs
@@ -42,26 +42,7 @@ impl TestConfig {
 
     }
 
-    pub fn get_destroy_devs() {
-        match get_safe_to_destroy_devs() {
-            Ok(devs) => {
-                if devs.len() == 0 {
-                    warn!("Test not run.  No available devices.");
-                    return;
-                }
-                devs
-            }
-            Err(e) => {
-                error!("Failed to read safe to destroy device list from config file. {}",
-                       e);
-                assert!(false);
-                return;
-            }
-        }
-    }
-
-
-    fn get_safe_to_destroy_devs(&mut self) -> TestResult<Vec<String>> {
+    pub fn get_safe_to_destroy_devs(&mut self) -> TestResult<Vec<String>> {
 
         if self.config_string.is_none() {
             return Err(TestError::Framework(TestErrorEnum::JsonError("Array not found".into())));
@@ -80,6 +61,11 @@ impl TestConfig {
 
         match json_path.as_array() {
             Some(array) => {
+                if array.len() == 0 {
+                    return Err(TestError::Framework(TestErrorEnum::JsonError("safe to destroy \
+                                                                              list empty"
+                        .into())));
+                }
                 for path in array.iter() {
                     match path.as_string() {
                         Some(p) => ok_to_destroy_dev_list.push(String::from(p)),

--- a/tests/util/test_consts.rs
+++ b/tests/util/test_consts.rs
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+pub const OK_TO_DESTROY_DEV_KEY: &'static str = "ok_to_destroy_dev_array_key";
+pub const DEFAULT_CONFIG_FILE: &'static str = "tests/test_config.json";

--- a/tests/util/test_result.rs
+++ b/tests/util/test_result.rs
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+extern crate rustc_serialize;
+extern crate libstratis;
+
+use libstratis::engine::EngineError;
+use self::rustc_serialize::json::ParserError;
+use std::fmt;
+use std::io::Error;
+
+#[derive(Debug)]
+pub enum TestErrorEnum {
+    Error(String),
+    JsonError(String),
+}
+
+impl TestErrorEnum {
+    pub fn get_error_string(&self) -> String {
+        match *self {
+            TestErrorEnum::Error(ref x) => format!("{}", x),
+            TestErrorEnum::JsonError(ref x) => format!("{} already exists", x),
+        }
+    }
+}
+
+impl fmt::Display for TestErrorEnum {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.get_error_string())
+    }
+}
+
+#[derive(Debug)]
+pub enum TestError {
+    Framework(TestErrorEnum),
+    EngineError(EngineError),
+    Json(ParserError),
+    Io(Error),
+}
+
+impl From<TestErrorEnum> for TestError {
+    fn from(err: TestErrorEnum) -> TestError {
+        TestError::Framework(err)
+    }
+}
+
+impl From<EngineError> for TestError {
+    fn from(err: EngineError) -> TestError {
+        TestError::EngineError(err)
+    }
+}
+
+impl From<Error> for TestError {
+    fn from(err: Error) -> TestError {
+        TestError::Io(err)
+    }
+}
+
+impl From<ParserError> for TestError {
+    fn from(err: ParserError) -> TestError {
+        TestError::Json(err)
+    }
+}
+
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TestError::Framework(ref err) => write!(f, "Test error: {}", err),
+            TestError::EngineError(ref err) => write!(f, "Engine error: {:?}", err),
+            TestError::Json(ref err) => write!(f, "Json error: {}", err),
+            TestError::Io(ref err) => write!(f, "IO error: {}", err),
+        }
+    }
+}
+
+pub type TestResult<T> = Result<T, TestError>;


### PR DESCRIPTION
Move main.rs to bin/stratisd.rs to allow for building stratisd as bin.

Added lib.rs so that the remainder of the application is compiled as a
lib crate.

Added two sample integration tests blockdev_tests.rs and pool_tests.rs.

Added [dev-dependencies] to include Json parser, log, and env_logger for
use in the integration tests.

Note: see README.md in the tests directory for instructions on enabling test logging.

Log levels currently supported are debug and info.

Added test_config.json to hold parameters for tests.  Currently it only
has 1 array element "ok_to_destroy_dev_array_key".  This array contains a
a list of devices that can be safely destroyed during testing.

Moved dbgp! macro to stratisd.rs - it is the only place it is used - we
should probably switch to a logging crate.

Signed-off-by: Todd Gill <tgill@redhat.com>