### PR TITLE
Make the docs as part of Travis CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-check: fmt build test
+check: fmt build test docs
 
 ${HOME}/.cargo/bin/cargo-fmt:
 	cargo install rustfmt --vers 0.6.3
@@ -12,8 +12,12 @@ build:
 test:
 	cargo test
 
+docs:
+	cargo doc --no-deps
+
 .PHONY:
 	check
 	fmt
 	build
 	test
+	docs

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,9 @@ build:
 
 test:
 	cargo test
+
+.PHONY:
+	check
+	fmt
+	build
+	test


### PR DESCRIPTION
The docs are meaningful, now that stratisd presents as a library. And we might as well make sure that they don't fail to build for some reason.