### PR TITLE
Linear Dev with Integration Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ build:
 	RUSTFLAGS='-D warnings' cargo build
 
 test:
-	cargo test -- --skip test_pools --skip test_blockdev_setup
+	cargo test -- --skip test_pools --skip test_blockdev_setup \
+		--skip test_lineardev_setup
 
 docs:
 	cargo doc --no-deps

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
+
+use engine::{EngineError, EngineResult, ErrorEnum};
+use super::blockdev::BlockDev;
+use types::Sectors;
+
+pub struct LinearDev {
+    name: String,
+    dev_info: Option<DeviceInfo>,
+}
+
+/// support use of DM to concatenate blockdevs and creat e a
+/// /dev/mapper/<name> for use as continuous sectors.
+impl LinearDev {
+    pub fn new(name: &str) -> LinearDev {
+        LinearDev {
+            name: name.to_owned(),
+            dev_info: None,
+        }
+    }
+
+    /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
+    /// <logical start sec> <length> "linear" /dev/xxx <start offset>
+    fn dm_table(&self, block_devs: &Vec<&BlockDev>) -> Vec<(u64, u64, String, String)> {
+        let mut table = Vec::new();
+        let mut logical_start_sector = Sectors(0);
+        for block_dev in block_devs {
+            let (start, length) = block_dev.avail_range();
+            let dstr = block_dev.dstr();
+            let line = (*logical_start_sector,
+                        *length,
+                        "linear".to_owned(),
+                        format!("{} {}", dstr, *start));
+            debug!("dmtable line : {:?}", line);
+            table.push(line);
+            logical_start_sector = logical_start_sector + length;
+        }
+
+        table
+    }
+
+    /// Use DM to concatenate a set of blockdevs together into a
+    /// /dev/mapper/xxx block device of continuous sectors.
+    pub fn concat(&mut self, dm: &DM, block_devs: &Vec<&BlockDev>) -> EngineResult<()> {
+
+        try!(dm.device_create(&self.name, None, DmFlags::empty()));
+        let table = self.dm_table(block_devs);
+        let id = &DevId::Name(&self.name);
+        self.dev_info = Some(dm.table_load(id, &table).unwrap());
+
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        return Ok(());
+    }
+
+    pub fn name(&self) -> EngineResult<&str> {
+        match self.dev_info {
+            Some(ref di) => return Ok(di.name().clone()),
+            None => return Err(EngineError::Engine(ErrorEnum::Invalid, "No dev_info".into())),
+        }
+    }
+
+    pub fn teardown(&self, dm: &DM) -> EngineResult<()> {
+        try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
+
+        Ok(())
+    }
+}

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -50,7 +50,7 @@ impl LinearDev {
         try!(dm.device_create(&self.name, None, DmFlags::empty()));
         let table = self.dm_table(block_devs);
         let id = &DevId::Name(&self.name);
-        self.dev_info = Some(dm.table_load(id, &table).unwrap());
+        self.dev_info = Some(try!(dm.table_load(id, &table)));
 
         try!(dm.device_suspend(id, DmFlags::empty()));
 

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod blockdev;
 pub mod engine;
+pub mod lineardev;
 pub mod metadata;
 pub mod filesystem;
 pub mod pool;

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,19 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::io;
-use std::fmt;
-use std::error::Error;
-use std::borrow::Cow;
-use std::fmt::Display;
-use std::ops::{Div, Mul, Rem};
-
-use nix;
-use term;
-use dbus;
-use serde;
 
 use consts::SECTOR_SIZE;
+use dbus;
+
+use nix;
+use serde;
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt;
+use std::fmt::Display;
+use std::io;
+use std::ops::{Div, Mul, Rem};
+use term;
 
 pub type StratisResult<T> = Result<T, StratisError>;
 
@@ -147,7 +147,6 @@ impl serde::Deserialize for Sectors {
         Ok(Sectors(val))
     }
 }
-
 
 // An error type for errors generated within Stratis
 //

--- a/tests/lineardev_tests.rs
+++ b/tests/lineardev_tests.rs
@@ -1,0 +1,188 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#[macro_use]
+extern crate log;
+extern crate uuid;
+extern crate devicemapper;
+extern crate libstratis;
+#[macro_use]
+mod util;
+
+use devicemapper::DM;
+
+use libstratis::engine::strat_engine::blockdev;
+use libstratis::engine::strat_engine::blockdev::BlockDev;
+use libstratis::engine::strat_engine::lineardev::LinearDev;
+use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
+use libstratis::types::Sectors;
+
+use std::iter::FromIterator;
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+use util::blockdev_utils::clean_blockdev_headers;
+use util::blockdev_utils::get_size;
+use util::test_config::TestConfig;
+use util::test_consts::DEFAULT_CONFIG_FILE;
+use util::test_result::TestError::Framework;
+use util::test_result::TestErrorEnum::Error;
+use util::test_result::TestResult;
+
+use uuid::Uuid;
+
+/// Return a LinearDev with concatenated BlockDevs
+fn concat_blockdevs(dm: &DM, name: &str, block_devs: &Vec<&BlockDev>) -> TestResult<LinearDev> {
+
+    let mut linear_dev = LinearDev::new(name);
+
+    match linear_dev.concat(dm, block_devs) {
+        Ok(_) => return Ok(linear_dev),
+        Err(e) => {
+            // tear down a partially created DM device if it exists
+            match linear_dev.teardown(&dm) {
+                Ok(_) => info!("completed teardown of {}", name),
+                Err(_) => info!("failed teardown of {}", name),
+            }
+            let message = format!("linear_dev.concat failed : {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+
+    }
+}
+
+/// Get the usable sector lengths for each dev
+/// Wait for the DM device to be created
+/// Validate the size of the DM device with the sum of the sector lengths
+fn validate_sizes(name: &str, block_devs: &Vec<&BlockDev>) -> TestResult<()> {
+
+    let mut linear_sectors = Sectors(0);
+
+    for blockdev in block_devs {
+        let (_start_sector, length) = blockdev.avail_range();
+        linear_sectors = linear_sectors + length;
+    }
+
+    debug!("available linear space = {} sectors", linear_sectors);
+
+    // The /dev/mapper/<name> device is not immediately available for use.
+    // TODO: Implement wait for event or poll.
+    thread::sleep(Duration::from_millis(1000));
+
+    let path_name = format!("/dev/mapper/{}", name);
+    let path = Path::new(&path_name);
+
+    let dm_dev_size = match get_size(path) {
+        Ok(s) => s,
+        Err(_) => panic!("Failed to get size for {} ", name),
+    };
+    debug!("size of dm device {:?} = {}", path, dm_dev_size);
+
+    assert_eq!(linear_sectors, dm_dev_size);
+
+    Ok(())
+}
+
+/// Validate the blockdev_paths are unique
+/// Initialize the list for use with Stratis
+/// Concatenate the list via LinearDev
+/// Validate the size of the resulting DM device
+fn test_lineardev_concat(dm: &DM, blockdev_paths: &Vec<&Path>) -> TestResult<(LinearDev)> {
+
+    let uuid = Uuid::new_v4();
+
+    let unique_blockdevs = match blockdev::resolve_devices(blockdev_paths) {
+        Ok(devs) => devs,
+        Err(e) => {
+            let message = format!("Failed to resolve starting set of blockdevs:{:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    let blockdev_map = match blockdev::initialize(&uuid, unique_blockdevs, MIN_MDA_SECTORS, true) {
+        Ok(blockdev_map) => blockdev_map,
+        Err(e) => {
+            let message = format!("Failed to initialize starting set of blockdevs {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    let name = "stratis_testing_linear";
+
+    let blockdev_vec = Vec::from_iter(blockdev_map.values());
+
+    let linear_dev = match concat_blockdevs(dm, &name, &blockdev_vec) {
+        Ok(dev) => dev,
+        Err(e) => {
+            let message = format!("Failed to concat_blockdevs {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    match validate_sizes(&name, &blockdev_vec) {
+        Ok(_) => info!("validate_sizes Ok"),
+        Err(e) => {
+            panic!("Failed : validate_sizes() : {:?}", e);
+        }
+    }
+
+    Ok(linear_dev)
+}
+
+#[test]
+/// Get list of safe to destroy devices.
+/// Clean any headers from the devices.
+/// Test concatenating the list of devices into linear sectors
+/// Teardown the DM device
+pub fn test_lineardev_setup() {
+
+    let dm = DM::new().unwrap();
+
+    let mut test_config = TestConfig::new(DEFAULT_CONFIG_FILE);
+
+    let _ = test_config.init();
+
+    let safe_to_destroy_devs = match test_config.get_safe_to_destroy_devs() {
+        Ok(devs) => {
+            if devs.len() == 0 {
+                warn!("No devs availabe for testing.  Test not run");
+                return;
+            }
+            devs
+        }
+        Err(e) => {
+            error!("Failed : get_safe_to_destroy_devs : {:?}", e);
+            return;
+        }
+    };
+
+    info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
+    let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
+
+    clean_blockdev_headers(&device_paths);
+    info!("devices cleaned for test");
+
+    assert!(match test_lineardev_concat(&dm, &device_paths) {
+        Ok(linear_dev) => {
+            info!("Linear dev name : {:?}", linear_dev.name());
+            let name = match linear_dev.name() {
+                Ok(n) => n,
+                Err(e) => panic!("Failed to get lineardev name {:?} ", e),
+            };
+            info!("completed test on {}", name);
+
+            match linear_dev.teardown(&dm) {
+                Ok(_) => info!("completed teardown of {}", name),
+                Err(e) => panic!("Failed to teardown {} : {:?}", name, e),
+            }
+            true
+        }
+        Err(e) => {
+            error!("Failed : test_lineardev_concat : {:?}", e);
+            false
+        }
+    });
+
+
+}


### PR DESCRIPTION
Added -- skip for test_lineardev_setup to Makefile
LinearDev uses DM linear to  concatenate of a list of BlockDevs into continuous sectors.
Integration test for LinearDev - the test takes a list of destroyable block devices and
concatenates them - it then checks the size of the resulting DM device to validate that it
is the sum of the sector ranges allocated on each block device.

Signed-off-by: Todd Gill <tgill@redhat.com>