### PR TITLE
Add env_logger to stratisd and libstratis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rand = "0.3"
 bidir-map = "0.3"
 serde = "0"
 serde_json = "0"
+log = "0.3"
+env_logger="0.3.5"
 
 [dependencies.uuid]
 version = "0.3.1"
@@ -31,5 +33,4 @@ features = ["v4"]
 [dev-dependencies]
 quickcheck = "0.4"
 rustc-serialize = "0.3.21"
-log = "0.3"
-env_logger="0.3.5"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ extern crate term;
 extern crate rand;
 extern crate serde;
 extern crate serde_json;
+#[macro_use]
+extern crate log;
 
 #[cfg(test)]
 extern crate quickcheck;


### PR DESCRIPTION
Move log dependencies from tests to application level.
Change stratisd.rs to use env_logger.

When user passes --debug to stratisd enable logging for binary crate
and the libstratis crate.  --debug will override RUST_LOG.

RUST_LOG env variable controls per module logging.  For example:

RUST_LOG=stratisd=debug,libstratis=debug
RUST_LOG=libstratis::engine::strat_engine::engine=info

Signed-off-by: Todd Gill <tgill@redhat.com>