### PR TITLE
Change MIN_MDA_SIZE to 2032

### DIFF
--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -25,7 +25,7 @@ const NUM_MDA_REGIONS: u64 = 4;
 const PER_MDA_REGION_COPIES: u64 = 2;
 const NUM_PRIMARY_MDA_REGIONS: u64 = NUM_MDA_REGIONS / PER_MDA_REGION_COPIES;
 const MDA_REGION_HDR_SIZE: usize = 32;
-pub const MIN_MDA_SIZE: Sectors = Sectors(2040);
+pub const MIN_MDA_SIZE: Sectors = Sectors(2032);
 const STRAT_MAGIC: &'static [u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
 
 #[derive(Debug)]


### PR DESCRIPTION
Static header size went from 8 to 16 sectors. That means that static header
plus MDA now no longer lines up on a power-of-2 boundary. This change
decreases MDA by 8 so that it does once more.

Signed-off-by: Andy Grover <agrover@redhat.com>