### PR TITLE
Fold StaticHeader init/setup into BDA equivalents

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -66,8 +66,7 @@ pub fn find_all() -> EngineResult<BTreeMap<PoolUuid, BTreeMap<DevUuid, BlockDev>
             .read(true)
             .open(devnode));
 
-        let static_header = try!(StaticHeader::setup(&mut f));
-        let bda = try!(BDA::load(&mut f, static_header));
+        let bda = try!(BDA::load(&mut f));
 
         Ok(Some(BlockDev {
             dev: dev,
@@ -191,9 +190,11 @@ pub fn initialize(pool_uuid: &PoolUuid,
     let mut bds = BTreeMap::new();
     for (dev, (devnode, dev_size, mut f)) in add_devs {
 
-        let static_header =
-            StaticHeader::new(pool_uuid, &Uuid::new_v4(), mda_size, dev_size.sectors());
-        let bda = try!(BDA::initialize(&mut f, static_header));
+        let bda = try!(BDA::initialize(&mut f,
+                                       pool_uuid,
+                                       &Uuid::new_v4(),
+                                       mda_size,
+                                       dev_size.sectors()));
 
         let bd = BlockDev {
             dev: dev,

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -43,8 +43,14 @@ pub struct BDA {
 
 impl BDA {
     /// Initialize a blockdev with a Stratis BDA.
-    pub fn initialize(mut f: &mut File, header: StaticHeader) -> EngineResult<BDA> {
+    pub fn initialize(mut f: &mut File,
+                      pool_uuid: &Uuid,
+                      dev_uuid: &Uuid,
+                      mda_size: Sectors,
+                      blkdev_size: Sectors)
+                      -> EngineResult<BDA> {
         let zeroed = [0u8; _BDA_STATIC_HDR_SIZE];
+        let header = StaticHeader::new(pool_uuid, dev_uuid, mda_size, blkdev_size);
         let hdr_buf = header.sigblock_to_buf();
 
         // Write 8K header. Static_Header copies go in sectors 1 and 9.
@@ -65,7 +71,8 @@ impl BDA {
         })
     }
 
-    pub fn load(f: &mut File, header: StaticHeader) -> EngineResult<BDA> {
+    pub fn load(f: &mut File) -> EngineResult<BDA> {
+        let header = try!(StaticHeader::setup(f));
         let regions = try!(MDARegions::load(&header, f));
 
         Ok(BDA {


### PR DESCRIPTION
StaticHeader is part of the BDA, so instead of making clients call two
functions (1 to setup SH, another (that takes SH) to setup BDA) just
call the StaticHeader functions from the BDA functions.

Signed-off-by: Andy Grover <agrover@redhat.com>