### PR TITLE
Work to improve/expand destroy_pool testing a little

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -83,6 +83,11 @@ pub trait Pool: Debug {
     fn blockdevs(&mut self) -> Vec<&mut Dev>;
     fn cachedevs(&mut self) -> Vec<&mut Dev>;
 
+    /// Destroy the pool.
+    /// Will fail if filesystems allocated from the pool are in use,
+    /// or even exist.
+    fn destroy(self) -> EngineResult<()>;
+
     /// Ensures that all designated filesystems are gone from pool.
     /// Returns a list of the filesystems found, and actually destroyed.
     /// This list will be a subset of the names passed in fs_names.

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -41,14 +41,7 @@ macro_rules! destroy_pool {
             return Err(EngineError::Engine(
                 ErrorEnum::Busy, "filesystems remaining on pool".into()));
         };
-        if !entry.get().block_devs.is_empty() {
-            return Err(EngineError::Engine(ErrorEnum::Busy, "devices remaining in pool".into()));
-        };
-        if !entry.get().cache_devs.is_empty() {
-            return Err(EngineError::Engine(ErrorEnum::Busy, "cache devices remaining in pool"
-                .into()));
-        };
-        entry.remove();
+        try!(entry.remove().destroy());
         Ok(true)
     }
 }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -160,6 +160,19 @@ mod tests {
     }
 
     #[test]
+    /// Destroying a pool with filesystems should fail
+    fn destroy_pool_w_filesystem() {
+        let name = "name";
+        let mut engine = SimEngine::new();
+        engine.create_pool(name, &[Path::new("/s/d")], None, false).unwrap();
+        {
+            let pool = engine.get_pool(name).unwrap();
+            pool.create_filesystems(&[("test", "/mnt/temp", None)]).unwrap();
+        }
+        assert!(engine.destroy_pool(name).is_err());
+    }
+
+    #[test]
     #[ignore]
     /// Creating a new pool identical to the previous should succeed
     fn create_new_pool_twice() {

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -151,15 +151,12 @@ mod tests {
     }
 
     #[test]
-    /// Destroying a pool with devices should fail
+    /// Destroying a pool with devices should succeed
     fn destroy_pool_w_devices() {
         let name = "name";
         let mut engine = SimEngine::new();
         engine.create_pool(name, &[Path::new("/s/d")], None, false).unwrap();
-        assert!(match engine.destroy_pool(name) {
-            Err(EngineError::Engine(ErrorEnum::Busy, _)) => true,
-            _ => false,
-        });
+        assert!(engine.destroy_pool(name).is_ok());
     }
 
     #[test]

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -81,6 +81,11 @@ impl Pool for SimPool {
         destroy_filesystems!{self; fs_names}
     }
 
+    fn destroy(self) -> EngineResult<()> {
+        // Nothing to do here.
+        Ok(())
+    }
+
     fn create_filesystems<'a, 'b, 'c>(&'a mut self,
                                       specs: &[(&'b str, &'c str, Option<Bytes>)])
                                       -> EngineResult<Vec<&'b str>> {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -222,6 +222,11 @@ impl BlockDev {
         }
     }
 
+    pub fn wipe_metadata(&mut self) -> EngineResult<()> {
+        let mut f = try!(OpenOptions::new().write(true).open(&self.devnode));
+        BDA::wipe(&mut f)
+    }
+
     /// Get the "x:y" device string for this blockdev
     pub fn dstr(&self) -> String {
         self.dev.dstr()

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -157,6 +157,21 @@ impl Pool for StratPool {
         Ok(bdev_paths)
     }
 
+    fn destroy(mut self) -> EngineResult<()> {
+
+        // TODO: first, tear down DM mappings
+
+        for bd in self.block_devs.values_mut() {
+            try!(bd.wipe_metadata());
+        }
+
+        for bd in self.cache_devs.values_mut() {
+            try!(bd.wipe_metadata());
+        }
+
+        Ok(())
+    }
+
     fn destroy_filesystems<'a, 'b>(&'a mut self,
                                    fs_names: &[&'b str])
                                    -> EngineResult<Vec<&'b str>> {


### PR DESCRIPTION
`destroy_pool` should succeed if the pool has devs, but should fail if the pool has filesystems.