### PR TITLE
Use DM to create a thin-pool for thin provisioned devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 test:
 	cargo test -- --skip test_pools --skip test_blockdev_setup \
-		--skip test_lineardev_setup
+		--skip test_lineardev_setup --skip test_thinpoolsetup_setup
 
 docs:
 	cargo doc --no-deps

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -83,6 +83,11 @@ pub trait Pool: Debug {
     fn blockdevs(&mut self) -> Vec<&mut Dev>;
     fn cachedevs(&mut self) -> Vec<&mut Dev>;
 
+    /// Destroy the pool.
+    /// Will fail if filesystems allocated from the pool are in use,
+    /// or even exist.
+    fn destroy(self) -> EngineResult<()>;
+
     /// Ensures that all designated filesystems are gone from pool.
     /// Returns a list of the filesystems found, and actually destroyed.
     /// This list will be a subset of the names passed in fs_names.

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -41,14 +41,7 @@ macro_rules! destroy_pool {
             return Err(EngineError::Engine(
                 ErrorEnum::Busy, "filesystems remaining on pool".into()));
         };
-        if !entry.get().block_devs.is_empty() {
-            return Err(EngineError::Engine(ErrorEnum::Busy, "devices remaining in pool".into()));
-        };
-        if !entry.get().cache_devs.is_empty() {
-            return Err(EngineError::Engine(ErrorEnum::Busy, "cache devices remaining in pool"
-                .into()));
-        };
-        entry.remove();
+        try!(entry.remove().destroy());
         Ok(true)
     }
 }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -160,6 +160,19 @@ mod tests {
     }
 
     #[test]
+    /// Destroying a pool with filesystems should fail
+    fn destroy_pool_w_filesystem() {
+        let name = "name";
+        let mut engine = SimEngine::new();
+        engine.create_pool(name, &[Path::new("/s/d")], None, false).unwrap();
+        {
+            let pool = engine.get_pool(name).unwrap();
+            pool.create_filesystems(&[("test", "/mnt/temp", None)]).unwrap();
+        }
+        assert!(engine.destroy_pool(name).is_err());
+    }
+
+    #[test]
     #[ignore]
     /// Creating a new pool identical to the previous should succeed
     fn create_new_pool_twice() {

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -151,15 +151,12 @@ mod tests {
     }
 
     #[test]
-    /// Destroying a pool with devices should fail
+    /// Destroying a pool with devices should succeed
     fn destroy_pool_w_devices() {
         let name = "name";
         let mut engine = SimEngine::new();
         engine.create_pool(name, &[Path::new("/s/d")], None, false).unwrap();
-        assert!(match engine.destroy_pool(name) {
-            Err(EngineError::Engine(ErrorEnum::Busy, _)) => true,
-            _ => false,
-        });
+        assert!(engine.destroy_pool(name).is_ok());
     }
 
     #[test]

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -81,6 +81,11 @@ impl Pool for SimPool {
         destroy_filesystems!{self; fs_names}
     }
 
+    fn destroy(self) -> EngineResult<()> {
+        // Nothing to do here.
+        Ok(())
+    }
+
     fn create_filesystems<'a, 'b, 'c>(&'a mut self,
                                       specs: &[(&'b str, &'c str, Option<Bytes>)])
                                       -> EngineResult<Vec<&'b str>> {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -222,6 +222,11 @@ impl BlockDev {
         }
     }
 
+    pub fn wipe_metadata(&mut self) -> EngineResult<()> {
+        let mut f = try!(OpenOptions::new().write(true).open(&self.devnode));
+        BDA::wipe(&mut f)
+    }
+
     /// Get the "x:y" device string for this blockdev
     pub fn dstr(&self) -> String {
         self.dev.dstr()

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -8,6 +8,8 @@ pub mod lineardev;
 pub mod metadata;
 pub mod filesystem;
 pub mod pool;
+// pub mod thindev;
+pub mod thinpooldev;
 
 mod serde_structs {
     include!(concat!(env!("OUT_DIR"), "/serde_structs.rs"));

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -157,6 +157,21 @@ impl Pool for StratPool {
         Ok(bdev_paths)
     }
 
+    fn destroy(mut self) -> EngineResult<()> {
+
+        // TODO: first, tear down DM mappings
+
+        for bd in self.block_devs.values_mut() {
+            try!(bd.wipe_metadata());
+        }
+
+        for bd in self.cache_devs.values_mut() {
+            try!(bd.wipe_metadata());
+        }
+
+        Ok(())
+    }
+
     fn destroy_filesystems<'a, 'b>(&'a mut self,
                                    fs_names: &[&'b str])
                                    -> EngineResult<Vec<&'b str>> {

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
+use engine::EngineResult;
+
+
+use super::blockdev::BlockDev;
+
+use types::DataBlocks;
+use types::Sectors;
+
+pub struct ThinPoolDev {
+    pub name: String,
+    dev_info: Option<DeviceInfo>,
+    data_block_size: Option<Sectors>,
+    pub low_water_mark: Option<DataBlocks>,
+    pub meta_dev: Option<BlockDev>,
+    pub data_dev: Option<BlockDev>,
+}
+
+/// support use of DM to create pools for thin provisioned devices
+impl ThinPoolDev {
+    pub fn new(name: &str) -> ThinPoolDev {
+        ThinPoolDev {
+            name: name.to_owned(),
+            dev_info: None,
+            data_block_size: None,
+            low_water_mark: None,
+            meta_dev: None,
+            data_dev: None,
+        }
+    }
+    /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
+    /// <start sec> <length> "thin-pool" /dev/meta /dev/data <block size> <low water mark>
+    fn dm_table(&self,
+                length: &Sectors,
+                data_block_size: &Sectors,
+                low_water_mark: &DataBlocks,
+                meta_dev: &BlockDev,
+                data_dev: &BlockDev)
+                -> Vec<(u64, u64, String, String)> {
+        let mut table = Vec::new();
+        let params = format!("{} {} {} {} 1 skip_block_zeroing",
+                             meta_dev.dstr(),
+                             data_dev.dstr(),
+                             data_block_size.0,
+                             low_water_mark.0);
+        table.push((0u64, length.0, "thin-pool".to_owned(), params));
+        debug!("dmtable line : {:?}", table);
+        table
+    }
+
+    /// Use DM to create a "thin-pool".  A "thin-pool" is shared space for
+    /// other thin provisioned devices to use.
+    ///
+    /// See section "Setting up a fresh pool device":
+    /// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
+    pub fn setup(&mut self,
+                 dm: &DM,
+                 length: &Sectors,
+                 data_block_size: &Sectors,
+                 low_water_mark: &DataBlocks,
+                 meta_dev: &BlockDev,
+                 data_dev: &BlockDev)
+                 -> EngineResult<()> {
+        debug!("setup : {}", self.name);
+        try!(dm.device_create(&self.name, None, DmFlags::empty()));
+
+        let table = self.dm_table(length, data_block_size, low_water_mark, meta_dev, data_dev);
+        self.data_block_size = Some(*data_block_size);
+        self.low_water_mark = Some(*low_water_mark);
+        let id = &DevId::Name(&self.name);
+        self.dev_info = Some(try!(dm.table_load(id, &table)));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        Ok(())
+    }
+
+    pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
+        try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
+
+        Ok(())
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -148,6 +148,32 @@ impl serde::Deserialize for Sectors {
     }
 }
 
+// A type for Data Blocks as used by the thin pool.
+custom_derive! {
+    #[derive(NewtypeFrom, NewtypeAdd, NewtypeSub, NewtypeDeref,
+             NewtypeBitAnd, NewtypeNot, NewtypeDiv, NewtypeRem,
+             NewtypeMul,
+             Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct DataBlocks(pub u64);
+}
+
+impl serde::Serialize for DataBlocks {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: serde::Serializer
+    {
+        serializer.serialize_u64(**self)
+    }
+}
+
+impl serde::Deserialize for DataBlocks {
+    fn deserialize<D>(deserializer: &mut D) -> Result<DataBlocks, D::Error>
+        where D: serde::de::Deserializer
+    {
+        let val = try!(serde::Deserialize::deserialize(deserializer));
+        Ok(DataBlocks(val))
+    }
+}
+
 // An error type for errors generated within Stratis
 //
 #[derive(Debug)]

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#[macro_use]
+extern crate log;
+extern crate uuid;
+extern crate devicemapper;
+extern crate libstratis;
+#[macro_use]
+mod util;
+
+use devicemapper::DM;
+
+use libstratis::engine::strat_engine::blockdev;
+use libstratis::engine::strat_engine::blockdev::BlockDev;
+use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
+use libstratis::engine::strat_engine::thinpooldev::ThinPoolDev;
+use libstratis::types::Sectors;
+
+use std::iter::FromIterator;
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+
+use util::blockdev_utils::clean_blockdev_headers;
+use util::blockdev_utils::get_size;
+use util::test_config::TestConfig;
+use util::test_consts::DEFAULT_CONFIG_FILE;
+use util::test_result::TestError::Framework;
+use util::test_result::TestErrorEnum::Error;
+use util::test_result::TestResult;
+
+use uuid::Uuid;
+
+fn test_thinpool_setup(dm: &DM, blockdev_paths: &Vec<&Path>) -> TestResult<(ThinPoolDev)> {}
+
+#[test]
+pub fn test_thinpoolsetup_setup() {
+
+    let dm = DM::new().unwrap();
+
+    let mut test_config = TestConfig::new(DEFAULT_CONFIG_FILE);
+
+    let _ = test_config.init();
+
+    let safe_to_destroy_devs = match test_config.get_safe_to_destroy_devs() {
+        Ok(devs) => {
+            if devs.len() == 0 {
+                warn!("No devs availabe for testing.  Test not run");
+                return;
+            }
+            devs
+        }
+        Err(e) => {
+            error!("Failed : get_safe_to_destroy_devs : {:?}", e);
+            return;
+        }
+    };
+
+    info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
+    let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
+
+    clean_blockdev_headers(&device_paths);
+    info!("devices cleaned for test");
+
+    assert!(match test_thinpool_setup(&dm, &device_paths) {
+        Ok(thinpool_dev) => {
+            info!("Linear dev name : {:?}", thinpool_dev.name());
+            let name = match thinpool_dev.name() {
+                Ok(n) => n,
+                Err(e) => panic!("Failed to get lineardev name {:?} ", e),
+            };
+            info!("completed test on {}", name);
+
+            match thinpool_dev.teardown(&dm) {
+                Ok(_) => info!("completed teardown of {}", name),
+                Err(e) => panic!("Failed to teardown {} : {:?}", name, e),
+            }
+            true
+        }
+        Err(e) => {
+            error!("Failed : test_lineardev_concat : {:?}", e);
+            false
+        }
+    });
+}


### PR DESCRIPTION

Added thingpooldev to combine a metadata and data device into a DM thin-pool
Added a test to validate the creation of the thin-pool
Added --skip to the Makefile for the integration test