### PR TITLE
Use DM to create a thin-pool for thin provisioned devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 test:
 	cargo test -- --skip test_pools --skip test_blockdev_setup \
-		--skip test_lineardev_setup
+		--skip test_lineardev_setup --skip test_thinpoolsetup_setup
 
 docs:
 	cargo doc --no-deps

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -5,6 +5,9 @@
 use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 
 use engine::{EngineError, EngineResult, ErrorEnum};
+
+use std::path::PathBuf;
+
 use super::blockdev::BlockDev;
 use types::Sectors;
 
@@ -60,6 +63,13 @@ impl LinearDev {
     pub fn name(&self) -> EngineResult<&str> {
         match self.dev_info {
             Some(ref di) => return Ok(di.name().clone()),
+            None => return Err(EngineError::Engine(ErrorEnum::Invalid, "No dev_info".into())),
+        }
+    }
+
+    pub fn path(&self) -> EngineResult<Option<PathBuf>> {
+        match self.dev_info {
+            Some(ref di) => return Ok(di.device().path().clone()),
             None => return Err(EngineError::Engine(ErrorEnum::Invalid, "No dev_info".into())),
         }
     }

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -9,6 +9,7 @@ pub mod metadata;
 pub mod filesystem;
 pub mod pool;
 pub mod serde_structs;
+pub mod thinpooldev;
 
 pub use self::engine::StratEngine;
 pub use self::pool::StratPool;

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
+use engine::EngineResult;
+
+use std::path::Path;
+
+use super::blockdev::BlockDev;
+
+use types::DataBlocks;
+use types::Sectors;
+
+pub struct ThinPoolDev {
+    pub name: String,
+    dev_info: Option<DeviceInfo>,
+    data_block_size: Option<Sectors>,
+    pub low_water_mark: Option<DataBlocks>, // How close to full before we are worried?
+    pub meta_dev: Option<BlockDev>,
+    pub data_dev: Option<BlockDev>,
+}
+
+/// support use of DM to create pools for thin provisioned devices
+impl ThinPoolDev {
+    pub fn new(name: &str) -> ThinPoolDev {
+        ThinPoolDev {
+            name: name.to_owned(),
+            dev_info: None,
+            data_block_size: None,
+            low_water_mark: None,
+            meta_dev: None,
+            data_dev: None,
+        }
+    }
+    /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
+    /// <start sec> <length> "thin-pool" /dev/meta /dev/data <block size> <low water mark>
+    fn dm_table(&self,
+                length: Sectors,
+                data_block_size: Sectors,
+                low_water_mark: DataBlocks,
+                meta_dev: &Path,
+                data_dev: &Path)
+                -> Vec<(u64, u64, String, String)> {
+        let mut table = Vec::new();
+        let params = format!("{} {} {} {} 1 skip_block_zeroing",
+                             meta_dev.to_string_lossy(),
+                             data_dev.to_string_lossy(),
+                             *data_block_size,
+                             *low_water_mark);
+        table.push((0u64, length.0, "thin-pool".to_owned(), params));
+        debug!("dmtable line : {:?}", table);
+        table
+    }
+
+    /// Use DM to create a "thin-pool".  A "thin-pool" is shared space for
+    /// other thin provisioned devices to use.
+    ///
+    /// See section "Setting up a fresh pool device":
+    /// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
+    pub fn setup(&mut self,
+                 dm: &DM,
+                 length: Sectors,
+                 data_block_size: Sectors,
+                 low_water_mark: DataBlocks,
+                 meta_dev: &Path,
+                 data_dev: &Path)
+                 -> EngineResult<()> {
+
+        debug!("setup : {}", self.name);
+        try!(dm.device_create(&self.name, None, DmFlags::empty()));
+
+        let table = self.dm_table(length, data_block_size, low_water_mark, meta_dev, data_dev);
+        self.data_block_size = Some(data_block_size);
+        self.low_water_mark = Some(low_water_mark);
+        let id = &DevId::Name(&self.name);
+        self.dev_info = Some(try!(dm.table_load(id, &table)));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        Ok(())
+    }
+
+    pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
+        try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
+
+        Ok(())
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -148,6 +148,32 @@ impl serde::Deserialize for Sectors {
     }
 }
 
+// A type for Data Blocks as used by the thin pool.
+custom_derive! {
+    #[derive(NewtypeFrom, NewtypeAdd, NewtypeSub, NewtypeDeref,
+             NewtypeBitAnd, NewtypeNot, NewtypeDiv, NewtypeRem,
+             NewtypeMul,
+             Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct DataBlocks(pub u64);
+}
+
+impl serde::Serialize for DataBlocks {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer
+    {
+        serializer.serialize_u64(**self)
+    }
+}
+
+impl serde::Deserialize for DataBlocks {
+    fn deserialize<D>(deserializer: D) -> Result<DataBlocks, D::Error>
+        where D: serde::de::Deserializer
+    {
+        let val = try!(serde::Deserialize::deserialize(deserializer));
+        Ok(DataBlocks(val))
+    }
+}
+
 // An error type for errors generated within Stratis
 //
 #[derive(Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,9 +150,10 @@ impl serde::Deserialize for Sectors {
 
 // A type for Data Blocks as used by the thin pool.
 custom_derive! {
-    #[derive(NewtypeFrom, NewtypeAdd, NewtypeSub, NewtypeDeref,
-             NewtypeBitAnd, NewtypeNot, NewtypeDiv, NewtypeRem,
-             NewtypeMul,
+    #[derive(NewtypeAdd, NewtypeAddAssign,
+             NewtypeDeref,
+             NewtypeFrom,
+             NewtypeSub,
              Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
     pub struct DataBlocks(pub u64);
 }

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -1,0 +1,217 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#[macro_use]
+extern crate log;
+extern crate uuid;
+extern crate devicemapper;
+extern crate libstratis;
+#[macro_use]
+mod util;
+
+use devicemapper::DM;
+
+use libstratis::engine::strat_engine::blockdev;
+use libstratis::engine::strat_engine::blockdev::BlockDev;
+use libstratis::engine::strat_engine::lineardev::LinearDev;
+use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
+use libstratis::engine::strat_engine::thinpooldev::ThinPoolDev;
+use libstratis::types::DataBlocks;
+use libstratis::types::Sectors;
+
+use std::path::{Path, PathBuf};
+
+use util::blockdev_utils::clean_blockdev_headers;
+use util::blockdev_utils::wait_for_dm;
+use util::test_config::TestConfig;
+use util::test_consts::DEFAULT_CONFIG_FILE;
+use util::test_result::TestError::Framework;
+use util::test_result::TestErrorEnum::Error;
+use util::test_result::TestResult;
+
+use uuid::Uuid;
+
+fn setup_supporting_devs(dm: &DM,
+                         metadata_dev: &mut LinearDev,
+                         data_dev: &mut LinearDev,
+                         metadata_blockdev: &BlockDev,
+                         data_blockdev: &BlockDev)
+                         -> TestResult<(PathBuf, PathBuf)> {
+
+    let mut meta_blockdevs = Vec::new();
+    meta_blockdevs.push(metadata_blockdev);
+
+    match metadata_dev.concat(dm, &meta_blockdevs) {
+        Ok(_) => {}
+        Err(e) => {
+            let message = format!("metadata.concat failed : {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+
+    }
+
+    let mut data_blockdevs = Vec::new();
+    data_blockdevs.push(data_blockdev);
+
+
+    match data_dev.concat(dm, &data_blockdevs) {
+        Ok(_) => {}
+        Err(e) => {
+            let message = format!("datadev.concat failed : {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+
+    }
+
+    let metadata_path = match metadata_dev.path() {
+        Ok(path) => path.unwrap().clone(),
+        Err(e) => {
+            let message = format!("Failed to get data path : {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    let data_path = match data_dev.path() {
+        Ok(path) => path.unwrap().clone(),
+        Err(e) => {
+            let message = format!("Failed to get data path : {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    wait_for_dm();
+
+    Ok((metadata_path, data_path))
+}
+/// Validate the blockdev_paths are unique
+/// Initialize the list for use with Stratis
+/// Create a thin-pool via ThinPoolDev
+/// Validate the resulting thin-pool dev and meta dev
+fn test_thinpool_setup(dm: &DM,
+                       thinpool_dev: &mut ThinPoolDev,
+                       metadata_dev: &mut LinearDev,
+                       data_dev: &mut LinearDev,
+                       blockdev_paths: &Vec<&Path>)
+                       -> TestResult<()> {
+
+    let uuid = Uuid::new_v4();
+
+    let unique_blockdevs = match blockdev::resolve_devices(blockdev_paths) {
+        Ok(devs) => devs,
+        Err(e) => {
+            let message = format!("Failed to resolve starting set of blockdevs:{:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    let blockdev_map = match blockdev::initialize(&uuid, unique_blockdevs, MIN_MDA_SECTORS, true) {
+        Ok(blockdev_map) => blockdev_map,
+        Err(e) => {
+            let message = format!("Failed to initialize starting set of blockdevs {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    };
+
+    let (_first_key, metadata_blockdev) = blockdev_map.iter().next().unwrap();
+    let (_last_key, data_blockdev) = blockdev_map.iter().next_back().unwrap();
+    let (_start_sector, length) = data_blockdev.avail_range();
+
+    let (metadata_path, data_path) =
+        match setup_supporting_devs(dm, metadata_dev, data_dev, metadata_blockdev, data_blockdev) {
+            Ok(tuple) => tuple,
+            Err(e) => {
+                let message = format!("Failed to setup_supporting_devs : {:?}", e);
+                return Err(Framework(Error(message)));
+            }
+        };
+
+    match thinpool_dev.setup(dm,
+                             &length,
+                             &Sectors(1024),
+                             &DataBlocks(256000),
+                             &metadata_path,
+                             &data_path) {
+        Ok(_) => info!("completed test on {:?}", thinpool_dev.name),
+        Err(e) => {
+            let message = format!("thinpool_dev.setup {:?}", e);
+            return Err(Framework(Error(message)));
+        }
+    }
+
+    wait_for_dm();
+
+    Ok(())
+}
+
+#[test]
+/// Get list of safe to destroy devices.
+/// Clean any headers from the devices.
+/// Construct meta and data devices for use in the thin-pool
+/// Test creating a thin-pool device
+/// Teardown the DM device
+pub fn test_thinpoolsetup_setup() {
+
+    let dm = DM::new().unwrap();
+
+    let mut test_config = TestConfig::new(DEFAULT_CONFIG_FILE);
+
+    let _ = test_config.init();
+
+    let safe_to_destroy_devs = match test_config.get_safe_to_destroy_devs() {
+        Ok(devs) => {
+            if devs.len() < 2 {
+                warn!("test_thinpoolsetup_setup requires at least 2 devices to run.  Test not \
+                       run.");
+                return;
+            }
+            devs
+        }
+        Err(e) => {
+            error!("Failed : get_safe_to_destroy_devs : {:?}", e);
+            return;
+        }
+    };
+
+    info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
+    let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
+
+    clean_blockdev_headers(&device_paths);
+    info!("devices cleaned for test");
+
+    let meta_name = "stratis_testing_thinpool_metadata";
+    let mut metadata_dev = LinearDev::new(meta_name);
+
+    let name = "stratis_testing_thinpool";
+    let mut thinpool_dev = ThinPoolDev::new(name);
+
+    let data_name = "stratis_testing_thinpool_datadev";
+    let mut data_dev = LinearDev::new(data_name);
+
+    match test_thinpool_setup(&dm,
+                              &mut thinpool_dev,
+                              &mut metadata_dev,
+                              &mut data_dev,
+                              &device_paths) {
+        Ok(_) => {
+            info!("completed test on {}", name);
+        }
+        Err(e) => {
+            error!("Failed : test_thinpoolsetup_setup : {:?}", e);
+        }
+    };
+
+    match thinpool_dev.teardown(&dm) {
+        Ok(_) => info!("completed teardown of {}", name),
+        Err(e) => error!("Failed to teardown {} : {:?}", name, e),
+    }
+
+    match data_dev.teardown(&dm) {
+        Ok(_) => info!("completed teardown of {}", data_name),
+        Err(_) => error!("failed teardown of {}", data_name),
+    }
+
+    match metadata_dev.teardown(&dm) {
+        Ok(_) => info!("completed teardown of {}", meta_name),
+        Err(_) => error!("failed teardown of {}", meta_name),
+    }
+}

--- a/tests/util/blockdev_utils.rs
+++ b/tests/util/blockdev_utils.rs
@@ -14,11 +14,12 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 use util::test_result::TestError;
 use util::test_result::TestErrorEnum;
 use util::test_result::TestResult;
-
 
 #[allow(dead_code)]
 pub fn get_ownership(path: &PathBuf) -> TestResult<DevOwnership> {
@@ -36,6 +37,13 @@ pub fn get_ownership(path: &PathBuf) -> TestResult<DevOwnership> {
     };
 
     Ok(ownership)
+}
+
+// The /dev/mapper/<name> device is not immediately available for use.
+// TODO: Implement wait for event or poll.
+#[allow(dead_code)]
+pub fn wait_for_dm() {
+    thread::sleep(Duration::from_millis(3000))
 }
 
 pub fn clean_blockdev_headers(blockdev_paths: &Vec<&Path>) {


### PR DESCRIPTION
Added thingpooldev to combine a metadata and data device into a DM thin-pool
Added a test to validate the creation of the thin-pool
Added --skip to the Makefile for the integration test