### PR TITLE
Call Stratis lib "stratis" instead of "libstratis"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "libstratis"
+name = "stratis"
 version = "0.1.0"
 dependencies = [
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libstratis"
+name = "stratis"
 version = "0.1.0"
 authors = ["Andy Grover <agrover@redhat.com>", "Mulhern <amulhern@redhat.com>", "Todd Gill <tgill@redhat.com>"]
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #[macro_use]
-extern crate libstratis;
+extern crate stratis;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
@@ -40,11 +40,11 @@ use clap::{App, Arg};
 use log::LogLevelFilter;
 use env_logger::LogBuilder;
 
-use libstratis::engine::Engine;
-use libstratis::engine::sim_engine::SimEngine;
-use libstratis::engine::strat_engine::StratEngine;
-use libstratis::stratis::VERSION;
-use libstratis::types::{StratisResult, StratisError};
+use stratis::engine::Engine;
+use stratis::engine::sim_engine::SimEngine;
+use stratis::engine::strat_engine::StratEngine;
+use stratis::stratis::VERSION;
+use stratis::types::{StratisResult, StratisError};
 
 fn write_err(err: StratisError) -> StratisResult<()> {
     let mut out = term::stderr().expect("could not get stderr");
@@ -71,7 +71,7 @@ fn main() {
     let mut builder = LogBuilder::new();
     if matches.is_present("debug") {
         builder.filter(Some("stratisd"), LogLevelFilter::Debug);
-        builder.filter(Some("libstratis"), LogLevelFilter::Debug);
+        builder.filter(Some("stratis"), LogLevelFilter::Debug);
     } else {
         if let Ok(s) = env::var("RUST_LOG") {
             builder.parse(&s);
@@ -89,7 +89,7 @@ fn main() {
         }
     };
 
-    let r = libstratis::dbus_api::run(engine);
+    let r = stratis::dbus_api::run(engine);
 
     if let Err(r) = r {
         if let Err(e) = write_err(r) {

--- a/tests/blockdev_tests.rs
+++ b/tests/blockdev_tests.rs
@@ -5,12 +5,12 @@
 extern crate log;
 extern crate uuid;
 extern crate devicemapper;
-extern crate libstratis;
+extern crate stratis;
 #[macro_use]
 mod util;
 
-use libstratis::engine::strat_engine::blockdev;
-use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
+use stratis::engine::strat_engine::blockdev;
+use stratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
 
 use std::path::Path;
 

--- a/tests/lineardev_tests.rs
+++ b/tests/lineardev_tests.rs
@@ -5,17 +5,17 @@
 extern crate log;
 extern crate uuid;
 extern crate devicemapper;
-extern crate libstratis;
+extern crate stratis;
 #[macro_use]
 mod util;
 
 use devicemapper::DM;
 
-use libstratis::engine::strat_engine::blockdev;
-use libstratis::engine::strat_engine::blockdev::BlockDev;
-use libstratis::engine::strat_engine::lineardev::LinearDev;
-use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
-use libstratis::types::Sectors;
+use stratis::engine::strat_engine::blockdev;
+use stratis::engine::strat_engine::blockdev::BlockDev;
+use stratis::engine::strat_engine::lineardev::LinearDev;
+use stratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
+use stratis::types::Sectors;
 
 use std::iter::FromIterator;
 use std::path::Path;

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -1,16 +1,16 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-extern crate libstratis;
+extern crate stratis;
 extern crate devicemapper;
 #[macro_use]
 extern crate log;
 #[macro_use]
 mod util;
 
-use libstratis::engine::Engine;
-use libstratis::engine::strat_engine::StratEngine;
-use libstratis::engine::strat_engine::engine::DevOwnership;
+use stratis::engine::Engine;
+use stratis::engine::strat_engine::StratEngine;
+use stratis::engine::strat_engine::engine::DevOwnership;
 
 use std::path::Path;
 use std::path::PathBuf;

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -5,21 +5,21 @@
 extern crate log;
 extern crate uuid;
 extern crate devicemapper;
-extern crate libstratis;
+extern crate stratis;
 extern crate rand;
 #[macro_use]
 mod util;
 
 use devicemapper::DM;
 
-use libstratis::engine::strat_engine::blockdev;
-use libstratis::engine::strat_engine::blockdev::BlockDev;
-use libstratis::engine::strat_engine::lineardev::LinearDev;
-use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
-use libstratis::engine::strat_engine::thindev::ThinDev;
-use libstratis::engine::strat_engine::thinpooldev::ThinPoolDev;
-use libstratis::types::DataBlocks;
-use libstratis::types::Sectors;
+use stratis::engine::strat_engine::blockdev;
+use stratis::engine::strat_engine::blockdev::BlockDev;
+use stratis::engine::strat_engine::lineardev::LinearDev;
+use stratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
+use stratis::engine::strat_engine::thindev::ThinDev;
+use stratis::engine::strat_engine::thinpooldev::ThinPoolDev;
+use stratis::types::DataBlocks;
+use stratis::types::Sectors;
 
 use std::path::{Path, PathBuf};
 

--- a/tests/util/blockdev_utils.rs
+++ b/tests/util/blockdev_utils.rs
@@ -3,11 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-use libstratis::consts::SECTOR_SIZE;
-use libstratis::engine::strat_engine::blockdev::blkdev_size;
-use libstratis::engine::strat_engine::engine::DevOwnership;
-use libstratis::engine::strat_engine::metadata::StaticHeader;
-use libstratis::types::Sectors;
+use stratis::consts::SECTOR_SIZE;
+use stratis::engine::strat_engine::blockdev::blkdev_size;
+use stratis::engine::strat_engine::engine::DevOwnership;
+use stratis::engine::strat_engine::metadata::StaticHeader;
+use stratis::types::Sectors;
 
 use std::fs::File;
 use std::fs::OpenOptions;

--- a/tests/util/test_result.rs
+++ b/tests/util/test_result.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 extern crate rustc_serialize;
-extern crate libstratis;
+extern crate stratis;
 
-use libstratis::engine::EngineError;
+use stratis::engine::EngineError;
 use self::rustc_serialize::json::ParserError;
 use std::fmt;
 use std::io::Error;


### PR DESCRIPTION
I think this is more in line with Rust naming conventions -- the names of
other crates we use don't start with "lib". Or, it might have the potential
to cause confusion.

Signed-off-by: Andy Grover <agrover@redhat.com>