### PR TITLE
Pull event loop out of DBus and check pool status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "devicemapper 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "loopdev 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_derive = "0"
 serde_json = "0"
 log = "0.3"
 env_logger="0.3.5"
+libc = "0.2"
 
 [dependencies.uuid]
 version = "0.3.1"

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -6,6 +6,8 @@ use std::borrow::Cow;
 use std::fmt::Display;
 use std::path::Path;
 use std::vec::Vec;
+use std::rc::Rc;
+use std::cell::RefCell;
 
 use dbus;
 use dbus::Connection;
@@ -244,7 +246,7 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> Tree<MTFn<TData>, TData> {
     base_tree.add(obj_path)
 }
 
-pub fn connect(engine: Box<Engine>)
+pub fn connect(engine: Rc<RefCell<Engine>>)
                -> StratisResult<(Connection, Tree<MTFn<TData>, TData>, DbusContext)> {
     let c = try!(Connection::get_private(BusType::System));
 

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -11,4 +11,4 @@ mod pool;
 mod types;
 mod util;
 
-pub use self::api::run;
+pub use self::api::{connect, handle};

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -99,15 +99,15 @@ impl OPContext {
 #[derive(Debug, Clone)]
 pub struct DbusContext {
     pub next_index: Rc<Cell<u64>>,
-    pub engine: Rc<RefCell<Box<Engine>>>,
+    pub engine: Rc<RefCell<Engine>>,
     pub actions: Rc<RefCell<ActionQueue>>,
 }
 
 impl DbusContext {
-    pub fn new(engine: Box<Engine>) -> DbusContext {
+    pub fn new(engine: Rc<RefCell<Engine>>) -> DbusContext {
         DbusContext {
             actions: Rc::new(RefCell::new(ActionQueue::new())),
-            engine: Rc::new(RefCell::new(engine)),
+            engine: engine,
             next_index: Rc::new(Cell::new(0)),
         }
     }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -129,4 +129,7 @@ pub trait Engine: Debug {
     /// Configure the simulator, for the real engine, this is a null op.
     /// denominator: the probably of failure is 1/denominator.
     fn configure_simulator(&mut self, denominator: u32) -> EngineResult<()>;
+
+    /// Check pools' current state and take appropriate actions
+    fn check(&mut self) -> ();
 }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -88,6 +88,12 @@ impl Engine for SimEngine {
         self.rdm.borrow_mut().set_probability(denominator);
         Ok(())
     }
+
+    fn check(&mut self) -> () {
+        for pool in self.pools.iter_mut() {
+            pool.check();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -59,6 +59,8 @@ impl SimPool {
 
         new_pool
     }
+
+    pub fn check(&mut self) -> () {}
 }
 
 impl Pool for SimPool {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -78,4 +78,10 @@ impl Engine for StratEngine {
     fn get_pool(&mut self, uuid: &PoolUuid) -> Option<&mut Pool> {
         get_pool!(self; uuid)
     }
+
+    fn check(&mut self) -> () {
+        for pool in self.pools.iter_mut() {
+            pool.check();
+        }
+    }
 }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -184,6 +184,12 @@ impl StratPool {
                 .collect(),
         }
     }
+
+    pub fn check(&mut self) -> () {
+        // TODO: Get status from applicable DM targets
+        // TODO: Get fullness of MDV, thin meta&data devs, and extend if needed,
+        //       or handle NOSPC
+    }
 }
 
 impl Pool for StratPool {


### PR DESCRIPTION
stratisd will not be entirely driven by DBus requests -- it may need to
respond to periodic timers, DM events, or udev events, for example. This
patch hoists the event loop out of the dbus::run function and back into
main() where we call poll() ourselves. It doesn't actually add support for
polling on other fds besides DBus fds yet.

For now, based on dbus-rs Watch example code, which works but requires
`unsafe`.

Divide dbus_api::run() into connect() and handle() functions.

Signed-off-by: Andy Grover <agrover@redhat.com>