### PR TITLE
Change version from 0.1.0 to 0.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libstratis"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Andy Grover <agrover@redhat.com>", "Mulhern <amulhern@redhat.com>", "Todd Gill <tgill@redhat.com>"]
 
 [dependencies]


### PR DESCRIPTION
New projects in Cargo default to version 0.1, but our design doc uses 0.1
as a milestone, and we haven't achieved that milestone yet. Change version
so we can start using this version field and have them line up with the
design doc.

Signed-off-by: Andy Grover <agrover@redhat.com>