### PR TITLE
Filesystem Create/Mount/Umount for thin devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "serde 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -323,6 +324,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "term"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e095e4e94e7382b76f48e93bd845ffddda62df8dfd4c163b1bfa93d40e22e13a"
 "checksum strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5f575d5ced6634a5c4cb842163dab907dc7e9148b28dc482d81b8855cbe985"
 "checksum syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f94368aae82bb29656c98443a7026ca931a659e8d19dcdc41d6e273054e820"
+"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ features = ["v4"]
 [dev-dependencies]
 quickcheck = "0.4"
 rustc-serialize = "0.3.21"
+tempdir = "0.3.5"
 

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -13,22 +13,32 @@ use types::Sectors;
 
 pub struct LinearDev {
     name: String,
-    dev_info: Option<DeviceInfo>,
+    dev_info: DeviceInfo,
 }
 
-/// support use of DM to concatenate blockdevs and creat e a
-/// /dev/mapper/<name> for use as continuous sectors.
+/// Use DM to concatenate a set of blockdevs together into a
+/// /dev/mapper/xxx block device of continuous sectors.
 impl LinearDev {
-    pub fn new(name: &str) -> LinearDev {
-        LinearDev {
+    /// Construct a new block device by concatenating the given block_devs
+    /// into linear space.  Use DM to reserve enough space for the stratis
+    /// metadata on each BlockDev.
+    pub fn new(name: &str, dm: &DM, block_devs: &Vec<&BlockDev>) -> EngineResult<LinearDev> {
+
+        try!(dm.device_create(&name, None, DmFlags::empty()));
+        let table = LinearDev::dm_table(block_devs);
+        let id = &DevId::Name(&name);
+        let dev_info = try!(dm.table_load(id, &table));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        Ok(LinearDev {
             name: name.to_owned(),
-            dev_info: None,
-        }
+            dev_info: dev_info,
+        })
     }
 
     /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
     /// <logical start sec> <length> "linear" /dev/xxx <start offset>
-    fn dm_table(&self, block_devs: &Vec<&BlockDev>) -> Vec<(u64, u64, String, String)> {
+    fn dm_table(block_devs: &Vec<&BlockDev>) -> Vec<(u64, u64, String, String)> {
         let mut table = Vec::new();
         let mut logical_start_sector = Sectors(0);
         for block_dev in block_devs {
@@ -46,31 +56,17 @@ impl LinearDev {
         table
     }
 
-    /// Use DM to concatenate a set of blockdevs together into a
-    /// /dev/mapper/xxx block device of continuous sectors.
-    pub fn concat(&mut self, dm: &DM, block_devs: &Vec<&BlockDev>) -> EngineResult<()> {
-
-        try!(dm.device_create(&self.name, None, DmFlags::empty()));
-        let table = self.dm_table(block_devs);
-        let id = &DevId::Name(&self.name);
-        self.dev_info = Some(try!(dm.table_load(id, &table)));
-
-        try!(dm.device_suspend(id, DmFlags::empty()));
-
-        return Ok(());
+    pub fn name(&self) -> &str {
+        self.dev_info.name().clone()
     }
 
-    pub fn name(&self) -> EngineResult<&str> {
-        match self.dev_info {
-            Some(ref di) => return Ok(di.name().clone()),
-            None => return Err(EngineError::Engine(ErrorEnum::Invalid, "No dev_info".into())),
-        }
-    }
-
-    pub fn path(&self) -> EngineResult<Option<PathBuf>> {
-        match self.dev_info {
-            Some(ref di) => return Ok(di.device().path().clone()),
-            None => return Err(EngineError::Engine(ErrorEnum::Invalid, "No dev_info".into())),
+    pub fn path(&self) -> EngineResult<PathBuf> {
+        match self.dev_info.device().path() {
+            Some(path) => return Ok(path),
+            None => {
+                return Err(EngineError::Engine(ErrorEnum::Invalid,
+                                               "No path associated with dev_info".into()))
+            }
         }
     }
 

--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -4,18 +4,19 @@
 
 
 use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
-use engine::EngineResult;
+use engine::{EngineError, EngineResult, ErrorEnum};
 use engine::strat_engine::thinpooldev::ThinPoolDev;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
 use types::Sectors;
 
 #[derive(Clone)]
 pub struct ThinDev {
     name: String,
-    pub dev_info: Option<DeviceInfo>,
+    pub dev_info: DeviceInfo,
     pub thin_id: u32,
-    pub size: Option<Sectors>,
-    dm_name: Option<String>,
-    params: Option<String>,
+    pub size: Sectors,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -24,23 +25,36 @@ pub enum ThinStatus {
     Fail,
 }
 
-/// support use of DM to thin provisioned devices over pools
+/// support use of DM for thin provisioned devices over pools
 impl ThinDev {
-    pub fn new(name: &str) -> ThinDev {
-        ThinDev {
+    /// Use the given ThinPoolDev as backing space for a newly constructed
+    /// thin provisioned ThinDev returned by new().
+    pub fn new(name: &str,
+               dm: &DM,
+               thin_pool: &mut ThinPoolDev,
+               thin_id: u32,
+               length: Sectors)
+               -> EngineResult<ThinDev> {
+
+        let thin_dev_path = format!("{}", try!(thin_pool.path()).to_string_lossy());
+        try!(thin_pool.message(dm, &format!("create_thin {}", thin_id)));
+        try!(dm.device_create(name, None, DmFlags::empty()));
+        let table = ThinDev::dm_table(&thin_dev_path, thin_id, &length);
+        let id = &DevId::Name(name);
+        let di = try!(dm.table_load(id, &table));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        Ok(ThinDev {
             name: name.to_owned(),
-            dev_info: None,
-            thin_id: 0,
-            size: None,
-            dm_name: None,
-            params: None,
-        }
+            dev_info: di,
+            thin_id: thin_id,
+            size: length,
+        })
     }
 
     /// Generate a Vec<> to be passed to DM.  The format of the Vec entries are:
     /// "<start> <length> thin </dev/mapper/poolname> <thin_id>"
-    fn dm_table(&self,
-                pool_dev_str: &String,
+    fn dm_table(pool_dev_str: &String,
                 thin_id: u32,
                 length: &Sectors)
                 -> Vec<(u64, u64, String, String)> {
@@ -54,27 +68,75 @@ impl ThinDev {
 
     }
 
-    /// Use DM to create a thin provisioned DM device.
-    pub fn setup(&mut self,
-                 dm: &DM,
-                 thin_pool: &mut ThinPoolDev,
-                 thin_id: u32,
-                 length: &Sectors)
-                 -> EngineResult<()> {
-
-        try!(thin_pool.message(dm, &format!("create_thin {}", thin_id)));
-        try!(dm.device_create(&self.name, None, DmFlags::empty()));
-        let table = self.dm_table(&thin_pool.dev_info.unwrap().device().dstr(),
-                                  thin_id,
-                                  length);
-        let id = &DevId::Name(&self.name);
-        self.dev_info = Some(try!(dm.table_load(id, &table)));
-        try!(dm.device_suspend(id, DmFlags::empty()));
+    pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
+        try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
         Ok(())
     }
 
-    pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
-        try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
+    pub fn path(&self) -> EngineResult<PathBuf> {
+        match self.dev_info.device().path() {
+            Some(path) => return Ok(path),
+            None => {
+                return Err(EngineError::Engine(ErrorEnum::Invalid,
+                                               "No path associated with dev_info".into()))
+            }
+        }
+    }
+
+    pub fn create_fs(&mut self) -> EngineResult<()> {
+        let path_result = try!(self.path());
+        let dev_path = Path::new(&path_result);
+
+        debug!("Create filesystem for : {:?}", dev_path);
+        let output = try!(Command::new("mkfs.xfs")
+            .arg("-f")
+            .arg(dev_path)
+            .output());
+
+        if output.status.success() {
+            debug!("Created xfs filesystem on {:?}", dev_path)
+        } else {
+            let message = String::from_utf8_lossy(&output.stderr);
+            debug!("stderr: {}", message);
+            return Err(EngineError::Engine(ErrorEnum::Error, message.into()));
+        }
+        Ok(())
+    }
+
+    pub fn mount_fs(&mut self, mount_point: &Path) -> EngineResult<()> {
+        let path_result = try!(self.path());
+        let dev_path = Path::new(&path_result);
+
+        debug!("Mount filesystem {:?} on : {:?}", dev_path, mount_point);
+        let output = try!(Command::new("mount")
+            .arg(dev_path)
+            .arg(mount_point)
+            .output());
+
+        if output.status.success() {
+            debug!("Mounted xfs filesystem on {:?}", mount_point)
+        } else {
+            let message = String::from_utf8_lossy(&output.stderr);
+            debug!("stderr: {}", message);
+            return Err(EngineError::Engine(ErrorEnum::Error, message.into()));
+        }
+        Ok(())
+    }
+
+    pub fn unmount_fs(&mut self, mount_point: &Path) -> EngineResult<()> {
+        debug!("Unount filesystem {:?}", mount_point);
+
+        let output = try!(Command::new("umount")
+            .arg(mount_point)
+            .output());
+
+        if output.status.success() {
+            debug!("Unmounted filesystem {:?}", mount_point)
+        } else {
+            let message = String::from_utf8_lossy(&output.stderr);
+            debug!("stderr: {}", message);
+            return Err(EngineError::Engine(ErrorEnum::Error, message.into()));
+        }
         Ok(())
     }
 }

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -3,40 +3,62 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
-use engine::EngineResult;
+use engine::{EngineError, EngineResult, ErrorEnum};
+use engine::strat_engine::lineardev::LinearDev;
 
 use std::path::Path;
-
-use super::blockdev::BlockDev;
+use std::path::PathBuf;
 
 use types::DataBlocks;
 use types::Sectors;
 
 pub struct ThinPoolDev {
-    pub name: String,
-    pub dev_info: Option<DeviceInfo>,
-    data_block_size: Option<Sectors>,
-    pub low_water_mark: Option<DataBlocks>,
-    pub meta_dev: Option<BlockDev>,
-    pub data_dev: Option<BlockDev>,
+    name: String,
+    dev_info: DeviceInfo,
+    meta_dev: LinearDev,
+    data_dev: LinearDev,
 }
 
-/// support use of DM to create pools for thin provisioned devices
+/// Use DM to create a "thin-pool".  A "thin-pool" is shared space for
+/// other thin provisioned devices to use.
+///
+/// See section "Setting up a fresh pool device":
+/// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
 impl ThinPoolDev {
-    pub fn new(name: &str) -> ThinPoolDev {
-        ThinPoolDev {
+    /// Construct a new ThinPoolDev with the given data and meta devs.  The
+    /// ThinPoolDev is used as backing for by ThinDev.
+    pub fn new(name: &str,
+               dm: &DM,
+               length: Sectors,
+               data_block_size: Sectors,
+               low_water_mark: DataBlocks,
+               meta: LinearDev,
+               data: LinearDev)
+               -> EngineResult<ThinPoolDev> {
+        try!(dm.device_create(&name, None, DmFlags::empty()));
+
+        let meta_dev_path = try!(meta.path());
+        let data_dev_path = try!(data.path());
+        let table = ThinPoolDev::dm_table(length,
+                                          data_block_size,
+                                          low_water_mark,
+                                          &meta_dev_path,
+                                          &data_dev_path);
+        let id = &DevId::Name(&name);
+        let di = try!(dm.table_load(id, &table));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        Ok(ThinPoolDev {
             name: name.to_owned(),
-            dev_info: None,
-            data_block_size: None,
-            low_water_mark: None,
-            meta_dev: None,
-            data_dev: None,
-        }
+            dev_info: di,
+            meta_dev: meta,
+            data_dev: data,
+        })
     }
+
     /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
     /// <start sec> <length> "thin-pool" /dev/meta /dev/data <block size> <low water mark>
-    fn dm_table(&self,
-                length: Sectors,
+    fn dm_table(length: Sectors,
                 data_block_size: Sectors,
                 low_water_mark: DataBlocks,
                 meta_dev: &Path,
@@ -53,42 +75,30 @@ impl ThinPoolDev {
         table
     }
 
-    /// Use DM to create a "thin-pool".  A "thin-pool" is shared space for
-    /// other thin provisioned devices to use.
-    ///
-    /// See section "Setting up a fresh pool device":
-    /// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
-    pub fn setup(&mut self,
-                 dm: &DM,
-                 length: Sectors,
-                 data_block_size: Sectors,
-                 low_water_mark: DataBlocks,
-                 meta_dev: &Path,
-                 data_dev: &Path)
-                 -> EngineResult<()> {
-
-        debug!("setup : {}", self.name);
-        try!(dm.device_create(&self.name, None, DmFlags::empty()));
-
-        let table = self.dm_table(length, data_block_size, low_water_mark, meta_dev, data_dev);
-        self.data_block_size = Some(data_block_size);
-        self.low_water_mark = Some(low_water_mark);
-        let id = &DevId::Name(&self.name);
-        self.dev_info = Some(try!(dm.table_load(id, &table)));
-        try!(dm.device_suspend(id, DmFlags::empty()));
-
-        Ok(())
-    }
-
     pub fn message(&self, dm: &DM, message: &str) -> EngineResult<()> {
         try!(dm.target_msg(&DevId::Name(&self.name), 0, message));
 
         Ok(())
     }
 
+    pub fn name(&self) -> &str {
+        self.dev_info.name().clone()
+    }
+
+    pub fn path(&self) -> EngineResult<PathBuf> {
+        match self.dev_info.device().path() {
+            Some(path) => return Ok(path),
+            None => {
+                return Err(EngineError::Engine(ErrorEnum::Invalid,
+                                               "No path associated with dev_info".into()))
+            }
+        }
+    }
+
     pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
-
+        try!(self.data_dev.teardown(dm));
+        try!(self.meta_dev.teardown(dm));
         Ok(())
     }
 }

--- a/tests/blockdev_tests.rs
+++ b/tests/blockdev_tests.rs
@@ -87,7 +87,7 @@ pub fn test_blockdev_setup() {
 
     let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
-    clean_blockdev_headers(&device_paths);
+    assert_ok!(clean_blockdev_headers(&device_paths));
 
     assert!(match test_blockdev_force_flag(&device_paths) {
         Ok(_) => true,
@@ -96,5 +96,4 @@ pub fn test_blockdev_setup() {
             false
         }
     });
-
 }

--- a/tests/lineardev_tests.rs
+++ b/tests/lineardev_tests.rs
@@ -156,7 +156,6 @@ pub fn test_lineardev_setup() {
     info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
     let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
-    clean_blockdev_headers(&device_paths);
     assert_ok!(clean_blockdev_headers(&device_paths));
 
     info!("devices cleaned for test");

--- a/tests/lineardev_tests.rs
+++ b/tests/lineardev_tests.rs
@@ -35,20 +35,12 @@ use uuid::Uuid;
 /// Return a LinearDev with concatenated BlockDevs
 fn concat_blockdevs(dm: &DM, name: &str, block_devs: &Vec<&BlockDev>) -> TestResult<LinearDev> {
 
-    let mut linear_dev = LinearDev::new(name);
-
-    match linear_dev.concat(dm, block_devs) {
-        Ok(_) => return Ok(linear_dev),
+    match LinearDev::new(name, dm, block_devs) {
+        Ok(ld) => return Ok(ld),
         Err(e) => {
-            // tear down a partially created DM device if it exists
-            match linear_dev.teardown(&dm) {
-                Ok(_) => info!("completed teardown of {}", name),
-                Err(_) => info!("failed teardown of {}", name),
-            }
             let message = format!("linear_dev.concat failed : {:?}", e);
             return Err(Framework(Error(message)));
         }
-
     }
 }
 
@@ -75,7 +67,10 @@ fn validate_sizes(name: &str, block_devs: &Vec<&BlockDev>) -> TestResult<()> {
 
     let dm_dev_size = match get_size(path) {
         Ok(s) => s,
-        Err(_) => panic!("Failed to get size for {} ", name),
+        Err(e) => {
+            error!("Failed to get size for {} ", name);
+            return Err(e);
+        }
     };
     debug!("size of dm device {:?} = {}", path, dm_dev_size);
 
@@ -123,7 +118,8 @@ fn test_lineardev_concat(dm: &DM, blockdev_paths: &Vec<&Path>) -> TestResult<(Li
     match validate_sizes(&name, &blockdev_vec) {
         Ok(_) => info!("validate_sizes Ok"),
         Err(e) => {
-            panic!("Failed : validate_sizes() : {:?}", e);
+            error!("Failed : validate_sizes() : {:?}", e);
+            return Err(e);
         }
     }
 
@@ -161,20 +157,17 @@ pub fn test_lineardev_setup() {
     let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
     clean_blockdev_headers(&device_paths);
+    assert_ok!(clean_blockdev_headers(&device_paths));
+
     info!("devices cleaned for test");
 
     assert!(match test_lineardev_concat(&dm, &device_paths) {
         Ok(linear_dev) => {
-            info!("Linear dev name : {:?}", linear_dev.name());
-            let name = match linear_dev.name() {
-                Ok(n) => n,
-                Err(e) => panic!("Failed to get lineardev name {:?} ", e),
-            };
-            info!("completed test on {}", name);
+            info!("completed test on {}", linear_dev.name());
 
             match linear_dev.teardown(&dm) {
-                Ok(_) => info!("completed teardown of {}", name),
-                Err(e) => panic!("Failed to teardown {} : {:?}", name, e),
+                Ok(_) => info!("completed teardown of {}", linear_dev.name()),
+                Err(e) => error!("Failed to teardown {} : {:?}", linear_dev.name(), e),
             }
             true
         }

--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -121,7 +121,7 @@ pub fn test_pools() {
 
     let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
-    clean_blockdev_headers(&device_paths);
+    assert_ok!(clean_blockdev_headers(&device_paths));
 
     assert!(test_create_and_delete(&device_paths).is_ok());
 }

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -145,6 +145,7 @@ pub fn test_thinpoolsetup_setup() {
     info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
     let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
+    assert_ok!(clean_blockdev_headers(&device_paths));
     info!("devices cleaned for test");
 
     let mut thinpool_dev = assert_ok!(test_thinpool_setup(&dm, &device_paths));

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -7,6 +7,7 @@ extern crate uuid;
 extern crate devicemapper;
 extern crate libstratis;
 extern crate rand;
+extern crate tempdir;
 #[macro_use]
 mod util;
 
@@ -21,45 +22,47 @@ use libstratis::engine::strat_engine::thinpooldev::ThinPoolDev;
 use libstratis::types::DataBlocks;
 use libstratis::types::Sectors;
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+use tempdir::TempDir;
 
 use util::blockdev_utils::clean_blockdev_headers;
 use util::blockdev_utils::wait_for_dm;
+use util::blockdev_utils::wipe_header;
+use util::blockdev_utils::write_files_to_directory;
 use util::test_config::TestConfig;
 use util::test_consts::DEFAULT_CONFIG_FILE;
+use util::test_result::TestResult;
 
 use uuid::Uuid;
 
 fn setup_supporting_devs(dm: &DM,
-                         metadata_dev: &mut LinearDev,
-                         data_dev: &mut LinearDev,
                          metadata_blockdev: &BlockDev,
                          data_blockdev: &BlockDev)
-                         -> (PathBuf, PathBuf) {
+                         -> TestResult<(LinearDev, LinearDev)> {
 
     let meta_blockdevs = vec![metadata_blockdev];
-    metadata_dev.concat(dm, &meta_blockdevs).unwrap();
+    let metadata_dev =
+        try!(LinearDev::new("stratis_testing_thinpool_metadata", dm, &meta_blockdevs));
 
     let data_blockdevs = vec![data_blockdev];
-    data_dev.concat(dm, &data_blockdevs).unwrap();
-
-    let metadata_path = metadata_dev.path().unwrap().unwrap();
-
-    let data_path = data_dev.path().unwrap().unwrap();
+    let data_dev = try!(LinearDev::new("stratis_testing_thinpool_datadev", dm, &data_blockdevs));
 
     wait_for_dm();
 
-    (metadata_path, data_path)
+    let metadata_path = try!(metadata_dev.path());
+    let data_path = try!(data_dev.path());
+    try!(wipe_header(Path::new(&metadata_path)));
+    try!(wipe_header(Path::new(&data_path)));
+
+    Ok((metadata_dev, data_dev))
 }
+
 /// Validate the blockdev_paths are unique
 /// Initialize the list for use with Stratis
 /// Create a thin-pool via ThinPoolDev
 /// Validate the resulting thin-pool dev and meta dev
-fn test_thinpool_setup(dm: &DM,
-                       thinpool_dev: &mut ThinPoolDev,
-                       metadata_dev: &mut LinearDev,
-                       data_dev: &mut LinearDev,
-                       blockdev_paths: &Vec<&Path>) {
+fn test_thinpool_setup(dm: &DM, blockdev_paths: &Vec<&Path>) -> TestResult<ThinPoolDev> {
 
     let uuid = Uuid::new_v4();
 
@@ -72,18 +75,42 @@ fn test_thinpool_setup(dm: &DM,
     let (_last_key, data_blockdev) = blockdev_map.iter().next_back().unwrap();
     let (_start_sector, length) = data_blockdev.avail_range();
 
-    let (metadata_path, data_path) =
-        setup_supporting_devs(dm, metadata_dev, data_dev, metadata_blockdev, data_blockdev);
+    let (metadata_dev, data_dev) =
+        try!(setup_supporting_devs(dm, metadata_blockdev, data_blockdev));
 
-    thinpool_dev.setup(dm,
-               length,
-               Sectors(1024),
-               DataBlocks(256000),
-               &metadata_path,
-               &data_path)
-        .unwrap();
+    let mut thinpool_dev = try!(ThinPoolDev::new("stratis_testing_thinpool",
+                                                 dm,
+                                                 length,
+                                                 Sectors(1024),
+                                                 DataBlocks(256000),
+                                                 metadata_dev,
+                                                 data_dev));
 
     wait_for_dm();
+
+    try!(test_thindev_setup(&dm, &mut thinpool_dev));
+
+    Ok(thinpool_dev)
+}
+
+fn test_thindev_setup(dm: &DM, thinpool_dev: &mut ThinPoolDev) -> TestResult<()> {
+    let thin_id = rand::random::<u16>();
+    let mut thin_dev = try!(ThinDev::new("stratis_testing_thindev",
+                                         &dm,
+                                         thinpool_dev,
+                                         thin_id as u32,
+                                         Sectors(300000)));
+    wait_for_dm();
+
+    let tmp_dir = try!(TempDir::new("stratis_testing"));
+
+    try!(thin_dev.create_fs());
+    try!(thin_dev.mount_fs(tmp_dir.path()));
+    try!(write_files_to_directory(&tmp_dir, 100));
+
+    try!(thin_dev.unmount_fs(tmp_dir.path()));
+    try!(thin_dev.teardown(dm));
+    Ok(())
 }
 
 #[test]
@@ -98,7 +125,6 @@ pub fn test_thinpoolsetup_setup() {
     let dm = DM::new().unwrap();
 
     let mut test_config = TestConfig::new(DEFAULT_CONFIG_FILE);
-
     let _ = test_config.init();
 
     let safe_to_destroy_devs = match test_config.get_safe_to_destroy_devs() {
@@ -119,34 +145,9 @@ pub fn test_thinpoolsetup_setup() {
     info!("safe_to_destroy_devs = {:?}", safe_to_destroy_devs);
     let device_paths = safe_to_destroy_devs.iter().map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
-    clean_blockdev_headers(&device_paths);
     info!("devices cleaned for test");
 
-    let meta_name = "stratis_testing_thinpool_metadata";
-    let mut metadata_dev = LinearDev::new(meta_name);
-
-    let name = "stratis_testing_thinpool";
-    let mut thinpool_dev = ThinPoolDev::new(name);
-
-    let data_name = "stratis_testing_thinpool_datadev";
-    let mut data_dev = LinearDev::new(data_name);
-
-    test_thinpool_setup(&dm,
-                        &mut thinpool_dev,
-                        &mut metadata_dev,
-                        &mut data_dev,
-                        &device_paths);
-
-    let thindev_name = "stratis_testing_thindev";
-    let mut thin_dev = ThinDev::new(thindev_name);
-    let thin_id = rand::random::<u16>();
-    thin_dev.setup(&dm, &mut thinpool_dev, thin_id as u32, &Sectors(300000)).unwrap();
-
-    thin_dev.teardown(&dm).unwrap();
+    let mut thinpool_dev = assert_ok!(test_thinpool_setup(&dm, &device_paths));
 
     thinpool_dev.teardown(&dm).unwrap();
-
-    data_dev.teardown(&dm).unwrap();
-
-    metadata_dev.teardown(&dm).unwrap();
 }

--- a/tests/util/blockdev_utils.rs
+++ b/tests/util/blockdev_utils.rs
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+extern crate tempdir;
 
 use libstratis::consts::SECTOR_SIZE;
 use libstratis::engine::strat_engine::blockdev::blkdev_size;
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
+use util::blockdev_utils::tempdir::TempDir;
 use util::test_result::TestError;
 use util::test_result::TestErrorEnum;
 use util::test_result::TestResult;
@@ -43,20 +44,22 @@ pub fn get_ownership(path: &PathBuf) -> TestResult<DevOwnership> {
 // TODO: Implement wait for event or poll.
 #[allow(dead_code)]
 pub fn wait_for_dm() {
-    thread::sleep(Duration::from_millis(3000))
+    thread::sleep(Duration::from_millis(2500))
 }
 
-pub fn clean_blockdev_headers(blockdev_paths: &Vec<&Path>) {
+pub fn clean_blockdev_headers(blockdev_paths: &Vec<&Path>) -> TestResult<()> {
 
     for path in blockdev_paths {
         match wipe_header(path) {
             Ok(_) => {}
             Err(e) => {
-                panic!("Failed to clean signature on {:?} : {:?}", path, e);
+                error!("Failed to clean signature on {:?} : {:?}", path, e);
+                return Err(e);
             }
         }
     }
     info!("devices cleaned for test");
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -75,11 +78,24 @@ pub fn get_size(path: &Path) -> TestResult<Sectors> {
     };
 }
 
-fn wipe_header(path: &Path) -> TestResult<()> {
+pub fn wipe_header(path: &Path) -> TestResult<()> {
     let mut f = try!(OpenOptions::new().write(true).open(path));
     let zeroed = [0u8; SECTOR_SIZE * 16];
 
     try!(f.write_all(&zeroed[..SECTOR_SIZE * 16]));
 
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub fn write_files_to_directory(tmp_dir: &TempDir, number_of_files: u32) -> TestResult<()> {
+    for i in 0..number_of_files {
+        {
+            let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));
+            let mut tmp_file = File::create(file_path)
+                .expect("failed to create temp file on filesystem");
+            writeln!(tmp_file, "Write some data to file.").expect("failed to write temp file");
+        }
+    }
     Ok(())
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -6,4 +6,5 @@ pub mod test_consts;
 #[macro_use]
 pub mod test_config;
 #[macro_use]
+pub mod test_utils;
 pub mod blockdev_utils;

--- a/tests/util/test_utils.rs
+++ b/tests/util/test_utils.rs
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+macro_rules! assert_ok {
+    ($e:expr) => (match $e {
+        Ok(val) => val,
+        Err(err) => {
+            error!("FAILED : {:?}", err);
+            assert!(false);
+            return;
+        }
+    });
+}
+
+macro_rules! try_log_error {
+    ($e:expr) => (match $e {
+        Ok(val) => info!("{:?}", val),
+        Err(err) =>
+            error!("FAILED : {:?}", err),
+    });
+}


### PR DESCRIPTION
Add Create/Mount/Umount for XFS on thindev
Added to the existing thinpool test:
    Creates a FS
    Mounts FS on temp dir
    Creates a directory on the FS and writes 100 files with small amount of content
    Unmounts 
    Tears down the DM framework
Minor test framework clean up
