### PR TITLE
No longer pin to lower rustfmt version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 check: fmt build test docs
 
 ${HOME}/.cargo/bin/cargo-fmt:
-	cargo install rustfmt --vers 0.6.3
+	cargo install rustfmt
 
 fmt: ${HOME}/.cargo/bin/cargo-fmt
 	PATH=${HOME}/.cargo/bin:${PATH} cargo fmt -- --write-mode=diff


### PR DESCRIPTION
The bug that we were triggering was fixed in the newest version.

https://github.com/rust-lang-nursery/rustfmt/issues/1280

Signed-off-by: mulhern <amulhern@redhat.com>