### PR TITLE
Connect API to thin devs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 test:
 	cargo test -- --skip test_pools --skip test_blockdev_setup \
-		--skip test_lineardev_setup --skip test_thinpoolsetup_setup
+		--skip test_lineardev_setup --skip test_thinpool
 
 docs:
 	cargo doc --no-deps

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -44,6 +44,7 @@ pub fn engine_to_dbus_err(err: &EngineError) -> (DbusErrorEnum, String) {
                 engine::ErrorEnum::Busy => DbusErrorEnum::BUSY,
                 engine::ErrorEnum::Invalid => DbusErrorEnum::ERROR,
                 engine::ErrorEnum::NotFound => DbusErrorEnum::NOTFOUND,
+                engine::ErrorEnum::FailedToOpen => DbusErrorEnum::ERROR,
             }
         }
         EngineError::Io(_) => DbusErrorEnum::IO_ERROR,

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -49,6 +49,8 @@ pub trait Dev: Debug {
 pub trait Filesystem: HasName + HasUuid {
     /// Rename this filesystem.
     fn rename(&mut self, name: &str) -> ();
+    /// Destroy this filesystem
+    fn destroy(self) -> EngineResult<()>;
 }
 
 pub trait Pool: HasName + HasUuid {

--- a/src/engine/errors.rs
+++ b/src/engine/errors.rs
@@ -19,6 +19,7 @@ pub enum ErrorEnum {
     Busy,
     Invalid,
     NotFound,
+    FailedToOpen,
 }
 
 #[derive(Debug)]

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -23,10 +23,11 @@ macro_rules! destroy_filesystems {
     ( $s:ident; $fs:expr ) => {
         let mut removed = Vec::new();
         for uuid in $fs.iter().map(|x| *x) {
-            if $s.filesystems.remove_by_uuid(&uuid).is_some() {
+            if let Some(fs) = $s.filesystems.remove_by_uuid(&uuid) {
+                try!(fs.destroy());
                 removed.push(uuid);
-            };
-        };
+            }
+        }
         Ok(removed)
     }
 }

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -4,6 +4,7 @@
 
 use uuid::Uuid;
 
+use engine::EngineResult;
 use engine::Filesystem;
 
 use super::super::engine::{HasName, HasUuid};
@@ -26,6 +27,10 @@ impl SimFilesystem {
 impl Filesystem for SimFilesystem {
     fn rename(&mut self, name: &str) {
         self.name = name.to_owned();
+    }
+
+    fn destroy(self) -> EngineResult<()> {
+        Ok(())
     }
 }
 

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -189,6 +189,13 @@ pub fn initialize(pool_uuid: &PoolUuid,
 
     let add_devs = try!(filter_devs(dev_infos, pool_uuid, force));
 
+    // TODO: Fix this code.  We should deal with any number of blockdevs
+    //
+    if add_devs.len() <= 2 {
+        return Err(EngineError::Engine(ErrorEnum::Error,
+                                       "Need at least 2 blockdevs to create a pool".into()));
+    }
+
     let mut bds = BTreeMap::new();
     for (dev, (devnode, dev_size, mut f)) in add_devs {
 

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -11,6 +11,8 @@ use std::fs::{OpenOptions, read_dir};
 use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::thread;
+use std::time::Duration;
 
 use time::Timespec;
 use devicemapper::Device;
@@ -249,5 +251,11 @@ impl BlockDev {
         assert!(start <= self.bda.header.blkdev_size);
         let length = self.bda.header.blkdev_size - start;
         (start, length)
+    }
+
+    /// The /dev/mapper/<name> device is not immediately available for use.
+    /// TODO: Implement wait for event or poll.
+    pub fn wait_for_dm() {
+        thread::sleep(Duration::from_millis(500))
     }
 }

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -191,7 +191,7 @@ pub fn initialize(pool_uuid: &PoolUuid,
 
     // TODO: Fix this code.  We should deal with any number of blockdevs
     //
-    if add_devs.len() <= 2 {
+    if add_devs.len() < 2 {
         return Err(EngineError::Engine(ErrorEnum::Error,
                                        "Need at least 2 blockdevs to create a pool".into()));
     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -5,6 +5,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
+use devicemapper::DM;
 use uuid::Uuid;
 
 use engine::Engine;
@@ -56,7 +57,8 @@ impl Engine for StratEngine {
             return Err(EngineError::Engine(ErrorEnum::AlreadyExists, name.into()));
         }
 
-        let pool = try!(StratPool::new(name, blockdev_paths, redundancy, force));
+        let dm = try!(DM::new());
+        let pool = try!(StratPool::new(name, &dm, blockdev_paths, redundancy, force));
         let bdev_paths = pool.block_devs.iter().map(|p| p.1.devnode.clone()).collect();
 
         let uuid = pool.uuid().clone();

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -8,13 +8,12 @@ use uuid::Uuid;
 use devicemapper::DM;
 
 use consts::IEC;
+
 use engine::EngineResult;
 use engine::Filesystem;
 use engine::strat_engine::thindev::ThinDev;
 use engine::strat_engine::thinpooldev::ThinPoolDev;
-
 use super::super::engine::{HasName, HasUuid};
-
 use types::Bytes;
 
 

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -68,4 +68,9 @@ impl Filesystem for StratFilesystem {
     fn rename(&mut self, name: &str) {
         self.name = name.to_owned();
     }
+
+    fn destroy(self) -> EngineResult<()> {
+        let dm = try!(DM::new());
+        self.thin_dev.teardown(&dm)
+    }
 }

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -1,12 +1,22 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+extern crate rand;
 
 use uuid::Uuid;
 
+use devicemapper::DM;
+
+use consts::IEC;
+use engine::EngineResult;
 use engine::Filesystem;
+use engine::strat_engine::thindev::ThinDev;
+use engine::strat_engine::thinpooldev::ThinPoolDev;
 
 use super::super::engine::{HasName, HasUuid};
+
+use types::Bytes;
+
 
 #[derive(Debug)]
 pub struct StratFilesystem {
@@ -28,9 +38,12 @@ impl StratFilesystem {
         let thin_id = rand::random::<u16>();
         // TODO We don't require a size to be provided for create_filesystems -
         // but devicemapper requires an initial size for a thin provisioned
-        // device - currently hard coded to Sectors(300000).
-        let mut new_thin_dev =
-            try!(ThinDev::new(name, dm, thin_pool, thin_id as u32, Sectors(300000)));
+        // device - currently hard coded to 1GB.
+        let mut new_thin_dev = try!(ThinDev::new(name,
+                                                 dm,
+                                                 thin_pool,
+                                                 thin_id as u32,
+                                                 Bytes(IEC::Gi).sectors()));
         try!(new_thin_dev.create_fs());
         Ok(StratFilesystem {
             fs_id: fs_id,

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -6,7 +6,6 @@ use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 
 use engine::{EngineError, EngineResult, ErrorEnum};
 use engine::strat_engine::blockdev::blkdev_size;
-use engine::strat_engine::thinpooldev::ThinPoolDev;
 
 use std::fmt;
 use std::fs::File;
@@ -40,7 +39,7 @@ impl LinearDev {
         let dev_info = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
-        ThinPoolDev::wait_for_dm();
+        BlockDev::wait_for_dm();
         Ok(LinearDev {
             name: name.to_owned(),
             dev_info: dev_info,

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -6,6 +6,8 @@ use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 
 use engine::{EngineError, EngineResult, ErrorEnum};
 
+use std::fmt;
+use std::fs::File;
 use std::path::PathBuf;
 
 use super::blockdev::BlockDev;
@@ -14,6 +16,12 @@ use types::Sectors;
 pub struct LinearDev {
     name: String,
     dev_info: DeviceInfo,
+}
+
+impl fmt::Debug for LinearDev {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
+    }
 }
 
 /// Use DM to concatenate a set of blockdevs together into a

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -5,6 +5,7 @@
 use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 
 use engine::{EngineError, EngineResult, ErrorEnum};
+use engine::strat_engine::thinpooldev::ThinPoolDev;
 
 use std::fmt;
 use std::fs::File;
@@ -38,6 +39,7 @@ impl LinearDev {
         let dev_info = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
+        ThinPoolDev::wait_for_dm();
         Ok(LinearDev {
             name: name.to_owned(),
             dev_info: dev_info,

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,7 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use devicemapper::DM;
 use std::collections::BTreeMap;
+use std::iter::FromIterator;
 use std::path::Path;
 use std::path::PathBuf;
 use std::vec::Vec;
@@ -19,6 +21,8 @@ use engine::Filesystem;
 use engine::Pool;
 use engine::RenameAction;
 use engine::engine::Redundancy;
+use engine::strat_engine::lineardev::LinearDev;
+use engine::strat_engine::thinpooldev::ThinPoolDev;
 
 use super::super::engine::{HasName, HasUuid};
 use super::super::structures::Table;
@@ -28,6 +32,9 @@ use super::blockdev::{BlockDev, initialize, resolve_devices};
 use super::filesystem::StratFilesystem;
 use super::metadata::MIN_MDA_SECTORS;
 
+use types::DataBlocks;
+use types::Sectors;
+
 #[derive(Debug)]
 pub struct StratPool {
     name: String,
@@ -35,10 +42,12 @@ pub struct StratPool {
     pub block_devs: BTreeMap<PathBuf, BlockDev>,
     pub filesystems: Table<StratFilesystem>,
     redundancy: Redundancy,
+    thin_pool: ThinPoolDev,
 }
 
 impl StratPool {
     pub fn new(name: &str,
+               dm: &DM,
                paths: &[&Path],
                redundancy: Redundancy,
                force: bool)
@@ -48,12 +57,42 @@ impl StratPool {
         let devices = try!(resolve_devices(paths));
         let bds = try!(initialize(&pool_uuid, devices, MIN_MDA_SECTORS, force));
 
+        // TODO: We've got some temporary code in BlockDev::initialize that
+        // makes sure we've got at least 2 blockdevs supplied - one for a meta
+        // and one for data.  In the future, we will be able to deal with a
+        // single blockdev.  When that code is added to use a single blockdev,
+        // the check for 2 devs in BlockDev::initialize should be removed.
+        assert!(bds.len() >= 2);
+        let meta_dev;
+        let data_dev;
+        let length;
+        {
+            let mut data_devs = Vec::from_iter(bds.values());
+
+            meta_dev = try!(LinearDev::new(&format!("stratis_{}_meta", name),
+                                           dm,
+                                           &vec![data_devs.remove(0)]));
+
+            data_dev = try!(LinearDev::new(&format!("stratis_{}_data", name), dm, &data_devs));
+            length = try!(data_dev.size()).sectors();
+
+        }
+        // TODO Fix hard coded data blocksize and low water mark.
+        let thinpool_dev = try!(ThinPoolDev::new(&format!("stratis_{}_thinpool", name),
+                                                 dm,
+                                                 length,
+                                                 Sectors(1024),
+                                                 DataBlocks(256000),
+                                                 meta_dev,
+                                                 data_dev));
+
         let mut pool = StratPool {
             name: name.to_owned(),
             pool_uuid: pool_uuid,
             block_devs: bds,
             filesystems: Table::new(),
             redundancy: redundancy,
+            thin_pool: thinpool_dev,
         };
 
         try!(pool.write_metadata());
@@ -143,7 +182,9 @@ impl Pool for StratPool {
 
     fn destroy(mut self) -> EngineResult<()> {
 
-        // TODO: first, tear down DM mappings
+        // TODO Do we want to create a new File each time we interact with DM?
+        let dm = try!(DM::new());
+        try!(self.thin_pool.teardown(&dm));
 
         for bd in self.block_devs.values_mut() {
             try!(bd.wipe_metadata());

--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -83,7 +83,7 @@ impl ThinDev {
     }
 
     pub fn name(&self) -> &str {
-        self.dev_info.name().clone()
+        self.dev_info.name()
     }
 
     pub fn path(&self) -> EngineResult<PathBuf> {

--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -4,6 +4,7 @@
 
 use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 use engine::{EngineError, EngineResult, ErrorEnum};
+use engine::strat_engine::blockdev::BlockDev;
 use engine::strat_engine::thinpooldev::ThinPoolDev;
 
 use std::fmt;
@@ -51,7 +52,7 @@ impl ThinDev {
         let id = &DevId::Name(name);
         let di = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
-        ThinPoolDev::wait_for_dm();
+        BlockDev::wait_for_dm();
         Ok(ThinDev {
             name: name.to_owned(),
             dev_info: di,

--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -51,7 +51,7 @@ impl ThinDev {
         let id = &DevId::Name(name);
         let di = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
-
+        ThinPoolDev::wait_for_dm();
         Ok(ThinDev {
             name: name.to_owned(),
             dev_info: di,

--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -77,7 +77,7 @@ impl ThinDev {
 
     }
 
-    pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
+    pub fn teardown(&self, dm: &DM) -> EngineResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
         Ok(())
     }

--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -2,13 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 use engine::{EngineError, EngineResult, ErrorEnum};
 use engine::strat_engine::thinpooldev::ThinPoolDev;
+
+use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+
 use types::Sectors;
 
 #[derive(Clone)]
@@ -17,6 +19,12 @@ pub struct ThinDev {
     pub dev_info: DeviceInfo,
     pub thin_id: u32,
     pub size: Sectors,
+}
+
+impl fmt::Debug for ThinDev {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -71,6 +79,10 @@ impl ThinDev {
     pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
         Ok(())
+    }
+
+    pub fn name(&self) -> &str {
+        self.dev_info.name().clone()
     }
 
     pub fn path(&self) -> EngineResult<PathBuf> {

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -6,6 +6,7 @@ use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 use engine::{EngineError, EngineResult, ErrorEnum};
 use engine::strat_engine::lineardev::LinearDev;
 
+use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -18,6 +19,13 @@ pub struct ThinPoolDev {
     meta_dev: LinearDev,
     data_dev: LinearDev,
 }
+
+impl fmt::Debug for ThinPoolDev {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
+    }
+}
+
 
 /// Use DM to create a "thin-pool".  A "thin-pool" is shared space for
 /// other thin provisioned devices to use.

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -105,7 +105,7 @@ impl ThinPoolDev {
         }
     }
 
-    pub fn teardown(&mut self, dm: &DM) -> EngineResult<()> {
+    pub fn teardown(&self, dm: &DM) -> EngineResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
         try!(self.data_dev.teardown(dm));
         try!(self.meta_dev.teardown(dm));

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -9,6 +9,8 @@ use engine::strat_engine::lineardev::LinearDev;
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 use types::DataBlocks;
 use types::Sectors;
@@ -56,6 +58,7 @@ impl ThinPoolDev {
         let di = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
+        ThinPoolDev::wait_for_dm();
         Ok(ThinPoolDev {
             name: name.to_owned(),
             dev_info: di,
@@ -108,5 +111,11 @@ impl ThinPoolDev {
         try!(self.data_dev.teardown(dm));
         try!(self.meta_dev.teardown(dm));
         Ok(())
+    }
+
+    // The /dev/mapper/<name> device is not immediately available for use.
+    // TODO: Implement wait for event or poll.
+    pub fn wait_for_dm() {
+        thread::sleep(Duration::from_millis(500))
     }
 }

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -92,7 +92,7 @@ impl ThinPoolDev {
     }
 
     pub fn name(&self) -> &str {
-        self.dev_info.name().clone()
+        self.dev_info.name()
     }
 
     pub fn path(&self) -> EngineResult<PathBuf> {

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -4,13 +4,12 @@
 
 use devicemapper::{DM, DevId, DeviceInfo, DmFlags};
 use engine::{EngineError, EngineResult, ErrorEnum};
+use engine::strat_engine::blockdev::BlockDev;
 use engine::strat_engine::lineardev::LinearDev;
 
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
-use std::thread;
-use std::time::Duration;
 
 use types::DataBlocks;
 use types::Sectors;
@@ -58,7 +57,7 @@ impl ThinPoolDev {
         let di = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
-        ThinPoolDev::wait_for_dm();
+        BlockDev::wait_for_dm();
         Ok(ThinPoolDev {
             name: name.to_owned(),
             dev_info: di,
@@ -111,11 +110,5 @@ impl ThinPoolDev {
         try!(self.data_dev.teardown(dm));
         try!(self.meta_dev.teardown(dm));
         Ok(())
-    }
-
-    // The /dev/mapper/<name> device is not immediately available for use.
-    // TODO: Implement wait for event or poll.
-    pub fn wait_for_dm() {
-        thread::sleep(Duration::from_millis(500))
     }
 }

--- a/tests/lineardev_tests.rs
+++ b/tests/lineardev_tests.rs
@@ -19,8 +19,6 @@ use libstratis::types::Sectors;
 
 use std::iter::FromIterator;
 use std::path::Path;
-use std::thread;
-use std::time::Duration;
 
 use util::blockdev_utils::clean_blockdev_headers;
 use util::blockdev_utils::get_size;
@@ -57,10 +55,6 @@ fn validate_sizes(name: &str, block_devs: &Vec<&BlockDev>) -> TestResult<()> {
     }
 
     debug!("available linear space = {} sectors", linear_sectors);
-
-    // The /dev/mapper/<name> device is not immediately available for use.
-    // TODO: Implement wait for event or poll.
-    thread::sleep(Duration::from_millis(1000));
 
     let path_name = format!("/dev/mapper/{}", name);
     let path = Path::new(&path_name);

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -116,7 +116,7 @@ fn test_thindev_setup(dm: &DM, thinpool_dev: &mut ThinPoolDev) -> TestResult<()>
 /// Test creating a thin-pool device
 /// Test create a thin device provisioned from the pool
 /// Teardown the DM devices in the proper order
-pub fn test_thinpoolsetup_setup() {
+pub fn test_thinpool() {
 
     let dm = DM::new().unwrap();
 
@@ -126,7 +126,7 @@ pub fn test_thinpoolsetup_setup() {
     let safe_to_destroy_devs = match test_config.get_safe_to_destroy_devs() {
         Ok(devs) => {
             if devs.len() < 2 {
-                warn!("test_thinpoolsetup_setup requires at least 2 devices to run.  Test not \
+                warn!("test_thinpool requires at least 2 devices to run.  Test not \
                        run.");
                 return;
             }

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -27,7 +27,6 @@ use std::path::Path;
 use tempdir::TempDir;
 
 use util::blockdev_utils::clean_blockdev_headers;
-use util::blockdev_utils::wait_for_dm;
 use util::blockdev_utils::wipe_header;
 use util::blockdev_utils::write_files_to_directory;
 use util::test_config::TestConfig;
@@ -47,8 +46,6 @@ fn setup_supporting_devs(dm: &DM,
 
     let data_blockdevs = vec![data_blockdev];
     let data_dev = try!(LinearDev::new("stratis_testing_thinpool_datadev", dm, &data_blockdevs));
-
-    wait_for_dm();
 
     let metadata_path = try!(metadata_dev.path());
     let data_path = try!(data_dev.path());
@@ -86,7 +83,6 @@ fn test_thinpool_setup(dm: &DM, blockdev_paths: &Vec<&Path>) -> TestResult<ThinP
                                                  metadata_dev,
                                                  data_dev));
 
-    wait_for_dm();
 
     try!(test_thindev_setup(&dm, &mut thinpool_dev));
 
@@ -100,7 +96,7 @@ fn test_thindev_setup(dm: &DM, thinpool_dev: &mut ThinPoolDev) -> TestResult<()>
                                          thinpool_dev,
                                          thin_id as u32,
                                          Sectors(300000)));
-    wait_for_dm();
+
 
     let tmp_dir = try!(TempDir::new("stratis_testing"));
 

--- a/tests/util/blockdev_utils.rs
+++ b/tests/util/blockdev_utils.rs
@@ -14,8 +14,6 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
-use std::thread;
-use std::time::Duration;
 
 use util::blockdev_utils::tempdir::TempDir;
 use util::test_result::TestError;
@@ -38,13 +36,6 @@ pub fn get_ownership(path: &PathBuf) -> TestResult<DevOwnership> {
     };
 
     Ok(ownership)
-}
-
-// The /dev/mapper/<name> device is not immediately available for use.
-// TODO: Implement wait for event or poll.
-#[allow(dead_code)]
-pub fn wait_for_dm() {
-    thread::sleep(Duration::from_millis(2500))
 }
 
 pub fn clean_blockdev_headers(blockdev_paths: &Vec<&Path>) -> TestResult<()> {


### PR DESCRIPTION
Connect API to thin devices - pools and thin provisioned filesystems

Added Debug to ThinPoolDev and ThinDev because I added them to structs that derived
Debug.

Moved wait_for_dm out of tests and into ThinPoolDev for use by structs that create DM
devices.

Added size() to LinearDev so we can make thin upper limit of the ThinPoolDev proportionate
to the underlying data LinearDev.

StratPool now creates a backing ThinPoolDev.

Create Filesystem now creates a thindev in the pool and puts and XFS filesystem on it.

Added destroy() to cleanup filesystems

Note: There are a few TODO markers in this PR.
    1. Currently thin_id is just a random number
    2. Pool requires at least 2 devices (meta and data)
    3. Hard coded data blocksize and low water mark.
    4. We sleep for a time waiting for DM devices
    5. Need to decide on the ratio of real storage to the size of the thin pool. (1:1 currently)
    6. We don't require a size to be provided for create_filesystem - but devicemapper requires
        an initial size for a thin provisioned device.