### PR TITLE
unwrap cleanup in source code

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -2,15 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#[macro_use]
 extern crate libstratis;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
 extern crate devicemapper;
-#[macro_use]
 extern crate clap;
-#[macro_use]
 extern crate nix;
 extern crate crc;
 extern crate byteorder;
@@ -21,11 +18,8 @@ extern crate term;
 extern crate rand;
 extern crate serde;
 
-#[macro_use]
 extern crate custom_derive;
-#[macro_use]
 extern crate newtype_derive;
-#[macro_use]
 extern crate enum_derive;
 
 #[cfg(test)]

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -77,7 +77,9 @@ fn main() {
             builder.parse(&s);
         }
     };
-    builder.init().unwrap();
+
+    builder.init()
+        .expect("This is the first and only initialization of the logger; it must succeed.");
 
     let engine: Box<Engine> = {
         if matches.is_present("sim") {
@@ -89,9 +91,7 @@ fn main() {
         }
     };
 
-    let r = libstratis::dbus_api::run(engine);
-
-    if let Err(r) = r {
+    if let Err(r) = libstratis::dbus_api::run(engine) {
         if let Err(e) = write_err(r) {
             panic!("Unable to write to stderr: {}", e)
         }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -71,7 +71,11 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             dbus_context.pools
                 .borrow_mut()
                 .insert(pool_object_path.clone(), (object_path.clone(), uuid));
-            let paths = devnodes.iter().map(|d| d.to_str().unwrap().into());
+            let paths = devnodes.iter().map(|d| {
+                d.to_str()
+                    .expect("'d' originated in the 'devs' D-Bus argument.")
+                    .into()
+            });
             let paths = paths.map(|x| MessageItem::Str(x)).collect();
             let return_path = MessageItem::ObjectPath(pool_object_path);
             let return_list = MessageItem::Array(paths, "s".into());
@@ -245,7 +249,7 @@ pub fn run(engine: Box<Engine>) -> StratisResult<()> {
     let dbus_context = tree.get_data().clone();
     try!(tree.set_registered(&c, true));
 
-    c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32).unwrap();
+    try!(c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32));
 
     // ...and serve incoming requests.
     for c_item in c.iter(10000) {

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -69,5 +69,5 @@ pub fn ok_message_items() -> (MessageItem, MessageItem) {
 }
 
 pub fn default_object_path<'a>() -> dbus::Path<'a> {
-    dbus::Path::new("/").unwrap()
+    dbus::Path::new("/").expect("'/' is guaranteed to be a valid Path.")
 }

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -42,7 +42,9 @@ macro_rules! destroy_pool {
         } else {
             return Ok(false);
         }
-        try!($s.pools.remove_by_uuid($uuid).unwrap().destroy());
+        try!($s.pools.remove_by_uuid($uuid)
+             .expect("Must succeed since $s.pool.get_by_uuid() returned a value.")
+             .destroy());
         Ok(true)
     }
 }
@@ -70,7 +72,8 @@ macro_rules! rename_pool {
             return Err(EngineError::Engine(ErrorEnum::AlreadyExists, $new_name.into()));
         }
 
-        let mut pool = $s.pools.remove_by_uuid($uuid).unwrap();
+        let mut pool = $s.pools.remove_by_uuid($uuid)
+            .expect("Must succeed since $s.pools.get_by_uuid() returned a value.");
         pool.rename($new_name);
         $s.pools.insert(pool);
         return Ok(RenameAction::Renamed);
@@ -100,7 +103,8 @@ macro_rules! rename_filesystem {
             return Err(EngineError::Engine(ErrorEnum::AlreadyExists, $new_name.into()));
         }
 
-        let mut filesystem = $s.filesystems.remove_by_uuid($uuid).unwrap();
+        let mut filesystem = $s.filesystems.remove_by_uuid($uuid)
+            .expect("Must succeed since $s.filesystems.get_by_uuid() returned a value.");
         filesystem.rename($new_name);
         $s.filesystems.insert(filesystem);
         return Ok(RenameAction::Renamed);

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -150,10 +150,7 @@ pub fn initialize(pool_uuid: &PoolUuid,
     {
         let mut add_devs = Vec::new();
         for (dev, dev_result) in dev_infos {
-            if dev_result.is_err() {
-                return Err(dev_result.unwrap_err());
-            }
-            let (devnode, dev_size, ownership, f) = dev_result.unwrap();
+            let (devnode, dev_size, ownership, f) = try!(dev_result);
             if dev_size < MIN_DEV_SIZE {
                 let error_message = format!("{} too small, minimum {} bytes",
                                             devnode.display(),

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -485,7 +485,9 @@ impl MDAHeader {
             let mut data_buf = vec![0u8; *used as usize];
             try!(f.read_exact(&mut data_buf));
 
-            if self.data_crc.unwrap() != crc32::checksum_ieee(&data_buf) {
+            if self.data_crc
+                .expect("Option constructors of 'data_crc' and 'used' are always the same.") !=
+               crc32::checksum_ieee(&data_buf) {
                 return Err(EngineError::Engine(ErrorEnum::Invalid, "MDA region data CRC".into()));
             }
             Ok(Some(data_buf))

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -89,12 +89,11 @@ impl<T: HasName + HasUuid> Table<T> {
     /// Removes the Pool corresponding to name if there is one.
     pub fn remove_by_name(&mut self, name: &str) -> Option<T> {
         if let Some(index) = self.name_map.remove(name) {
-            // There is guaranteed to be a last because there is at least
-            // one index into the items.
-
             // Insert mappings for the about-to-be swapped element
             {
-                let last_item = &self.items.last().unwrap();
+                let last_item = &self.items
+                    .last()
+                    .expect("name_map is non-empty <-> items is non-empty");
                 self.name_map.insert(last_item.name().into(), index);
                 self.uuid_map.insert(last_item.uuid().clone(), index);
             }
@@ -115,12 +114,11 @@ impl<T: HasName + HasUuid> Table<T> {
     /// Removes the Pool corresponding to the uuid if there is one.
     pub fn remove_by_uuid(&mut self, uuid: &Uuid) -> Option<T> {
         if let Some(index) = self.uuid_map.remove(uuid) {
-            // There is guaranteed to be a last because there is at least
-            // one index into the items.
-
             // Insert mappings for the about-to-be swapped element
             {
-                let last_item = &self.items.last().unwrap();
+                let last_item = &self.items
+                    .last()
+                    .expect("uuid_map is non-empty <-> items is non-empty");
                 self.name_map.insert(last_item.name().into(), index);
                 self.uuid_map.insert(last_item.uuid().clone(), index);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate devicemapper;
-#[macro_use]
 extern crate clap;
 #[macro_use]
 extern crate nix;


### PR DESCRIPTION
Change all unwrap() calls to expect() calls wherever it is possible to
explain why the unwrap() must succeed.

Propagate an error in some cases where unwrap() is inappropriate.

Leave a TODO on any remaining unwraps().

Do a small amount of tidying.

Signed-off-by: mulhern <amulhern@redhat.com>