### PR TITLE
Zero the superblock on meta_data device before it is passed to thin-pool

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -242,7 +242,7 @@ impl BlockDev {
         }
     }
 
-    pub fn wipe_metadata(&mut self) -> EngineResult<()> {
+    pub fn wipe_metadata(&self) -> EngineResult<()> {
         let mut f = try!(OpenOptions::new().write(true).open(&self.devnode));
         BDA::wipe(&mut f)
     }

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::ErrorKind;
+use std::io::{Seek, Write, SeekFrom};
 use std::fs::{OpenOptions, read_dir};
 use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -95,7 +96,22 @@ pub fn find_all() -> EngineResult<HashMap<PoolUuid, HashMap<DevUuid, BlockDev>>>
     Ok(pool_map)
 }
 
+/// Zero sectors at the given offset
+pub fn wipe_sectors(path: &Path, offset: Sectors, sector_count: Sectors) -> EngineResult<()> {
+    let mut f = try!(OpenOptions::new()
+        .write(true)
+        .open(path));
 
+    let zeroed = [0u8; SECTOR_SIZE];
+
+    // set the start point to the offset
+    try!(f.seek(SeekFrom::Start(*offset)));
+    for _ in 0..*sector_count {
+        try!(f.write_all(&zeroed));
+    }
+    try!(f.flush());
+    Ok(())
+}
 
 /// Initialize multiple blockdevs at once. This allows all of them
 /// to be checked for usability before writing to any of them.

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -203,13 +203,13 @@ impl Pool for StratPool {
         Ok(bdev_paths)
     }
 
-    fn destroy(mut self) -> EngineResult<()> {
+    fn destroy(self) -> EngineResult<()> {
 
         // TODO Do we want to create a new File each time we interact with DM?
         let dm = try!(DM::new());
         try!(self.thin_pool.teardown(&dm));
 
-        for bd in self.block_devs.values_mut() {
+        for bd in self.block_devs.values() {
             try!(bd.wipe_metadata());
         }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -22,6 +22,7 @@ use engine::Filesystem;
 use engine::Pool;
 use engine::RenameAction;
 use engine::engine::Redundancy;
+use engine::strat_engine::blockdev::wipe_sectors;
 use engine::strat_engine::lineardev::LinearDev;
 use engine::strat_engine::thinpooldev::ThinPoolDev;
 
@@ -33,8 +34,9 @@ use super::blockdev::{BlockDev, initialize, resolve_devices};
 use super::filesystem::StratFilesystem;
 use super::metadata::MIN_MDA_SECTORS;
 
-use types::DataBlocks;
-use types::Sectors;
+use types::{DataBlocks, Sectors};
+
+pub const DATA_BLOCK_SIZE: Sectors = Sectors(2048);
 
 #[derive(Debug)]
 pub struct StratPool {
@@ -66,16 +68,26 @@ impl StratPool {
         assert!(bds.len() >= 2);
 
         let meta_dev = try!(LinearDev::new(&format!("stratis_{}_meta", name), dm, &vec![&bds[0]]));
+        // When constructing a thin-pool, Stratis reserves the first N
+        // sectors on a block device by creating a linear device with a
+        // starting offset. DM writes the super block in the first block.
+        // DM requires this first block to be zeros when the meta data for
+        // the thin-pool is initially created. If we don't zero the
+        // superblock DM issue error messages because it triggers code paths
+        // that are trying to re-adopt the device with the attributes that
+        // have been passed.
+        try!(wipe_sectors(&try!(meta_dev.path()), Sectors(0), DATA_BLOCK_SIZE));
         let data_dev = try!(LinearDev::new(&format!("stratis_{}_data", name),
                                            dm,
                                            &Vec::from_iter(bds[1..].iter())));
+        try!(wipe_sectors(&try!(data_dev.path()), Sectors(0), DATA_BLOCK_SIZE));
         let length = try!(data_dev.size()).sectors();
 
         // TODO Fix hard coded data blocksize and low water mark.
         let thinpool_dev = try!(ThinPoolDev::new(&format!("stratis_{}_thinpool", name),
                                                  dm,
                                                  length,
-                                                 Sectors(1024),
+                                                 DATA_BLOCK_SIZE,
                                                  DataBlocks(256000),
                                                  meta_dev,
                                                  data_dev));

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -15,6 +15,7 @@ use devicemapper::DM;
 
 use libstratis::engine::strat_engine::blockdev;
 use libstratis::engine::strat_engine::blockdev::BlockDev;
+use libstratis::engine::strat_engine::blockdev::wipe_sectors;
 use libstratis::engine::strat_engine::lineardev::LinearDev;
 use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
 use libstratis::engine::strat_engine::thindev::ThinDev;
@@ -27,7 +28,6 @@ use std::path::Path;
 use tempdir::TempDir;
 
 use util::blockdev_utils::clean_blockdev_headers;
-use util::blockdev_utils::wipe_header;
 use util::blockdev_utils::write_files_to_directory;
 use util::test_config::TestConfig;
 use util::test_consts::DEFAULT_CONFIG_FILE;
@@ -49,8 +49,8 @@ fn setup_supporting_devs(dm: &DM,
 
     let metadata_path = try!(metadata_dev.path());
     let data_path = try!(data_dev.path());
-    try!(wipe_header(Path::new(&metadata_path)));
-    try!(wipe_header(Path::new(&data_path)));
+    try!(wipe_sectors(Path::new(&metadata_path), Sectors(0), Sectors(16)));
+    try!(wipe_sectors(Path::new(&data_path), Sectors(0), Sectors(16)));
 
     Ok((metadata_dev, data_dev))
 }


### PR DESCRIPTION
When constructing a thin-pool, Stratis reserves the first n sectors on a block device by creating a
DM linear device with a starting offset.  DM writes the super block in the first block.  DM requires 
this first block to be zeros when the meta data for the thin-pool is initially created.  If we don't zero
the superblock DM issues very confusing error messages because it triggers code paths that are trying to re-adopt the device with the attributes that have been passed.

Add method to zero a sector range at a given offset.
Removed un-needed "mut" for &self parameter on wipe_metadata.
Added constant DATA_BLOCK_SIZE

Signed-off-by: Todd Gill <tgill@redhat.com>