### PR TITLE
Put all unshared functions in the files where they are used

### DIFF
--- a/tests/pool_tests.rs
+++ b/tests/pool_tests.rs
@@ -8,18 +8,37 @@ extern crate log;
 #[macro_use]
 mod util;
 
-use libstratis::engine::Engine;
-use libstratis::engine::strat_engine::StratEngine;
-use libstratis::engine::strat_engine::engine::DevOwnership;
-
+use std::fs::OpenOptions;
 use std::path::Path;
 use std::path::PathBuf;
 
+use libstratis::engine::Engine;
+use libstratis::engine::strat_engine::StratEngine;
+use libstratis::engine::strat_engine::engine::DevOwnership;
+use libstratis::engine::strat_engine::metadata::StaticHeader;
+
 use util::blockdev_utils::clean_blockdev_headers;
-use util::blockdev_utils::get_ownership;
 use util::test_config::TestConfig;
 use util::test_consts::DEFAULT_CONFIG_FILE;
-use util::test_result::TestResult;
+use util::test_result::{TestError, TestErrorEnum, TestResult};
+
+
+fn get_ownership(path: &Path) -> TestResult<DevOwnership> {
+
+    let mut f = try!(OpenOptions::new()
+        .read(true)
+        .open(&path));
+
+    let ownership = match StaticHeader::determine_ownership(&mut f) {
+        Ok(ownership) => ownership,
+        Err(err) => {
+            let error_message = format!("{} for device {:?}", err, path);
+            return Err(TestError::Framework(TestErrorEnum::Error(error_message)));
+        }
+    };
+
+    Ok(ownership)
+}
 
 // Check to make sure the disks in blockdev_paths are no longer "Owned" by
 // Stratis

--- a/tests/thinpooldev_tests.rs
+++ b/tests/thinpooldev_tests.rs
@@ -11,11 +11,14 @@ extern crate tempdir;
 #[macro_use]
 mod util;
 
+use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 
 use devicemapper::DM;
-use devicemapper::types::DataBlocks;
-use devicemapper::types::Sectors;
+use devicemapper::types::{DataBlocks, Sectors};
+use tempdir::TempDir;
+use uuid::Uuid;
 
 use libstratis::engine::strat_engine::blockdev;
 use libstratis::engine::strat_engine::blockdev::BlockDev;
@@ -25,15 +28,23 @@ use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
 use libstratis::engine::strat_engine::thindev::ThinDev;
 use libstratis::engine::strat_engine::thinpooldev::ThinPoolDev;
 
-use tempdir::TempDir;
-
 use util::blockdev_utils::clean_blockdev_headers;
-use util::blockdev_utils::write_files_to_directory;
 use util::test_config::TestConfig;
 use util::test_consts::DEFAULT_CONFIG_FILE;
 use util::test_result::TestResult;
 
-use uuid::Uuid;
+
+fn write_files_to_directory(tmp_dir: &TempDir, number_of_files: u32) -> TestResult<()> {
+    for i in 0..number_of_files {
+        {
+            let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));
+            let mut tmp_file = File::create(file_path)
+                .expect("failed to create temp file on filesystem");
+            writeln!(tmp_file, "Write some data to file.").expect("failed to write temp file");
+        }
+    }
+    Ok(())
+}
 
 fn setup_supporting_devs(dm: &DM,
                          metadata_blockdev: &BlockDev,

--- a/tests/util/blockdev_utils.rs
+++ b/tests/util/blockdev_utils.rs
@@ -1,43 +1,18 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-extern crate tempdir;
 extern crate devicemapper;
 
-use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::Path;
 
 use devicemapper::types::Sectors;
 
-use libstratis::engine::strat_engine::blockdev::blkdev_size;
 use libstratis::engine::strat_engine::blockdev::wipe_sectors;
-use libstratis::engine::strat_engine::engine::DevOwnership;
-use libstratis::engine::strat_engine::metadata::StaticHeader;
 
-use util::blockdev_utils::tempdir::TempDir;
 use util::test_result::TestError;
 use util::test_result::TestErrorEnum;
 use util::test_result::TestResult;
 
-#[allow(dead_code)]
-pub fn get_ownership(path: &Path) -> TestResult<DevOwnership> {
-
-    let mut f = try!(OpenOptions::new()
-        .read(true)
-        .open(&path));
-
-    let ownership = match StaticHeader::determine_ownership(&mut f) {
-        Ok(ownership) => ownership,
-        Err(err) => {
-            let error_message = format!("{} for device {:?}", err, path);
-            return Err(TestError::Framework(TestErrorEnum::Error(error_message)));
-        }
-    };
-
-    Ok(ownership)
-}
 
 pub fn clean_blockdev_headers(blockdev_paths: &[&Path]) -> TestResult<()> {
 
@@ -51,34 +26,5 @@ pub fn clean_blockdev_headers(blockdev_paths: &[&Path]) -> TestResult<()> {
         }
     }
     info!("devices cleaned for test");
-    Ok(())
-}
-
-#[allow(dead_code)]
-pub fn get_size(path: &Path) -> TestResult<Sectors> {
-    let f = match File::open(path) {
-        Ok(file) => file,
-        Err(e) => panic!("Failed to open blockdev : {:?}", e),
-    };
-
-    match blkdev_size(&f) {
-        Ok(bytes) => return Ok(bytes.sectors()),
-        Err(e) => {
-            let error_message = format!("{:?} for device {:?}", e, path);
-            return Err(TestError::Framework(TestErrorEnum::Error(error_message)));
-        }
-    };
-}
-
-#[allow(dead_code)]
-pub fn write_files_to_directory(tmp_dir: &TempDir, number_of_files: u32) -> TestResult<()> {
-    for i in 0..number_of_files {
-        {
-            let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));
-            let mut tmp_file = File::create(file_path)
-                .expect("failed to create temp file on filesystem");
-            writeln!(tmp_file, "Write some data to file.").expect("failed to write temp file");
-        }
-    }
     Ok(())
 }


### PR DESCRIPTION
That way it is not necessary to call them dead.
Reorder imports, in files where it is necessary to add or remove them
anyway.

Signed-off-by: mulhern <amulhern@redhat.com>