### PR TITLE
Switch to DBus system bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ licensed under the MPL 2.0 to be merged by us.
 
 ### Setting up for development
 
+Stratisd runs as root, and requires access to the D-Bus system bus. Thus in
+order to work properly, a D-Bus conf file must exist to grant access, either
+installed by distribution packaging; or manually, by copying `stratisd.conf`
+to `/etc/dbus-1/system.d/`.
+
 Stratisd requires Rust 1.15.1+ and Cargo to build. These may be available via
 your distribution's package manager. If not, [Rustup](https://www.rustup.rs/)
 is available to install and update the Rust toolchain.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ D-Bus API to communicate with `stratisd`.
 Stratisd is written in [Rust](https://www.rust-lang.org), which helps the
 implementation be small, correct, and not require a large language runtime.
 
-Stratisd requires Rust 1.15.1 or later.
-
 ## Documentation
 
 Please see https://stratis-storage.github.io/ and [our documentation
@@ -40,3 +38,13 @@ question.
 It is licensed under the [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). All
 contributions retain ownership by their original author, but must also be
 licensed under the MPL 2.0 to be merged by us.
+
+### Setting up for development
+
+Stratisd requires Rust 1.15.1+ and Cargo to build. These may be available via
+your distribution's package manager. If not, [Rustup](https://www.rustup.rs/)
+is available to install and update the Rust toolchain.
+
+Once toolchain is in place, run `cargo build` to build, and then run the
+`stratisd` executable in `./target/debug/` as root. Pass the `--help` option
+for more information on additional developer options.

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -245,7 +245,7 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> Tree<MTFn<TData>, TData> {
 }
 
 pub fn run(engine: Box<Engine>) -> StratisResult<()> {
-    let c = try!(Connection::get_private(BusType::Session));
+    let c = try!(Connection::get_private(BusType::System));
 
     let mut tree = get_base_tree(DbusContext::new(engine));
     let dbus_context = tree.get_data().clone();

--- a/stratisd.conf
+++ b/stratisd.conf
@@ -1,0 +1,13 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+<policy user="root">
+  <allow own="org.storage.stratis1"/>
+</policy>
+<policy context="default">
+  <allow send_destination="org.storage.stratis1"/>
+  <allow own_prefix="org.storage.stratis1.Manager"/>
+  <allow send_interface="org.storage.stratis1"/>
+</policy>
+</busconfig>


### PR DESCRIPTION
This is a 1-line change to the code, but won't work unless we tell dbus-daemon we're allowed to be on the system bus by copying a special file. Add this file and describe where it needs to be copied in the README.

First, also add some additional development info to the README.