### PR TITLE
Respect force flag w/ Stratis pools

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -181,10 +181,14 @@ pub fn initialize(pool_uuid: &PoolUuid,
                 }
                 DevOwnership::Ours(uuid) => {
                     if *pool_uuid != uuid {
-                        let error_str = format!("Device {} already belongs to Stratis pool {}",
-                                                devnode.display(),
-                                                uuid);
-                        return Err(EngineError::Engine(ErrorEnum::Invalid, error_str));
+                        if !force {
+                            let error_str = format!("Device {} already belongs to Stratis pool {}",
+                                                    devnode.display(),
+                                                    uuid);
+                            return Err(EngineError::Engine(ErrorEnum::Invalid, error_str));
+                        } else {
+                            add_devs.push((dev, (devnode, dev_size, f)))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If force flag is true, we should initialize the blockdev belonging
to some other Stratis pool.

Signed-off-by: mulhern <amulhern@redhat.com>