### PR TITLE
Make final methods consume self

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -240,7 +240,7 @@ impl BlockDev {
         }
     }
 
-    pub fn wipe_metadata(&self) -> EngineResult<()> {
+    pub fn wipe_metadata(self) -> EngineResult<()> {
         let mut f = try!(OpenOptions::new().write(true).open(&self.devnode));
         BDA::wipe(&mut f)
     }

--- a/src/engine/strat_engine/lineardev.rs
+++ b/src/engine/strat_engine/lineardev.rs
@@ -100,9 +100,8 @@ impl LinearDev {
         }
     }
 
-    pub fn teardown(&self, dm: &DM) -> EngineResult<()> {
+    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
-
         Ok(())
     }
 }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -201,13 +201,13 @@ impl Pool for StratPool {
         Ok(bdev_paths)
     }
 
-    fn destroy(self) -> EngineResult<()> {
+    fn destroy(mut self) -> EngineResult<()> {
 
         // TODO Do we want to create a new File each time we interact with DM?
         let dm = try!(DM::new());
         try!(self.thin_pool.teardown(&dm));
 
-        for bd in self.block_devs.values() {
+        for (_, bd) in self.block_devs.drain() {
             try!(bd.wipe_metadata());
         }
 

--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -77,7 +77,7 @@ impl ThinDev {
 
     }
 
-    pub fn teardown(&self, dm: &DM) -> EngineResult<()> {
+    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
         Ok(())
     }

--- a/src/engine/strat_engine/thinpooldev.rs
+++ b/src/engine/strat_engine/thinpooldev.rs
@@ -105,7 +105,7 @@ impl ThinPoolDev {
         }
     }
 
-    pub fn teardown(&self, dm: &DM) -> EngineResult<()> {
+    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
         try!(self.data_dev.teardown(dm));
         try!(self.meta_dev.teardown(dm));


### PR DESCRIPTION
Closes: #282.

These final methods are teardown() for DM struct and wipe_metadata() for
blockdevs. We believe that with both these methods, once the method action
is performed that we should not be using the struct anymore.

Remove some actions in a test that did a use after a method call.

Update StratPool::destroy() for consuming wipe_metadata() method.

Signed-off-by: mulhern <amulhern@redhat.com>