### PR TITLE
Always set RUST_BACKTRACE to 1 for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,21 +14,21 @@ build:
 
 # Tests are in order of complexity, from least to greatest.
 test-loop:
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test loop_test_force_flag_stratis
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test loop_test_linear_device
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test loop_test_thinpool_device
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test loop_test_pool_blockdevs
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_force_flag_stratis
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_linear_device
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_thinpool_device
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_pool_blockdevs
 
 
 # Tests are in order of complexity, from least to greatest.
 test-real:
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test real_test_force_flag_stratis
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test real_test_linear_device
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test real_test_thinpool_device
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' cargo test -- --test real_test_pool_blockdevs
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_force_flag_stratis
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_linear_device
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_thinpool_device
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_pool_blockdevs
 
 test:
-	RUSTFLAGS='-D warnings' cargo test -- --skip real_ --skip loop_
+	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_
 
 docs:
 	cargo doc --no-deps


### PR DESCRIPTION
Might as well see the backtrace immediately, if one happens.

Signed-off-by: mulhern <amulhern@redhat.com>