### PR TITLE
Revise *_fs methods

### DIFF
--- a/src/engine/strat_engine/thindev.rs
+++ b/src/engine/strat_engine/thindev.rs
@@ -125,7 +125,7 @@ impl ThinDev {
             .output());
 
         if output.status.success() {
-            debug!("Mounted xfs filesystem on {:?}", mount_point)
+            debug!("Mounted filesystem on {:?}", mount_point)
         } else {
             let message = String::from_utf8_lossy(&output.stderr);
             debug!("stderr: {}", message);
@@ -134,8 +134,8 @@ impl ThinDev {
         Ok(())
     }
 
-    pub fn unmount_fs(&self, mount_point: &Path) -> EngineResult<()> {
-        debug!("Unount filesystem {:?}", mount_point);
+    pub fn unmount_fs(mount_point: &Path) -> EngineResult<()> {
+        debug!("Unmount filesystem {:?}", mount_point);
 
         let output = try!(Command::new("umount")
             .arg(mount_point)

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -117,7 +117,7 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
 
     let tmp_dir = TempDir::new("stratis_testing").unwrap();
     thin_dev.mount_fs(tmp_dir.path()).unwrap();
-    thin_dev.unmount_fs(tmp_dir.path()).unwrap();
+    ThinDev::unmount_fs(tmp_dir.path()).unwrap();
     for i in 0..100 {
         let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));
         writeln!(&File::create(file_path).unwrap(), "data").unwrap();


### PR DESCRIPTION
These revisions went into a previous device-mapper commit before the methods
themselves were pulled from the commit. I don't know where these methods
will end up, but we might as well not lose the changes.

Signed-off-by: mulhern <amulhern@redhat.com>