### PR TITLE
Block allocation improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ranged_set 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -271,6 +272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ranged_set"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "step 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +353,11 @@ dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "step"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -494,6 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum ranged_set 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ef7abce634f34b65223b226ba3da5136770652c4cc55d3c6736d25a60b1e27b6"
 "checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
@@ -504,6 +520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
 "checksum serde_derive 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3e472ff72816522c7837cf932585a838576a85e8642632ccf7b8d43b7a1bf1af"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
+"checksum step 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3be40e3ca373d873e8fda4c68e1f0bab4142c6995d35d74c0b75d4f2bdc3956"
 "checksum strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5f575d5ced6634a5c4cb842163dab907dc7e9148b28dc482d81b8855cbe985"
 "checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
 "checksum syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)" = "171b739972d9a1bfb169e8077238b51f9ebeaae4ff6e08072f7ba386a8802da2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "0"
 log = "0.3"
 env_logger="0.3.5"
 libc = "0.2"
+ranged_set = "0"
 
 [dependencies.uuid]
 version = "0.3.1"

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// Code to handle a single block device.
+
 use std::io;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -241,7 +243,7 @@ pub fn initialize(pool_uuid: &PoolUuid,
 
 #[derive(Debug)]
 pub struct BlockDev {
-    dev: Device,
+    pub dev: Device,
     pub devnode: PathBuf,
     bda: BDA,
     used: RangeAllocator,

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -212,13 +212,6 @@ pub fn initialize(pool_uuid: &PoolUuid,
 
     let add_devs = try!(filter_devs(dev_infos, pool_uuid, force));
 
-    // TODO: Fix this code.  We should deal with any number of blockdevs
-    //
-    if add_devs.len() < 2 {
-        return Err(EngineError::Engine(ErrorEnum::Error,
-                                       "Need at least 2 blockdevs to create a pool".into()));
-    }
-
     let mut bds = Vec::new();
     for (dev, (devnode, dev_size, mut f)) in add_devs {
 

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -199,6 +199,10 @@ pub fn initialize(pool_uuid: &PoolUuid,
                                                 devnode.display(),
                                                 uuid);
                         return Err(EngineError::Engine(ErrorEnum::Invalid, error_str));
+                    } else {
+                        // Already in this pool (according to its header)
+                        // TODO: Check we already know about it
+                        // if yes, ignore. If no, add it w/o initializing?
                     }
                 }
             }

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Code to handle a collection of block devices.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use devicemapper::{Sectors, Segment};
+use time::Timespec;
+
+use engine::{EngineResult, PoolUuid};
+use super::metadata::MIN_MDA_SECTORS;
+pub use super::BlockDevSave;
+use engine::strat_engine::blockdev::{BlockDev, resolve_devices, initialize};
+
+#[derive(Debug)]
+pub struct BlockDevMgr {
+    pub block_devs: HashMap<PathBuf, BlockDev>,
+}
+
+impl BlockDevMgr {
+    pub fn new(block_devs: Vec<BlockDev>) -> BlockDevMgr {
+        BlockDevMgr {
+            block_devs: block_devs.into_iter().map(|bd| (bd.devnode.clone(), bd)).collect(),
+        }
+    }
+
+    pub fn add(&mut self,
+               pool_uuid: &PoolUuid,
+               paths: &[&Path],
+               force: bool)
+               -> EngineResult<Vec<PathBuf>> {
+        let devices = try!(resolve_devices(paths));
+        let bds = try!(initialize(pool_uuid, devices, MIN_MDA_SECTORS, force));
+        let bdev_paths = bds.iter().map(|p| p.devnode.clone()).collect();
+        for bd in bds {
+            self.block_devs.insert(bd.devnode.clone(), bd);
+        }
+        Ok(bdev_paths)
+    }
+
+    pub fn destroy_all(mut self) -> EngineResult<()> {
+        for (_, bd) in self.block_devs.drain() {
+            try!(bd.wipe_metadata());
+        }
+        Ok(())
+    }
+
+    // Unused space left on blockdevs
+    pub fn avail_space(&self) -> Sectors {
+        self.block_devs.values().map(|bd| bd.available()).sum()
+    }
+
+    /// If available space is less than size, return None, else return
+    /// the segments allocated.
+    pub fn alloc_space(&mut self, size: Sectors) -> Option<Vec<Segment>> {
+        let mut needed: Sectors = size;
+        let mut segs = Vec::new();
+
+        if self.avail_space() < size {
+            return None;
+        }
+
+        for mut bd in self.block_devs.values_mut() {
+            if needed == Sectors(0) {
+                break;
+            }
+
+            let (gotten, r_segs) = bd.request_space(needed);
+            segs.extend(r_segs.iter()
+                .map(|&(start, len)| Segment::new(bd.dev, start, len)));
+            needed = needed - gotten;
+        }
+
+        assert_eq!(needed, Sectors(0));
+
+        Some(segs)
+    }
+
+    pub fn devnodes(&self) -> Vec<PathBuf> {
+        self.block_devs.keys().map(|p| p.clone()).collect()
+    }
+
+    pub fn to_save(&self) -> HashMap<String, BlockDevSave> {
+        self.block_devs
+            .iter()
+            .map(|(_, bd)| (bd.uuid().simple().to_string(), bd.to_save()))
+            .collect()
+    }
+
+    /// Write the given data to all blockdevs marking with specified time.
+    // TODO: Cap # of blockdevs written to, as described in SWDD
+    pub fn save_state(&mut self, time: &Timespec, metadata: &[u8]) -> EngineResult<()> {
+        // TODO: Do something better than panic when saving to blockdev fails.
+        // Panic can occur for a the usual IO reasons, but also:
+        // 1. If the timestamp is older than a previously written timestamp.
+        // 2. If the variable length metadata is too large.
+        for bd in self.block_devs.values_mut() {
+            bd.save_state(time, metadata).unwrap();
+        }
+        Ok(())
+    }
+
+    /// Return the metadata from the first blockdev with up-to-date, readable
+    /// metadata.
+    pub fn load_state(&self) -> Option<Vec<u8>> {
+        if self.block_devs.is_empty() {
+            return None;
+        }
+
+        let most_recent_blockdev = self.block_devs
+            .values()
+            .max_by_key(|bd| bd.last_update_time())
+            .expect("must be a maximum since bds is non-empty");
+
+        let most_recent_time = most_recent_blockdev.last_update_time();
+
+        if most_recent_time.is_none() {
+            return None;
+        }
+
+        for bd in self.block_devs
+            .values()
+            .filter(|b| b.last_update_time() == most_recent_time) {
+            match bd.load_state() {
+                Ok(Some(data)) => return Some(data),
+                _ => continue,
+            }
+        }
+
+        None
+    }
+}

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -59,11 +59,11 @@ impl Engine for StratEngine {
 
         let dm = try!(DM::new());
         let pool = try!(StratPool::initialize(name, &dm, blockdev_paths, redundancy, force));
-        let bdev_paths = pool.block_devs.iter().map(|p| p.1.devnode.clone()).collect();
+        let bdev_devnodes = pool.block_devs.devnodes();
 
         let uuid = pool.uuid().clone();
         self.pools.insert(pool);
-        Ok((uuid, bdev_paths))
+        Ok((uuid, bdev_devnodes))
     }
 
     fn destroy_pool(&mut self, uuid: &PoolUuid) -> EngineResult<bool> {

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -8,6 +8,7 @@ pub mod metadata;
 pub mod filesystem;
 pub mod pool;
 pub mod serde_structs;
+pub mod range_alloc;
 
 pub use self::engine::StratEngine;
 pub use self::pool::StratPool;

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub mod blockdev;
+pub mod blockdevmgr;
 pub mod engine;
 pub mod metadata;
 pub mod filesystem;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -97,7 +97,6 @@ impl StratPool {
         let data_regions = block_mgr.alloc_space(INITIAL_DATA_SIZE)
             .expect("blockmgr must not fail, already checked for space");
         let data_dev = try!(LinearDev::new(&format!("stratis_{}_data", name), dm, &data_regions));
-        try!(wipe_sectors(&try!(data_dev.devnode()), Sectors(0), DATA_BLOCK_SIZE));
         let length = try!(data_dev.size()).sectors();
 
         // TODO Fix hard coded data blocksize and low water mark.

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -1,0 +1,225 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::cmp::min;
+use std::u64::MAX;
+
+use devicemapper::Sectors;
+use ranged_set::RangedSet;
+
+#[derive(Debug)]
+pub struct RangeAllocator {
+    limit: Sectors,
+    used: RangedSet<u64>,
+}
+
+impl RangeAllocator {
+    /// Create a new RangeAllocator with all entries in the range unused.
+    pub fn new(limit: Sectors) -> RangeAllocator {
+        // Implementation of used_ranges means we can't handle limit=MAX
+        assert!(*limit < MAX, "limit must be less than 2^64");
+        RangeAllocator {
+            limit: limit,
+            used: RangedSet::new(),
+        }
+    }
+
+    /// Create a new RangeAllocator with the specified (offset,
+    /// length) ranges marked as used.
+    pub fn new_with_used(limit: Sectors, initial_used: &[(Sectors, Sectors)]) -> RangeAllocator {
+        let mut allocator = RangeAllocator::new(limit);
+        allocator.insert_ranges(initial_used);
+        allocator
+    }
+
+    fn check_for_overflow(&self, off: Sectors, len: Sectors) {
+        assert_ne!(off.checked_add(*len), None);
+        assert!(off + len <= self.limit, "off+len greater than range limit");
+    }
+
+    /// Mark ranges previously marked as unused as now used.
+    fn insert_ranges(&mut self, ranges: &[(Sectors, Sectors)]) -> () {
+        for &(off, len) in ranges {
+            self.check_for_overflow(off, len);
+
+            for val in *off..*off + *len {
+                let inserted = self.used.insert(val);
+                if inserted == false {
+                    panic!(format!("inserted value {} already present", val));
+                }
+            }
+        }
+    }
+
+    /// Mark ranges previously marked as used as now unused.
+    pub fn remove_ranges(&mut self, to_free: &[(Sectors, Sectors)]) -> () {
+        for &(off, len) in to_free {
+            self.check_for_overflow(off, len);
+
+            for val in *off..*off + *len {
+                let removed = self.used.remove(&val);
+                if removed == false {
+                    panic!(format!("tried to remove value {} not present in RangedSet", val));
+                }
+            }
+        }
+    }
+
+    /// Available sectors
+    pub fn available(&self) -> Sectors {
+        Sectors((0..*self.limit).filter(|val| !self.used.contains(val)).count() as u64)
+    }
+
+    /// Allocated sectors
+    pub fn used(&self) -> Sectors {
+        Sectors((0..*self.limit).filter(|val| self.used.contains(val)).count() as u64)
+    }
+
+    /// Get a list of (offset, length) segments that are in use
+    fn used_ranges(&self) -> Vec<(Sectors, Sectors)> {
+        let mut used = Vec::new();
+
+        // iterate one *past* limit. This ensures a used range extending
+        // up to limit will end and be added to used_ranges properly.
+        (0..*self.limit + 1).fold(None, |curr_range, val| {
+            match (curr_range, self.used.contains(&val)) {
+                (None, true) => Some((val, 1)),
+                (None, false) => None,
+                (Some((off, len)), true) => Some((off, len + 1)),
+                (Some((off, len)), false) => {
+                    used.push((Sectors(off), Sectors(len)));
+                    None
+                }
+            }
+        });
+
+        used
+    }
+
+    /// Get a list of (offset, length) segments that are not in use
+    fn avail_ranges(&self) -> Vec<(Sectors, Sectors)> {
+        let mut free = Vec::new();
+
+        // Insert an entry to mark the end so the fold works correctly
+        let mut used = self.used_ranges();
+        used.push((self.limit, Sectors(0)));
+
+        used.into_iter()
+            .fold(Sectors(0), |prev_end, (start, len)| {
+                if prev_end < start {
+                    free.push((prev_end, start - prev_end))
+                }
+                start + len
+            });
+
+        free
+    }
+
+    /// Attempt to allocate. Returns number of sectors allocated (may
+    /// be less than request, including zero) and a Vec<(offset,
+    /// length)> of sectors successfully allocated.
+    pub fn request(&mut self, amount: Sectors) -> (Sectors, Vec<(Sectors, Sectors)>) {
+        let mut segs = Vec::new();
+        let mut needed = amount;
+
+        for (start, len) in self.avail_ranges() {
+            if needed == Sectors(0) {
+                break;
+            }
+
+            let to_use = min(needed, len);
+
+            let used_range = (start, to_use);
+            segs.push(used_range);
+            self.insert_ranges(&[used_range]);
+
+            needed = needed - to_use;
+        }
+
+        (amount - needed, segs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_allocator_allocations() {
+        let mut allocator = RangeAllocator::new(Sectors(128));
+
+        assert_eq!(allocator.used(), Sectors(0));
+        assert_eq!(allocator.available(), Sectors(128));
+
+        allocator.insert_ranges(&[(Sectors(10), Sectors(100))]);
+
+        assert_eq!(allocator.used(), Sectors(100));
+        assert_eq!(allocator.available(), Sectors(28));
+
+        let request = allocator.request(Sectors(50));
+        assert_eq!(request.0, Sectors(28));
+        assert_eq!(allocator.used(), Sectors(128));
+        assert_eq!(allocator.available(), Sectors(0));
+        assert_eq!(request.1.len(), 2);
+
+        let good_remove_ranges = [(Sectors(21), Sectors(20)), (Sectors(41), Sectors(40))];
+        allocator.remove_ranges(&good_remove_ranges);
+        assert_eq!(allocator.used(), Sectors(68));
+        assert_eq!(allocator.available(), Sectors(60));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_allocator_failures_alloc_overlap() {
+        let mut allocator = RangeAllocator::new(Sectors(128));
+
+        let _request = allocator.request(Sectors(128));
+
+        // overlap
+        let bad_remove_ranges = [(Sectors(21), Sectors(20)), (Sectors(40), Sectors(40))];
+        allocator.remove_ranges(&bad_remove_ranges);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_allocator_failures_range_overwrite() {
+        let mut allocator = RangeAllocator::new(Sectors(128));
+
+        let _request = allocator.request(Sectors(128));
+        assert_eq!(_request.0, Sectors(128));
+        assert_eq!(_request.1, &[(Sectors(0), Sectors(128))]);
+
+        // overwriting a used range
+        allocator.insert_ranges(&[(Sectors(1), Sectors(1))]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_allocator_failures_removing_unused() {
+        let mut allocator = RangeAllocator::new(Sectors(128));
+
+        // removing an unused range
+        allocator.remove_ranges(&[(Sectors(1), Sectors(1))]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_allocator_failures_overflow_limit() {
+        let mut allocator = RangeAllocator::new(Sectors(128));
+
+        // overflow limit range
+        allocator.insert_ranges(&[(Sectors(1), Sectors(128))]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_allocator_failures_overflow_max() {
+        use std::u64::MAX;
+
+        let mut allocator = RangeAllocator::new(Sectors(MAX));
+
+        // overflow max u64
+        allocator.insert_ranges(&[(Sectors(MAX), Sectors(1))]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate log;
+extern crate ranged_set;
 
 #[cfg(test)]
 extern crate quickcheck;

--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -74,6 +74,7 @@ fn test_with_spec<F>(count: u8, test: F) -> ()
 
 #[test]
 pub fn loop_test_force_flag_stratis() {
+    test_with_spec(1, test_force_flag_stratis);
     test_with_spec(2, test_force_flag_stratis);
     test_with_spec(3, test_force_flag_stratis);
 }

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -86,10 +86,10 @@ pub fn test_force_flag_dirty(paths: &[&Path]) -> () {
 
 /// Verify that it is impossible to steal blockdevs from another Stratis
 /// pool.
-/// 1. Initialize devices with uuid.
+/// 1. Initialize devices with pool uuid.
 /// 2. Initializing again with different uuid must fail.
-/// 3. Initializing again with same uuid must fail, because all the
-/// devices already belong.
+/// 3. Initializing again with same pool uuid must succeed, because all the
+/// devices already belong so there's nothing to do.
 /// 4. Initializing again with different uuid and force = true also fails.
 pub fn test_force_flag_stratis(paths: &[&Path]) -> () {
     let unique_devices = resolve_devices(&paths).unwrap();
@@ -100,9 +100,7 @@ pub fn test_force_flag_stratis(paths: &[&Path]) -> () {
     initialize(&uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).unwrap();
     assert!(initialize(&uuid2, unique_devices.clone(), MIN_MDA_SECTORS, false).is_err());
 
-    // FIXME: once requirement that number of devices added be at least 2 is removed
-    // this should succeed.
-    assert!(initialize(&uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).is_err());
+    assert!(initialize(&uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).is_ok());
 
     // FIXME: this should succeed, but currently it fails, to be extra safe.
     // See: https://github.com/stratis-storage/stratisd/pull/292

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -28,12 +28,12 @@ use self::uuid::Uuid;
 use libstratis::engine::Engine;
 use libstratis::engine::strat_engine::StratEngine;
 use libstratis::engine::strat_engine::blockdev::{blkdev_size, initialize, resolve_devices,
-                                                 write_sectors, BlockDev};
+                                                 write_sectors};
+use libstratis::engine::strat_engine::blockdevmgr::BlockDevMgr;
 use libstratis::engine::strat_engine::engine::DevOwnership;
 use libstratis::engine::strat_engine::filesystem::{create_fs, mount_fs, unmount_fs};
 use libstratis::engine::strat_engine::metadata::{StaticHeader, BDA_STATIC_HDR_SECTORS,
                                                  MIN_MDA_SECTORS};
-use libstratis::engine::strat_engine::pool::StratPool;
 
 
 /// Dirty sectors where specified, with 1s.
@@ -223,22 +223,15 @@ pub fn test_pool_blockdevs(paths: &[&Path]) -> () {
 pub fn test_variable_length_metadata_times(paths: &[&Path]) -> () {
     let unique_devices = resolve_devices(&paths).unwrap();
     let uuid = Uuid::new_v4();
-    let mut blockdevs = initialize(&uuid, unique_devices, MIN_MDA_SECTORS, false).unwrap();
-    assert!(StratPool::load_state(&blockdevs.iter().collect::<Vec<&BlockDev>>()).is_none());
+    let blockdevs = initialize(&uuid, unique_devices, MIN_MDA_SECTORS, false).unwrap();
+    let mut mgr = BlockDevMgr::new(blockdevs);
+    assert!(mgr.load_state().is_none());
 
     let (state1, state2) = (vec![1u8, 2u8, 3u8, 4u8], vec![5u8, 6u8, 7u8, 8u8]);
-    let current_time = now().to_timespec();
-    StratPool::save_state(&mut blockdevs.iter_mut().collect::<Vec<&mut BlockDev>>(),
-                          &current_time,
-                          &state1)
-        .unwrap();
-    assert!(StratPool::load_state(&blockdevs.iter().collect::<Vec<&BlockDev>>()).unwrap() ==
-            state1);
 
-    StratPool::save_state(&mut blockdevs.iter_mut().collect::<Vec<&mut BlockDev>>(),
-                          &now().to_timespec(),
-                          &state2)
-        .unwrap();
-    assert!(StratPool::load_state(&blockdevs.iter().collect::<Vec<&BlockDev>>()).unwrap() ==
-            state2);
+    mgr.save_state(&now().to_timespec(), &state1).unwrap();
+    assert!(mgr.load_state().unwrap() == state1);
+
+    mgr.save_state(&now().to_timespec(), &state2).unwrap();
+    assert!(mgr.load_state().unwrap() == state2);
 }


### PR DESCRIPTION
This PR lets us more easily track the used segments of each blockdev, and also adds a BlockDevMgr, to let us more easily ask for segments across all the disks from which to construct lineardevs.

There is some work that builds on this to use this in StratPool::new, but there was a small change to devicemapper API that I was hoping to land that makes things a little easier.