### PR TITLE
Init logger in tests

### DIFF
--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -1,9 +1,10 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 extern crate devicemapper;
+extern crate env_logger;
 extern crate libstratis;
+extern crate log;
 extern crate loopdev;
 extern crate tempdir;
 
@@ -19,6 +20,7 @@ use tempdir::TempDir;
 use libstratis::consts::IEC;
 use libstratis::engine::strat_engine::blockdev::wipe_sectors;
 
+use util::logger::init_logger;
 use util::simple_tests::test_force_flag_dirty;
 use util::simple_tests::test_force_flag_stratis;
 use util::simple_tests::test_linear_device;

--- a/tests/real_tests.rs
+++ b/tests/real_tests.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 extern crate devicemapper;
+extern crate env_logger;
 extern crate libstratis;
+extern crate log;
 extern crate rustc_serialize;
 
 mod util;

--- a/tests/util/logger.rs
+++ b/tests/util/logger.rs
@@ -1,6 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+extern crate env_logger;
 
-pub mod simple_tests;
-pub mod logger;
+pub fn init_logger() {
+    env_logger::init().unwrap();
+}


### PR DESCRIPTION
To use the logging in libstratis, the loggger needs to be initialized.