### PR TITLE
Remove dependency on rustc-serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,6 @@ dependencies = [
  "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ features = ["v4"]
 
 [dev-dependencies]
 quickcheck = "0.4"
-rustc-serialize = "0.3.21"
+serde_json = "0"
 tempdir = "0.3.5"
 loopdev = "0.1.1"


### PR DESCRIPTION
Use serde-json instead.

Closes #317.

Signed-off-by: mulhern <amulhern@redhat.com>