### PR TITLE
Initialize the logger for loopback and real tests.

### DIFF
--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 extern crate devicemapper;
+extern crate env_logger;
 extern crate libstratis;
+extern crate log;
 extern crate loopdev;
 extern crate tempdir;
 
@@ -19,6 +21,7 @@ use tempdir::TempDir;
 
 use libstratis::consts::IEC;
 
+use util::logger::init_logger;
 use util::simple_tests::test_force_flag_dirty;
 use util::simple_tests::test_force_flag_stratis;
 use util::simple_tests::test_linear_device;
@@ -59,6 +62,7 @@ fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopDevice> {
 fn test_with_spec<F>(count: u8, test: F) -> ()
     where F: Fn(&[&Path]) -> ()
 {
+    init_logger();
     let tmpdir = TempDir::new("stratis").unwrap();
     let loop_devices: Vec<LoopDevice> = get_devices(count, &tmpdir);
     let device_paths: Vec<PathBuf> = loop_devices.iter().map(|x| x.get_path().unwrap()).collect();

--- a/tests/real_tests.rs
+++ b/tests/real_tests.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 extern crate devicemapper;
+extern crate env_logger;
 extern crate libstratis;
+extern crate log;
 extern crate serde_json;
 
 mod util;
@@ -18,6 +20,7 @@ use self::devicemapper::{Bytes, Sectors};
 use libstratis::consts::IEC;
 use libstratis::engine::strat_engine::blockdev::wipe_sectors;
 
+use util::logger::init_logger;
 use util::simple_tests::test_force_flag_dirty;
 use util::simple_tests::test_force_flag_stratis;
 use util::simple_tests::test_linear_device;
@@ -52,6 +55,7 @@ fn get_devices(count: u8) -> Option<Vec<PathBuf>> {
 fn test_with_spec<F>(count: u8, test: F) -> ()
     where F: Fn(&[&Path]) -> ()
 {
+    init_logger();
     let devices = get_devices(count).unwrap();
     let device_paths: Vec<&Path> = devices.iter().map(|x| x.as_path()).collect();
     test(&device_paths);

--- a/tests/util/logger.rs
+++ b/tests/util/logger.rs
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+extern crate env_logger;
+
+use std::sync::{Once, ONCE_INIT};
+
+static LOGGER_INIT: Once = ONCE_INIT;
+
+/// Initialzie the logger once.  More than one init() attempt returns
+/// errors.
+pub fn init_logger() {
+    LOGGER_INIT.call_once(|| {
+        env_logger::init()
+            .expect("This is the first and only initialization of the logger; it must succeed.");
+    });
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -3,3 +3,4 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub mod simple_tests;
+pub mod logger;


### PR DESCRIPTION
This allows the team to enable logging in libstratis and the tests.

Signed-off-by: Todd Gill <tgill@redhat.com>