### PR TITLE
Initial support for Metadata Volume (MDV)

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -92,7 +92,7 @@ fn run() -> StratisResult<()> {
             Rc::new(RefCell::new(SimEngine::new()))
         } else {
             info!("Using StratEngine");
-            Rc::new(RefCell::new(StratEngine::new()))
+            Rc::new(RefCell::new(try!(StratEngine::initialize())))
         }
     };
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::fs::create_dir;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -35,8 +37,14 @@ pub struct StratEngine {
 }
 
 impl StratEngine {
-    pub fn new() -> StratEngine {
-        StratEngine { pools: Table::new() }
+    pub fn initialize() -> EngineResult<StratEngine> {
+        if let Err(err) = create_dir("/dev/stratis") {
+            if err.kind() != ErrorKind::AlreadyExists {
+                return Err(From::from(err));
+            }
+        }
+
+        Ok(StratEngine { pools: Table::new() })
     }
 
     /// Teardown Stratis, preparatory to a shutdown.

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -15,6 +15,7 @@ use devicemapper::{ThinDev, ThinStatus};
 use devicemapper::ThinPoolDev;
 
 use engine::{EngineError, EngineResult, ErrorEnum, Filesystem};
+use super::serde_structs::{Isomorphism, FilesystemSave};
 use super::super::engine::{FilesystemUuid, HasName, HasUuid, PoolUuid};
 use super::dmdevice::{ThinRole, format_thin_name};
 
@@ -94,6 +95,17 @@ impl Filesystem for StratFilesystem {
         match self.thin_dev.teardown(&dm) {
             Ok(_) => Ok(()),
             Err(e) => Err(EngineError::Engine(ErrorEnum::Error, e.description().into())),
+        }
+    }
+}
+
+impl Isomorphism<FilesystemSave> for StratFilesystem {
+    fn to_save(&self) -> FilesystemSave {
+        FilesystemSave {
+            name: self.name.clone(),
+            uuid: self.fs_id.simple().to_string(),
+            thin_id: self.thin_dev.id(),
+            size: self.thin_dev.size(),
         }
     }
 }

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Manage the linear volume that stores metadata on pool levels 5-7.
+
+use std::convert::From;
+use std::error::Error;
+use std::fs::{create_dir, OpenOptions, read_dir, remove_file, rename};
+use std::io::ErrorKind;
+use std::io::prelude::*;
+use std::os::unix::io::AsRawFd;
+use std::path::PathBuf;
+
+use devicemapper::{LinearDev, DM};
+use serde_json;
+use nix::unistd::fsync;
+
+use engine::engine::{HasUuid, FilesystemUuid};
+use engine::EngineResult;
+use engine::PoolUuid;
+use super::filesystem::{create_fs, mount_fs, unmount_fs, StratFilesystem};
+use super::serde_structs::{Isomorphism, FilesystemSave};
+
+// TODO: Monitor fs size and extend linear and fs if needed
+// TODO: Document format of stuff on MDV in SWDD (currently ad-hoc)
+
+#[derive(Debug)]
+pub struct MetadataVol {
+    dev: LinearDev,
+    mount_pt: PathBuf,
+}
+
+impl MetadataVol {
+    /// Initialize a new Metadata Volume.
+    pub fn initialize(pool_uuid: &PoolUuid, dev: LinearDev) -> EngineResult<MetadataVol> {
+        try!(create_fs(try!(dev.devnode()).as_path()));
+        MetadataVol::setup(pool_uuid, dev)
+    }
+
+    /// Set up an existing Metadata Volume.
+    pub fn setup(pool_uuid: &PoolUuid, dev: LinearDev) -> EngineResult<MetadataVol> {
+        let mount_pt = PathBuf::from(format!("/dev/stratis/.mdv-{}", pool_uuid.simple()));
+
+        if let Err(err) = create_dir(&mount_pt) {
+            if err.kind() != ErrorKind::AlreadyExists {
+                return Err(From::from(err));
+            }
+        }
+
+        try!(mount_fs(&try!(dev.devnode()), &mount_pt));
+
+        if let Err(err) = create_dir(&mount_pt.join("filesystems")) {
+            if err.kind() != ErrorKind::AlreadyExists {
+                return Err(From::from(err));
+            }
+        }
+
+        Ok(MetadataVol { dev, mount_pt })
+    }
+
+    /// Save info on a new filesystem to persistent storage, or update
+    /// the existing info on a filesystem.
+    // Write to a temp file and then rename to actual filename, to
+    // ensure file contents are not truncated if operation is
+    // interrupted.
+    pub fn save_fs(&self, fs: &StratFilesystem) -> EngineResult<()> {
+        let data = try!(serde_json::to_string(&fs.to_save()));
+        let path = self.mount_pt
+            .join("filesystems")
+            .join(fs.uuid().simple().to_string())
+            .with_extension("json");
+
+        let temp_path = path.clone().with_extension("temp");
+
+        // Braces to ensure f is closed before renaming
+        {
+            let mut f = try!(OpenOptions::new()
+                                 .write(true)
+                                 .create(true)
+                                 .open(&temp_path));
+            try!(f.write_all(data.as_bytes()));
+
+            // Try really hard to make sure it goes to disk
+            try!(f.flush());
+            try!(fsync(f.as_raw_fd()));
+        }
+
+        try!(rename(temp_path, path));
+
+        Ok(())
+    }
+
+    /// Remove info on a filesystem from persistent storage.
+    pub fn rm_fs(&self, fs_uuid: &FilesystemUuid) -> EngineResult<()> {
+        let fs_path = self.mount_pt
+            .join("filesystems")
+            .join(fs_uuid.simple().to_string())
+            .with_extension("json");
+        if let Err(err) = remove_file(fs_path) {
+            if err.kind() != ErrorKind::NotFound {
+                return Err(From::from(err));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check the current state of the MDV.
+    pub fn check(&self) -> EngineResult<()> {
+        for dir_e in try!(read_dir(self.mount_pt.join("filesystems"))) {
+            let dir_e = try!(dir_e);
+
+            // Clean up any lingering .temp files. These should only
+            // exist if there was a crash during save_fs().
+            if dir_e.path().ends_with(".temp") {
+                match remove_file(dir_e.path()) {
+                    Err(err) => {
+                        debug!("could not remove file {:?}: {}",
+                               dir_e.path(),
+                               err.description())
+                    }
+                    Ok(_) => debug!("Cleaning up temp file {:?}", dir_e.path()),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get list of filesystems stored on the MDV.
+    pub fn filesystems(&self) -> EngineResult<Vec<FilesystemSave>> {
+        let mut filesystems = Vec::new();
+
+        for dir_e in try!(read_dir(self.mount_pt.join("filesystems"))) {
+            let dir_e = try!(dir_e);
+
+            if dir_e.path().ends_with(".temp") {
+                continue;
+            }
+
+            let mut f = try!(OpenOptions::new().read(true).open(&dir_e.path()));
+            let mut data = Vec::new();
+            try!(f.read_to_end(&mut data));
+
+            filesystems.push(try!(serde_json::from_slice(&data)));
+        }
+
+        Ok(filesystems)
+    }
+
+    /// Tear down a Metadata Volume.
+    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
+        try!(unmount_fs(&self.mount_pt));
+        try!(self.dev.teardown(dm));
+
+        Ok(())
+    }
+}

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -13,5 +13,6 @@ pub mod pool;
 pub mod serde_structs;
 pub mod setup;
 pub mod range_alloc;
+pub mod mdv;
 
 pub use self::engine::StratEngine;

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -14,6 +14,8 @@
 
 use std::marker::Sized;
 
+use devicemapper::Sectors;
+
 /// Implements saving struct data to a serializable form and reconstructing
 /// a struct from that form.
 /// Assuming the context of the existing devices this must be an isomorphism,
@@ -30,4 +32,12 @@ pub trait Isomorphism<T> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolSave {
     pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FilesystemSave {
+    pub name: String,
+    pub uuid: String,
+    pub thin_id: u32,
+    pub size: Sectors,
 }

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -192,7 +192,7 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
 /// Test that creating a pool claims all blockdevs and that destroying a pool
 /// releases all blockdevs.
 pub fn test_pool_blockdevs(paths: &[&Path]) -> () {
-    let mut engine = StratEngine::new();
+    let mut engine = StratEngine::initialize().unwrap();
     let (uuid, blockdevs) = engine
         .create_pool("test_pool", paths, None, true)
         .unwrap();
@@ -220,7 +220,7 @@ pub fn test_pool_blockdevs(paths: &[&Path]) -> () {
 
 /// Verify that tearing down an engine doesn't fail if no filesystems on it.
 pub fn test_teardown(paths: &[&Path]) -> () {
-    let mut engine = StratEngine::new();
+    let mut engine = StratEngine::initialize().unwrap();
     engine
         .create_pool("test_pool", paths, None, true)
         .unwrap();
@@ -274,7 +274,7 @@ pub fn test_setup(paths: &[&Path]) -> () {
 /// space required.
 pub fn test_empty_pool(paths: &[&Path]) -> () {
     assert!(paths.len() == 0);
-    let mut engine = StratEngine::new();
+    let mut engine = StratEngine::initialize().unwrap();
     assert!(match engine
                       .create_pool("test_pool", paths, None, true)
                       .unwrap_err() {
@@ -296,7 +296,7 @@ pub fn test_basic_metadata(paths: &[&Path]) {
 
     let (paths1, paths2) = paths.split_at(2);
 
-    let mut engine = StratEngine::new();
+    let mut engine = StratEngine::initialize().unwrap();
 
     let name1 = "name1";
     let (uuid1, _) = engine.create_pool(&name1, paths1, None, false).unwrap();


### PR DESCRIPTION
Create and manage another linear device and filesystem when creating a pool. Use it to persistently save, to enumerate, and allow the removal of per-filesystem information.