### PR TITLE
Combine RangeAllocator::new() with RangeAllocator::new_with_used()

### DIFF
--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -218,7 +218,7 @@ pub fn initialize(pool_uuid: &PoolUuid,
                                        &Uuid::new_v4(),
                                        mda_size,
                                        dev_size.sectors()));
-        let allocator = RangeAllocator::new_with_used(bda.dev_size(), &[(Sectors(0), bda.size())]);
+        let allocator = RangeAllocator::new(bda.dev_size(), &[(Sectors(0), bda.size())]);
 
         bds.push(BlockDev::new(dev, devnode, bda, allocator));
     }


### PR DESCRIPTION
Keep the name new(), get rid of new_with_used().

It is too easy to pass the empty vec to mean "nothing used" to make it
worthwhile to have distinct methods. The name new_with_used() occasionally
sounds wierdly paradoxical, or at least awkward, easier if it is not
there.

Signed-off-by: mulhern <amulhern@redhat.com>