### PR TITLE
Ingnore Errno::ENOMEDIUM for blockdev::find_all().

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -88,11 +88,10 @@ pub fn find_all() -> EngineResult<HashMap<PoolUuid, Vec<Device>>> {
                 }
                 _ => {
                     if let Some(errno) = err.raw_os_error() {
-                        if Errno::from_i32(errno) == Errno::ENXIO {
-                            continue;
-                        } else {
-                            return Err(EngineError::Io(err));
-                        }
+                        match Errno::from_i32(errno) {
+                            Errno::ENXIO | Errno::ENOMEDIUM => continue,
+                            _ => return Err(EngineError::Io(err)),
+                        };
                     } else {
                         return Err(EngineError::Io(err));
                     }


### PR DESCRIPTION
Errno::ENOMEDIUM is returned in the case of an optical device.

Signed-off-by: Todd Gill <tgill@redhat.com>