### PR TITLE
Do not export the *Pools

### DIFF
--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -11,19 +11,11 @@ use std::rc::Rc;
 
 use super::randomization::Randomizer;
 
-#[derive(Debug, Eq, PartialEq)]
-/// A list of very basic states a SimDev can be in.
-pub enum State {
-    OK,
-    FAILED,
-}
-
 #[derive(Debug)]
 /// A simulated device.
 pub struct SimDev {
     pub devnode: PathBuf,
     rdm: Rc<RefCell<Randomizer>>,
-    pub state: State,
 }
 
 impl Dev for SimDev {}
@@ -34,19 +26,6 @@ impl SimDev {
         SimDev {
             devnode: devnode.to_owned(),
             rdm: rdm,
-            state: State::OK,
         }
-    }
-
-    /// Function that causes self to progress probabilistically to a new state.
-    pub fn update(&mut self) {
-        if self.rdm.borrow_mut().throw_die() {
-            self.state = State::FAILED;
-        }
-    }
-
-    /// Checks usability of a SimDev
-    pub fn usable(&self) -> bool {
-        self.state == State::OK
     }
 }

--- a/src/engine/sim_engine/mod.rs
+++ b/src/engine/sim_engine/mod.rs
@@ -1,5 +1,4 @@
 pub use self::engine::SimEngine;
-pub use self::pool::SimPool;
 
 mod blockdev;
 mod engine;

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -15,4 +15,3 @@ pub mod setup;
 pub mod range_alloc;
 
 pub use self::engine::StratEngine;
-pub use self::pool::StratPool;


### PR DESCRIPTION
They are unneeded by the binary, which operates only on the engine.

Get rid of some very unnused code thus revealed.

Signed-off-by: mulhern <amulhern@redhat.com>