### PR TITLE
decrease the space we wipe on device from 1 GiB to 1 MiB for real devices

### DIFF
--- a/tests/real_tests.rs
+++ b/tests/real_tests.rs
@@ -33,7 +33,7 @@ use util::simple_tests::test_thinpool_device;
 
 
 /// Set up count devices from configuration file.
-/// Wipe first GiB on each device.
+/// Wipe first MiB on each device.
 fn get_devices(count: u8) -> Option<Vec<PathBuf>> {
     let file = OpenOptions::new()
         .read(true)
@@ -54,7 +54,7 @@ fn get_devices(count: u8) -> Option<Vec<PathBuf>> {
         .map(|x| PathBuf::from(x.as_str().unwrap()))
         .collect();
 
-    let length = Bytes(IEC::Gi as u64).sectors();
+    let length = Bytes(IEC::Mi as u64).sectors();
     for device in devices.iter() {
         wipe_sectors(device, Sectors(0), length).unwrap();
     }


### PR DESCRIPTION
The 1 GiB is slow and un-needed.  This now matches what we do for
the loopback tests.

Signed-off-by: Todd Gill <tgill@redhat.com>