### PR TITLE
Cleanup testdevs on failure

### DIFF
--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -4,6 +4,7 @@
 extern crate rand;
 
 use std::error::Error;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command;
 
@@ -147,10 +148,14 @@ pub fn mount_fs(dev_path: &Path, mount_point: &Path) -> EngineResult<()> {
     Ok(())
 }
 
-pub fn unmount_fs(mount_point: &Path) -> EngineResult<()> {
+pub fn unmount_fs<I, S>(mount_point: &Path, flags: I) -> EngineResult<()>
+    where I: IntoIterator<Item = S>,
+          S: AsRef<OsStr>
+{
     debug!("Unmount filesystem {:?}", mount_point);
 
-    let output = try!(Command::new("umount").arg(mount_point).output());
+    let mut command = Command::new("umount");
+    let output = try!(command.arg(mount_point).args(flags).output());
 
     if output.status.success() {
         debug!("Unmounted filesystem {:?}", mount_point)

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -158,7 +158,8 @@ impl MetadataVol {
 
     /// Tear down a Metadata Volume.
     pub fn teardown(self, dm: &DM) -> EngineResult<()> {
-        try!(unmount_fs(&self.mount_pt));
+        let v: Vec<&str> = Vec::new();
+        try!(unmount_fs(&self.mount_pt, &v));
         try!(self.dev.teardown(dm));
 
         Ok(())

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -193,7 +193,6 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
 
     let tmp_dir = TempDir::new("stratis_testing").unwrap();
     mount_fs(&thin_dev.devnode().unwrap(), tmp_dir.path()).unwrap();
-    unmount_fs(tmp_dir.path()).unwrap();
     for i in 0..100 {
         let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));
         writeln!(&OpenOptions::new()
@@ -204,6 +203,9 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
                  "data")
                 .unwrap();
     }
+    // The -d (detach-loop) is passed for both loopback and real devs,
+    // it helps with loopback devs and does no harm for real devs.
+    unmount_fs(tmp_dir.path(), &["-d"]).unwrap();
     thin_dev.teardown(&dm).unwrap();
     thinpool_dev.teardown(&dm).unwrap();
 }


### PR DESCRIPTION

Update tests so they can be run multiple times in any order.  Previously stale data on real devices
would cause the some of the loopback tests to fail.  There was also a problem with loopback devices
not not going away after a test completed.

The PR wraps both loopback and real devices in a struct that implements the Drop trait.  When the
devices go out of scope, the clean up code in drop() is invoked.

Added a "flags" parameter to unmount.  These changes pass the "-d" to detach loop on unmount.
The parameter may also be useful in the future for lazy unmounts.

