### PR TITLE
Extend MDV if it fills up

### DIFF
--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -153,6 +153,21 @@ pub fn create_fs(dev_path: &Path) -> EngineResult<()> {
     Ok(())
 }
 
+pub fn grow_fs(dev_path: &Path) -> EngineResult<()> {
+
+    debug!("Grow filesystem for : {:?}", dev_path);
+    let output = try!(Command::new("xfs_growfs").arg(&dev_path).output());
+
+    if output.status.success() {
+        debug!("Grew xfs filesystem on {:?}", dev_path)
+    } else {
+        let message = String::from_utf8_lossy(&output.stderr);
+        debug!("stderr: {}", message);
+        return Err(EngineError::Engine(ErrorEnum::Error, message.into()));
+    }
+    Ok(())
+}
+
 pub fn mount_fs(dev_path: &Path, mount_point: &Path) -> EngineResult<()> {
 
     debug!("Mount filesystem {:?} on : {:?}", dev_path, mount_point);

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -235,7 +235,7 @@ impl StratPool {
         #![allow(match_same_arms)]
         let dm = DM::new().expect("Could not get DM handle");
 
-        if let Err(e) = self.mdv.check() {
+        if let Err(e) = self.mdv.check(&mut self.block_devs) {
             error!("MDV error: {}", e);
             return;
         }


### PR DESCRIPTION
The initial MDV size is 16MiB (~12MiB usable). Given that we're writing a tiny amount per filesystem, it would take a HUGE number of tracked filesystems to require growing the MDV. But, theoretically possible.

This also includes `filesystem::grow_fs`, which may be useful for growing our thin filesystems when the time comes.