### PR TITLE
Change RangeAllocator methods so they return a Result

### DIFF
--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -236,7 +236,8 @@ pub fn initialize(pool_uuid: &PoolUuid,
         }
 
         let bda = bda.expect("!bda.is_err()");
-        let allocator = RangeAllocator::new(bda.dev_size(), &[(Sectors(0), bda.size())]);
+        let allocator = RangeAllocator::new(bda.dev_size(), &[(Sectors(0), bda.size())])
+            .expect("bda.size() < bda.dev_size() and single range");
 
         bds.push(BlockDev::new(dev, devnode, bda, allocator));
     }

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -49,6 +49,9 @@ impl RangeAllocator {
     /// Return an error if ranges overlap with each other or with previously
     /// inserted ranges.
     /// TODO: Make this operation atomic.
+    /// TODO: Consider using a different algorithmic that first sorts ranges
+    /// and then merges used and ranges by traversing them in parallel, for
+    /// efficiency.
     fn insert_ranges(&mut self, ranges: &[(Sectors, Sectors)]) -> EngineResult<()> {
         for &(off, len) in ranges {
             try!(self.check_for_overflow(off, len));

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -103,8 +103,9 @@ impl RangeAllocator {
         Ok(())
     }
 
+    #[allow(dead_code)]
     /// Mark ranges previously marked as used as now unused.
-    pub fn remove_ranges(&mut self, to_free: &[(Sectors, Sectors)]) -> () {
+    fn remove_ranges(&mut self, to_free: &[(Sectors, Sectors)]) -> () {
         for &(off, len) in to_free {
             self.check_for_overflow(off, len);
 

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -8,6 +8,8 @@ use std::collections::BTreeMap;
 
 use devicemapper::Sectors;
 
+use super::super::errors::{EngineError, EngineResult, ErrorEnum};
+
 #[derive(Debug)]
 pub struct RangeAllocator {
     limit: Sectors,
@@ -17,13 +19,15 @@ pub struct RangeAllocator {
 impl RangeAllocator {
     /// Create a new RangeAllocator with the specified (offset, length)
     /// ranges marked as used.
-    pub fn new(limit: Sectors, initial_used: &[(Sectors, Sectors)]) -> RangeAllocator {
+    pub fn new(limit: Sectors,
+               initial_used: &[(Sectors, Sectors)])
+               -> EngineResult<RangeAllocator> {
         let mut allocator = RangeAllocator {
             limit: limit,
             used: BTreeMap::new(),
         };
-        allocator.insert_ranges(initial_used);
-        allocator
+        try!(allocator.insert_ranges(initial_used));
+        Ok(allocator)
     }
 
     fn check_for_overflow(&self, off: Sectors, len: Sectors) {
@@ -32,38 +36,49 @@ impl RangeAllocator {
     }
 
     /// Mark ranges previously marked as unused as now used.
-    fn insert_ranges(&mut self, ranges: &[(Sectors, Sectors)]) -> () {
+    /// Return an error if ranges overlap with each other or with previously
+    /// inserted ranges.
+    /// TODO: Make this operation atomic.
+    fn insert_ranges(&mut self, ranges: &[(Sectors, Sectors)]) -> EngineResult<()> {
         for &(off, len) in ranges {
             self.check_for_overflow(off, len);
 
-            let contig_prev = self.used
+            let prev = self.used
                 .range(..off)
                 .rev()
                 .next()
-                .map(|(k, v)| (*k, *v))
-                .and_then(|(prev_off, prev_len)| {
-                    assert!(off >= prev_off + prev_len,
-                            "given range must not overlap previous range");
-                    if off == prev_off + prev_len {
-                        Some((prev_off, prev_len))
-                    } else {
-                        None
-                    }
-                });
+                .map(|(k, v)| (*k, *v));
 
-            let contig_next = self.used
-                .range(off..)
-                .next()
-                .map(|(k, v)| (*k, *v))
-                .and_then(|(next_off, next_len)| {
-                    assert!(off + len <= next_off,
-                            "given range must not overlap next range");
-                    if off + len == next_off {
-                        Some((next_off, next_len))
-                    } else {
-                        None
-                    }
-                });
+            let mut contig_prev = None;
+            if let Some((prev_off, prev_len)) = prev {
+                if prev_off + prev_len > off {
+                    let err_msg = format!("range starting at {} overlaps previous range ({}, {})",
+                                          off,
+                                          prev_off,
+                                          prev_len);
+                    return Err(EngineError::Engine(ErrorEnum::Invalid, err_msg));
+                }
+                if prev_off + prev_len == off {
+                    contig_prev = Some((prev_off, prev_len))
+                }
+            }
+
+
+            let next = self.used.range(off..).next().map(|(k, v)| (*k, *v));
+
+            let mut contig_next = None;
+            if let Some((next_off, next_len)) = next {
+                if off + len > next_off {
+                    let err_msg = format!("range ({}, {}) overlaps subsequent range starting at {}",
+                                          off,
+                                          len,
+                                          next_off);
+                    return Err(EngineError::Engine(ErrorEnum::Invalid, err_msg));
+                }
+                if off + len == next_off {
+                    contig_next = Some((next_off, next_len))
+                }
+            }
 
             match (contig_prev, contig_next) {
                 (None, None) => {
@@ -85,6 +100,7 @@ impl RangeAllocator {
                 }
             }
         }
+        Ok(())
     }
 
     /// Mark ranges previously marked as used as now unused.
@@ -185,7 +201,8 @@ impl RangeAllocator {
 
             let used_range = (start, to_use);
             segs.push(used_range);
-            self.insert_ranges(&[used_range]);
+            self.insert_ranges(&[used_range])
+                .expect("available ranges must be insertable");
 
             needed = needed - to_use;
         }
@@ -209,12 +226,14 @@ mod tests {
     /// 7. Remove two adjacent ranges of total length 60 sectors.
     /// 8. Verify that number of available sectors is 60, used is 68.
     fn test_allocator_allocations() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         assert_eq!(allocator.used(), Sectors(0));
         assert_eq!(allocator.available(), Sectors(128));
 
-        allocator.insert_ranges(&[(Sectors(10), Sectors(100))]);
+        allocator
+            .insert_ranges(&[(Sectors(10), Sectors(100))])
+            .unwrap();
 
         assert_eq!(allocator.used(), Sectors(100));
         assert_eq!(allocator.available(), Sectors(28));
@@ -237,7 +256,7 @@ mod tests {
         let ranges = [(Sectors(20), Sectors(10)),
                       (Sectors(10), Sectors(10)),
                       (Sectors(30), Sectors(10))];
-        let allocator = RangeAllocator::new(Sectors(128), &ranges);
+        let allocator = RangeAllocator::new(Sectors(128), &ranges).unwrap();
         let used = allocator.used_ranges();
         assert_eq!(used.len(), 1);
         assert_eq!(used[0], (Sectors(10), Sectors(30)));
@@ -246,11 +265,17 @@ mod tests {
     #[test]
     /// Verify insert_ranges properly coalesces adjacent allocations.
     fn test_allocator_insert_ranges_contig() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
-        allocator.insert_ranges(&[(Sectors(20), Sectors(10))]);
-        allocator.insert_ranges(&[(Sectors(10), Sectors(10))]);
-        allocator.insert_ranges(&[(Sectors(30), Sectors(10))]);
+        allocator
+            .insert_ranges(&[(Sectors(20), Sectors(10))])
+            .unwrap();
+        allocator
+            .insert_ranges(&[(Sectors(10), Sectors(10))])
+            .unwrap();
+        allocator
+            .insert_ranges(&[(Sectors(30), Sectors(10))])
+            .unwrap();
 
         let used = allocator.used_ranges();
         assert_eq!(used.len(), 1);
@@ -264,9 +289,11 @@ mod tests {
     /// 3. Removing a range from the middle of an existing range
     /// 4. Removing an entire range
     fn test_allocator_remove_ranges_contig() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
-        allocator.insert_ranges(&[(Sectors(20), Sectors(20))]);
+        allocator
+            .insert_ranges(&[(Sectors(20), Sectors(20))])
+            .unwrap();
 
         allocator.remove_ranges(&[(Sectors(20), Sectors(3))]);
         let used = allocator.used_ranges();
@@ -296,25 +323,23 @@ mod tests {
     fn test_max_allocator_range() {
         use std::u64::MAX;
 
-        RangeAllocator::new(Sectors(MAX), &[]);
+        RangeAllocator::new(Sectors(MAX), &[]).unwrap();
     }
 
     #[test]
-    #[should_panic]
     fn test_allocator_insert_prev_overlap() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         let bad_insert_ranges = [(Sectors(21), Sectors(20)), (Sectors(40), Sectors(40))];
-        allocator.insert_ranges(&bad_insert_ranges)
+        assert!(allocator.insert_ranges(&bad_insert_ranges).is_err())
     }
 
     #[test]
-    #[should_panic]
     fn test_allocator_insert_next_overlap() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         let bad_insert_ranges = [(Sectors(40), Sectors(1)), (Sectors(39), Sectors(2))];
-        allocator.insert_ranges(&bad_insert_ranges)
+        assert!(allocator.insert_ranges(&bad_insert_ranges).is_err())
     }
 
     #[test]
@@ -322,7 +347,7 @@ mod tests {
     /// Verify that remove_ranges() panics if ranges to be removed share
     /// elements.
     fn test_allocator_failures_alloc_overlap() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         let _request = allocator.request(Sectors(128));
 
@@ -331,17 +356,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    /// Verify that insert_ranges() panics when all sectors have already been
+    /// Verify that insert_ranges() errors when all sectors have already been
     /// allocated.
     fn test_allocator_failures_range_overwrite() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         let request = allocator.request(Sectors(128));
         assert_eq!(request.0, Sectors(128));
         assert_eq!(request.1, &[(Sectors(0), Sectors(128))]);
 
-        allocator.insert_ranges(&[(Sectors(1), Sectors(1))]);
+        assert!(allocator
+                    .insert_ranges(&[(Sectors(1), Sectors(1))])
+                    .is_err());
     }
 
     #[test]
@@ -349,9 +375,11 @@ mod tests {
     /// Verify that remove_ranges() panics when an element at the
     /// beginning of the specified range is not in use.
     fn test_allocator_failures_removing_unused_beginning() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
-        allocator.insert_ranges(&[(Sectors(20), Sectors(20))]);
+        allocator
+            .insert_ranges(&[(Sectors(20), Sectors(20))])
+            .unwrap();
         allocator.remove_ranges(&[(Sectors(19), Sectors(2))]);
     }
 
@@ -360,9 +388,11 @@ mod tests {
     /// Verify that remove_ranges() panics when an element at the
     /// end of the specified range is not in use.
     fn test_allocator_failures_removing_unused_end() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
-        allocator.insert_ranges(&[(Sectors(20), Sectors(20))]);
+        allocator
+            .insert_ranges(&[(Sectors(20), Sectors(20))])
+            .unwrap();
         allocator.remove_ranges(&[(Sectors(39), Sectors(2))]);
     }
 
@@ -371,7 +401,7 @@ mod tests {
     /// Verify that remove_ranges() panics when the entire specified
     /// range is not in use.
     fn test_allocator_failures_removing_unused() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         allocator.remove_ranges(&[(Sectors(39), Sectors(2))]);
     }
@@ -381,10 +411,10 @@ mod tests {
     /// Verify that insert_ranges() panics when an element outside the range
     /// limit is requested.
     fn test_allocator_failures_overflow_limit() {
-        let mut allocator = RangeAllocator::new(Sectors(128), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         // overflow limit range
-        allocator.insert_ranges(&[(Sectors(1), Sectors(128))]);
+        let _ = allocator.insert_ranges(&[(Sectors(1), Sectors(128))]);
     }
 
     #[test]
@@ -394,9 +424,9 @@ mod tests {
     fn test_allocator_failures_overflow_max() {
         use std::u64::MAX;
 
-        let mut allocator = RangeAllocator::new(Sectors(MAX), &[]);
+        let mut allocator = RangeAllocator::new(Sectors(MAX), &[]).unwrap();
 
         // overflow max u64
-        allocator.insert_ranges(&[(Sectors(MAX), Sectors(1))]);
+        let _ = allocator.insert_ranges(&[(Sectors(MAX), Sectors(1))]);
     }
 }


### PR DESCRIPTION
The motivation for this is that during setup, RangeAllocators must be instantiated from metadata in order to reconstruct the BlockDevs.