### PR TITLE
Do not store device size in BDA

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -70,7 +70,7 @@ impl BlockDev {
 
     /// The device's size.
     pub fn size(&self) -> Sectors {
-        self.bda.dev_size()
+        self.used.size()
     }
 
     /// Last time metadata was written to this device.

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -210,12 +210,8 @@ pub fn initialize(pool_uuid: &PoolUuid,
     let mut bds = Vec::new();
     for (dev, (devnode, dev_size, mut f)) in add_devs {
 
-        let bda = try!(BDA::initialize(&mut f,
-                                       pool_uuid,
-                                       &Uuid::new_v4(),
-                                       mda_size,
-                                       dev_size.sectors()));
-        let allocator = RangeAllocator::new(bda.dev_size(), &[(Sectors(0), bda.size())]);
+        let bda = try!(BDA::initialize(&mut f, pool_uuid, &Uuid::new_v4(), mda_size));
+        let allocator = RangeAllocator::new(dev_size.sectors(), &[(Sectors(0), bda.size())]);
 
         bds.push(BlockDev::new(dev, devnode, bda, allocator));
     }

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -26,6 +26,10 @@ impl RangeAllocator {
         allocator
     }
 
+    pub fn size(&self) -> Sectors {
+        self.limit
+    }
+
     fn check_for_overflow(&self, off: Sectors, len: Sectors) {
         assert_ne!(off.checked_add(*len), None);
         assert!(off + len <= self.limit, "off+len greater than range limit");


### PR DESCRIPTION
Use the RangeAllocator limit field as our source of this information.

Signed-off-by: mulhern <amulhern@redhat.com>