### PR TITLE
Add a function to obtain BlockDevs from metadata

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -56,7 +56,7 @@ impl BlockDev {
     /// List the available-for-upper-layer-use range in this blockdev.
     pub fn avail_range(&self) -> Segment {
         let start = self.bda.size();
-        let size = self.size();
+        let size = self.current_capacity();
         // Blockdev size is at least MIN_DEV_SIZE, so this can fail only if
         // size of metadata area exceeds 1 GiB. Initial metadata area size
         // is 4 MiB.
@@ -74,9 +74,14 @@ impl BlockDev {
         self.bda.pool_uuid()
     }
 
-    /// The device's size.
-    pub fn size(&self) -> Sectors {
+    /// The size of the device as recorded in the metadata.
+    pub fn recorded_size(&self) -> Sectors {
         self.bda.dev_size()
+    }
+
+    /// The actual size of the device now.
+    pub fn current_capacity(&self) -> Sectors {
+        self.used.capacity()
     }
 
     /// Last time metadata was written to this device.

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -30,6 +30,11 @@ impl RangeAllocator {
         Ok(allocator)
     }
 
+    /// The capacity of this manager
+    pub fn capacity(&self) -> Sectors {
+        self.limit
+    }
+
     fn check_for_overflow(&self, off: Sectors, len: Sectors) -> EngineResult<()> {
         if off.checked_add(*len).is_none() {
             let err_msg = format!("elements in range ({}, {}) inexpressible in u64", off, len);

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -9,16 +9,23 @@ use std::io::ErrorKind;
 use std::fs::{OpenOptions, read_dir};
 use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use nix::Errno;
 use nix::sys::stat::{S_IFBLK, S_IFMT};
 use serde_json;
 
+use devicemapper::Device;
+
 use super::super::errors::{EngineResult, EngineError, ErrorEnum};
 use super::super::types::PoolUuid;
 
-use super::metadata::{BDA, StaticHeader};
+use super::blockdev::BlockDev;
+use super::blockdevmgr::BlockDevMgr;
+use super::device::blkdev_size;
 use super::engine::DevOwnership;
+use super::metadata::{BDA, StaticHeader};
+use super::range_alloc::RangeAllocator;
 use super::serde_structs::PoolSave;
 
 
@@ -181,4 +188,59 @@ pub fn get_pool_metadata(pool_table: &HashMap<PoolUuid, Vec<PathBuf>>)
         }
     }
     Ok(metadata)
+}
+
+/// Instantiate each pool's blockdevs.
+/// Return a map from the pool uuid to the pools blockdevs.
+pub fn get_pool_blockdevs(devnode_table: &HashMap<PoolUuid, Vec<PathBuf>>,
+                          metadata_table: &HashMap<PoolUuid, PoolSave>)
+                          -> EngineResult<HashMap<PoolUuid, BlockDevMgr>> {
+    let mut result = HashMap::new();
+    for (pool_uuid, pool_save) in metadata_table {
+        let segments = pool_save
+            .flex_devs
+            .meta_dev
+            .iter()
+            .chain(pool_save.flex_devs.thin_meta_dev.iter())
+            .chain(pool_save.flex_devs.thin_data_dev.iter());
+
+        let mut segment_table = HashMap::new();
+        for seg in segments {
+            segment_table
+                .entry(seg.0.clone())
+                .or_insert(vec![])
+                .push((seg.1, seg.2))
+        }
+
+        let devnodes = devnode_table
+            .get(&pool_uuid)
+            .expect("devnode_table.keys() == metadata_table.keys()");
+
+        let mut blockdevs = vec![];
+        for dev in devnodes {
+            let bda = try!(BDA::load(&mut try!(OpenOptions::new().read(true).open(dev))));
+            let bda = try!(bda.ok_or(EngineError::Engine(ErrorEnum::NotFound,
+                                                         "no BDA found for Stratis device"
+                                                             .into())));
+
+            let dev_uuid = bda.dev_uuid().simple().to_string();
+
+            let actual_size = try!(blkdev_size(&try!(OpenOptions::new().read(true).open(dev))))
+                .sectors();
+
+            // If size of device has changed and is less, then it is possible
+            // that the segments previously allocated for this blockdev no
+            // longer exist. If that is the case, RangeAllocator::new() will
+            // return an error.
+            let allocator = match segment_table.get(&dev_uuid) {
+                Some(segments) => try!(RangeAllocator::new(actual_size, segments)),
+                None => try!(RangeAllocator::new(actual_size, &vec![])),
+            };
+
+            let device = try!(Device::from_str(&dev.to_string_lossy()));
+            blockdevs.push(BlockDev::new(device, dev.clone(), bda, allocator));
+        }
+        result.insert(pool_uuid.clone(), BlockDevMgr::new(blockdevs));
+    }
+    Ok(result)
 }


### PR DESCRIPTION
This PR adds a function to obtain BlockDevs belonging to a pool from the pool's metadata. It also adds methods to distinguish between two BlockDev sizes, its current capacity and the size that it was recorded to have in the metadata. A difference between these two numbers may be cause for a warning or other action at a later stage.

The function ```get_pool_blockdevs``` is quite conservative. This is correct, but at a future date it might be reasonable to make it less conservative. For example, if any blockdev belonging to any pool can not be instantiated, the entire method returns an error. In future, it might make sense to modify the method so that a failure for one pool's blockdevs still allows it to discover the BlockDevs for other pools. This would allow Stratis to be set up with a subset of the pools it thinks it should have.