### PR TITLE
Resolve workaround and rely on FromIterator

### DIFF
--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -142,24 +142,13 @@ impl BlockDevMgr {
 
 impl Recordable<HashMap<String, BlockDevSave>> for BlockDevMgr {
     fn record(&self) -> EngineResult<HashMap<String, BlockDevSave>> {
-
-        // This function exists to assist the type-checker. The type-checker
-        // was unable to infer the type of the apparently equivalent anonymous
-        // closure in Rust version 1.17.0.
-        fn mapper(bd: &BlockDev) -> EngineResult<(String, BlockDevSave)> {
-            Ok((bd.uuid().simple().to_string(), try!(bd.record())))
-        }
-
-        let mut result: HashMap<String, BlockDevSave> = HashMap::new();
-        for item in self.block_devs.iter().map(mapper) {
-            match item {
-                Ok((uuid, save)) => {
-                    result.insert(uuid, save);
-                }
-                Err(err) => return Err(err),
-            }
-        }
-        Ok(result)
+        self.block_devs
+            .iter()
+            .map(|bd| {
+                     bd.record()
+                         .and_then(|bdsave| Ok((bd.uuid().simple().to_string(), bdsave)))
+                 })
+            .collect()
     }
 }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -320,37 +320,21 @@ impl Recordable<PoolSave> for StratPool {
             Ok((bd.uuid().simple().to_string(), seg.start, seg.length))
         };
 
-        let mut meta_dev = vec![];
-        for item in self.mdv.segments().iter().map(&mapper) {
-            match item {
-                Ok(seg) => meta_dev.push(seg),
-                Err(err) => return Err(err),
-            }
-        }
+        let meta_dev = try!(self.mdv.segments().iter().map(&mapper).collect());
 
-        let mut thin_meta_dev = vec![];
-        for item in self.thin_pool
-                .meta_dev()
-                .segments()
-                .iter()
-                .map(&mapper) {
-            match item {
-                Ok(seg) => thin_meta_dev.push(seg),
-                Err(err) => return Err(err),
-            }
-        }
+        let thin_meta_dev = try!(self.thin_pool
+                                     .meta_dev()
+                                     .segments()
+                                     .iter()
+                                     .map(&mapper)
+                                     .collect());
 
-        let mut thin_data_dev = vec![];
-        for item in self.thin_pool
-                .data_dev()
-                .segments()
-                .iter()
-                .map(&mapper) {
-            match item {
-                Ok(seg) => thin_data_dev.push(seg),
-                Err(err) => return Err(err),
-            }
-        }
+        let thin_data_dev = try!(self.thin_pool
+                                     .data_dev()
+                                     .segments()
+                                     .iter()
+                                     .map(&mapper)
+                                     .collect());
 
         Ok(PoolSave {
                name: self.name.clone(),


### PR DESCRIPTION
I noticed the comment in `BlockDevMgr::record` and spent some time trying to resolve the worked-around issue. This patch also takes advantage of some slick Rust support for turning a `Vec<Result<T>>` into `Result<Vec<T>>` where it will return the first `Err`, or the collection. I found one other spot where this feature helped. Other spots where we have a `Vec<Result<T>>` didn't seem to benefit as much, in my opinion, so I left them.