### PR TITLE
Publish devnode as part of the dbus Filesystem

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -25,6 +25,8 @@ pub trait Filesystem: HasName + HasUuid {
     fn rename(&mut self, name: &str) -> ();
     /// Destroy this filesystem
     fn destroy(self) -> EngineResult<()>;
+    /// path of the device node
+    fn devnode(&self) -> EngineResult<PathBuf>;
 }
 
 pub trait Pool: HasName + HasUuid {

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::path::PathBuf;
 
 use super::super::engine::{HasName, HasUuid, Filesystem};
 use super::super::errors::EngineResult;
@@ -29,6 +30,10 @@ impl Filesystem for SimFilesystem {
 
     fn destroy(self) -> EngineResult<()> {
         Ok(())
+    }
+
+    fn devnode(&self) -> EngineResult<PathBuf> {
+        Ok(PathBuf::from(format!("/dev/stratis/{}", self.name)))
     }
 }
 

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -5,7 +5,7 @@ extern crate rand;
 
 use std::error::Error;
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use devicemapper::DM;
@@ -98,6 +98,10 @@ impl Filesystem for StratFilesystem {
             Ok(_) => Ok(()),
             Err(e) => Err(EngineError::Engine(ErrorEnum::Error, e.description().into())),
         }
+    }
+
+    fn devnode(&self) -> EngineResult<PathBuf> {
+        Ok(try!(self.thin_dev.devnode()))
     }
 }
 


### PR DESCRIPTION
API users will need to know which devnode to use to
mount the filesystem.

Signed-off-by: Todd Gill <tgill@redhat.com>