### PR TITLE
Have StratPool::initialize also return the device nodes it used

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -96,12 +96,12 @@ impl Engine for StratEngine {
         }
 
         let dm = try!(DM::new());
-        let pool = try!(StratPool::initialize(name, &dm, blockdev_paths, redundancy, force));
-        let bdev_devnodes = pool.block_devs.devnodes();
+        let (pool, devnodes) =
+            try!(StratPool::initialize(name, &dm, blockdev_paths, redundancy, force));
 
         let uuid = pool.uuid().clone();
         self.pools.insert(pool);
-        Ok((uuid, bdev_devnodes))
+        Ok((uuid, devnodes))
     }
 
     fn destroy_pool(&mut self, uuid: &PoolUuid) -> EngineResult<bool> {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -52,7 +52,7 @@ const INITIAL_MDV_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
 pub struct StratPool {
     name: String,
     pool_uuid: PoolUuid,
-    pub block_devs: BlockDevMgr,
+    block_devs: BlockDevMgr,
     pub filesystems: Table<StratFilesystem>,
     redundancy: Redundancy,
     thin_pool: ThinPoolDev,
@@ -70,7 +70,7 @@ impl StratPool {
                       paths: &[&Path],
                       redundancy: Redundancy,
                       force: bool)
-                      -> EngineResult<StratPool> {
+                      -> EngineResult<(StratPool, Vec<PathBuf>)> {
         let pool_uuid = Uuid::new_v4();
 
         let mut block_mgr =
@@ -135,6 +135,8 @@ impl StratPool {
 
         let mdv = try!(StratPool::setup_mdv(dm, pool_uuid, mdv_regions));
 
+        let devnodes = block_mgr.devnodes();
+
         let mut pool = StratPool {
             name: name.to_owned(),
             pool_uuid: pool_uuid,
@@ -149,7 +151,7 @@ impl StratPool {
 
         try!(pool.write_metadata());
 
-        Ok(pool)
+        Ok((pool, devnodes))
     }
 
     /// Setup a StratPool using its UUID and the list of devnodes it has.

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -26,11 +26,11 @@ use libstratis::engine::types::Redundancy;
 /// than are initially allocated to the pool, the pool must have been expanded.
 pub fn test_thinpool_expand(paths: &[&Path]) -> () {
     StratEngine::initialize().unwrap();
-    let mut pool = StratPool::initialize("stratis_test_pool",
-                                         &DM::new().unwrap(),
-                                         paths,
-                                         Redundancy::NONE,
-                                         true)
+    let (mut pool, _) = StratPool::initialize("stratis_test_pool",
+                                              &DM::new().unwrap(),
+                                              paths,
+                                              Redundancy::NONE,
+                                              true)
             .unwrap();
     let &(_, fs_uuid) = pool.create_filesystems(&vec!["stratis_test_filesystem"])
         .unwrap()


### PR DESCRIPTION
This is tidier because it aligns initialize() better with add() and also
because it allows us to make one more field private and also because it
aligns StratPool::initialize() better with StratEngine::initialize().

Signed-off-by: mulhern <amulhern@redhat.com>