### PR TITLE
Extend testing to test saving and restoring of metadata

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -66,6 +66,11 @@ impl StratEngine {
         }
         Ok(())
     }
+
+    /// Get pool as StratPool
+    pub fn get_strat_pool(&self, uuid: &PoolUuid) -> Option<&StratPool> {
+        self.pools.get_by_uuid(uuid)
+    }
 }
 
 impl Engine for StratEngine {

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -11,7 +11,7 @@ pub mod metadata;
 mod mdv;
 pub mod filesystem;
 mod pool;
-mod serde_structs;
+pub mod serde_structs;
 pub mod setup;
 mod range_alloc;
 

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -29,7 +29,7 @@ pub trait Recordable<T> {
     fn record(&self) -> EngineResult<T>;
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolSave {
     pub name: String,
     pub block_devs: HashMap<DevUuid, BlockDevSave>,
@@ -37,12 +37,12 @@ pub struct PoolSave {
     pub thinpool_dev: ThinPoolDevSave,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockDevSave {
     pub devnode: PathBuf,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FilesystemSave {
     pub name: String,
     pub uuid: FilesystemUuid,
@@ -50,14 +50,14 @@ pub struct FilesystemSave {
     pub size: Sectors,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FlexDevsSave {
     pub meta_dev: Vec<(Uuid, Sectors, Sectors)>,
     pub thin_meta_dev: Vec<(Uuid, Sectors, Sectors)>,
     pub thin_data_dev: Vec<(Uuid, Sectors, Sectors)>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ThinPoolDevSave {
     pub data_block_size: Sectors,
 }

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -32,7 +32,7 @@ use libstratis::engine::strat_engine::filesystem::{create_fs, mount_fs, unmount_
 use libstratis::engine::strat_engine::metadata::{StaticHeader, BDA_STATIC_HDR_SECTORS,
                                                  MIN_MDA_SECTORS};
 use libstratis::engine::strat_engine::serde_structs::Recordable;
-use libstratis::engine::strat_engine::setup::{find_all, get_metadata};
+use libstratis::engine::strat_engine::setup::{find_all, get_blockdevmgr, get_metadata};
 use libstratis::engine::strat_engine::StratEngine;
 
 /// Dirty sectors where specified, with 1s.
@@ -340,20 +340,24 @@ pub fn test_basic_metadata(paths: &[&Path]) {
 
     let pools = find_all().unwrap();
     assert!(pools.len() == 2);
-    assert!(get_metadata(&uuid1, pools.get(&uuid1).unwrap())
-                .unwrap()
-                .unwrap() == metadata1);
-    assert!(get_metadata(&uuid2, pools.get(&uuid2).unwrap())
-                .unwrap()
-                .unwrap() == metadata2);
+    let devnodes1 = pools.get(&uuid1).unwrap();
+    let devnodes2 = pools.get(&uuid2).unwrap();
+    let pool_save1 = get_metadata(&uuid1, devnodes1).unwrap().unwrap();
+    let pool_save2 = get_metadata(&uuid2, devnodes2).unwrap().unwrap();
+    assert!(pool_save1 == metadata1);
+    assert!(pool_save2 == metadata2);
+    assert!(get_blockdevmgr(&pool_save1, devnodes1).is_ok());
+    assert!(get_blockdevmgr(&pool_save2, devnodes2).is_ok());
 
     engine.teardown().unwrap();
     let pools = find_all().unwrap();
     assert!(pools.len() == 2);
-    assert!(get_metadata(&uuid1, pools.get(&uuid1).unwrap())
-                .unwrap()
-                .unwrap() == metadata1);
-    assert!(get_metadata(&uuid2, pools.get(&uuid2).unwrap())
-                .unwrap()
-                .unwrap() == metadata2);
+    let devnodes1 = pools.get(&uuid1).unwrap();
+    let devnodes2 = pools.get(&uuid2).unwrap();
+    let pool_save1 = get_metadata(&uuid1, devnodes1).unwrap().unwrap();
+    let pool_save2 = get_metadata(&uuid2, devnodes2).unwrap().unwrap();
+    assert!(pool_save1 == metadata1);
+    assert!(pool_save2 == metadata2);
+    assert!(get_blockdevmgr(&pool_save1, devnodes1).is_ok());
+    assert!(get_blockdevmgr(&pool_save2, devnodes2).is_ok());
 }


### PR DESCRIPTION
The goal is to allow better testing of the saving and reading of variable length metadata. To this end, a simple method has been added to the StratEngine public API.