### PR TITLE
Get rid of a stray 'extern' directive

### DIFF
--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -1,12 +1,13 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-extern crate rand;
 
 use std::error::Error;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+use rand;
 
 use devicemapper::DM;
 use devicemapper::Bytes;


### PR DESCRIPTION
We already indicate that rand is external at top level.

Signed-off-by: mulhern <amulhern@redhat.com>