### PR TITLE
Get filesystems in pools during setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "devicemapper 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "devicemapper 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -450,7 +450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc1914fae6f18ae347320f0ba5e4fc270e17c037ea621fe41ec7e8adf67d11b0"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4aee01fb76ada3e5e7ca642ea6664ebf7308a810739ca2aca44909a1191ac254"
-"checksum devicemapper 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e93e2f324e021017aaa094d20f92c712f1cc1e8d0b7d26f033f03ff975a46409"
+"checksum devicemapper 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "44d3ebfb3137b84c080069416f65fcc23dc9bf7be35fbece231469043a7836e8"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "406ac2a8c9eedf8af9ee1489bee9e50029278a6456c740f7454cf8a158abc816"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -17,7 +17,7 @@ use super::super::structures::Table;
 use super::super::types::{PoolUuid, Redundancy, RenameAction};
 
 use super::pool::StratPool;
-use super::setup::{find_all, get_blockdevs, get_dmdevs, get_metadata};
+use super::setup::{find_all, get_blockdevs, get_dmdevs, get_filesystems, get_metadata};
 
 pub const DEV_PATH: &'static str = "/dev/stratis";
 
@@ -50,7 +50,8 @@ impl StratEngine {
                                                                 format!("no metadata for pool {}",
                                                                         pool_uuid))));
             let blockdevs = try!(get_blockdevs(&pool_save, devices));
-            let (_, _) = try!(get_dmdevs(pool_uuid, &blockdevs, &pool_save));
+            let (thinpool, mdv) = try!(get_dmdevs(pool_uuid, &blockdevs, &pool_save));
+            let _ = try!(get_filesystems(pool_uuid, &thinpool, &mdv));
         }
         if !pools.is_empty() {
             let err_msg = "Stratis was already run once, can not yet reconstruct state";

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -7,11 +7,9 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use rand;
-
 use devicemapper::DM;
-use devicemapper::Bytes;
-use devicemapper::{ThinDev, ThinStatus};
+use devicemapper::{Bytes, Sectors};
+use devicemapper::{ThinDev, ThinDevId, ThinStatus};
 use devicemapper::ThinPoolDev;
 
 use super::super::consts::IEC;
@@ -37,29 +35,39 @@ pub enum FilesystemStatus {
 impl StratFilesystem {
     pub fn initialize(pool_id: &PoolUuid,
                       fs_id: FilesystemUuid,
+                      thin_id: ThinDevId,
                       name: &str,
                       dm: &DM,
                       thin_pool: &ThinPoolDev)
                       -> EngineResult<StratFilesystem> {
-        // TODO should replace with proper id generation. DM takes a 24 bit
-        // number for the thin_id.  Generate a u16 to avoid the possibility of
-        // "too big". Should this be moved into the DM binding (or lower)?
-        // How can a client be expected to avoid collisions?
-        let thin_id = rand::random::<u16>();
-        let device_name = format_thin_name(pool_id, ThinRole::Filesystem(fs_id));
-        // TODO We don't require a size to be provided for create_filesystems -
-        // but devicemapper requires an initial size for a thin provisioned
-        // device - currently hard coded to 1GB.
-        let new_thin_dev = try!(ThinDev::new(&device_name,
+        let fs = try!(StratFilesystem::setup(pool_id,
+                                             fs_id,
+                                             thin_id,
+                                             name,
+                                             Bytes(IEC::Ti).sectors(),
                                              dm,
-                                             thin_pool,
-                                             thin_id as u32,
-                                             Bytes(IEC::Ti).sectors()));
-        try!(create_fs(try!(new_thin_dev.devnode()).as_path()));
+                                             thin_pool));
+        try!(create_fs(try!(fs.devnode()).as_path()));
+        Ok(fs)
+    }
+
+    /// Setup a filesystem, setting up the thin device as necessary.
+    // FIXME: Check for still existing device mapper devices.
+    pub fn setup(pool_uuid: &PoolUuid,
+                 fs_id: FilesystemUuid,
+                 thindev_id: ThinDevId,
+                 name: &str,
+                 size: Sectors,
+                 dm: &DM,
+                 thin_pool: &ThinPoolDev)
+                 -> EngineResult<StratFilesystem> {
+        let device_name = format_thin_name(pool_uuid, ThinRole::Filesystem(fs_id));
+        let thin_dev = try!(ThinDev::setup(&device_name, dm, thin_pool, thindev_id, size));
+
         Ok(StratFilesystem {
                fs_id: fs_id,
                name: name.to_owned(),
-               thin_dev: new_thin_dev,
+               thin_dev: thin_dev,
            })
     }
 

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -133,7 +133,6 @@ impl MetadataVol {
         Ok(())
     }
 
-    #[allow(dead_code)]
     /// Get list of filesystems stored on the MDV.
     pub fn filesystems(&self) -> EngineResult<Vec<FilesystemSave>> {
         let mut filesystems = Vec::new();

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -9,14 +9,16 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::vec::Vec;
 
+use rand::random;
+use serde_json;
+use time::now;
+use uuid::Uuid;
+
 use devicemapper::consts::SECTOR_SIZE;
 use devicemapper::DM;
 use devicemapper::{DataBlocks, Sectors, Segment};
 use devicemapper::LinearDev;
-use devicemapper::{ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
-use time::now;
-use uuid::Uuid;
-use serde_json;
+use devicemapper::{ThinDevId, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
 
 use super::super::consts::IEC::Mi;
 use super::super::engine::{Filesystem, HasName, HasUuid, Pool};
@@ -264,8 +266,13 @@ impl Pool for StratPool {
         let mut result = Vec::new();
         for name in names.iter() {
             let uuid = Uuid::new_v4();
+            // FIXME: Start managing thin ids in pool.
+            let thin_id =
+                ThinDevId::new_u64((random::<u32>() >> 8) as u64)
+                    .expect("must require only 24 bits");
             let new_filesystem = try!(StratFilesystem::initialize(&self.pool_uuid,
                                                                   uuid,
+                                                                  thin_id,
                                                                   name,
                                                                   &dm,
                                                                   &mut self.thin_pool));

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 
 use uuid::Uuid;
 
-use devicemapper::Sectors;
+use devicemapper::{Sectors, ThinDevId};
 
 use super::super::errors::EngineResult;
 use super::super::types::{DevUuid, FilesystemUuid};
@@ -46,7 +46,7 @@ pub struct BlockDevSave {
 pub struct FilesystemSave {
     pub name: String,
     pub uuid: FilesystemUuid,
-    pub thin_id: u32,
+    pub thin_id: ThinDevId,
     pub size: Sectors,
 }
 

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -32,7 +32,8 @@ use libstratis::engine::strat_engine::filesystem::{create_fs, mount_fs, unmount_
 use libstratis::engine::strat_engine::metadata::{StaticHeader, BDA_STATIC_HDR_SECTORS,
                                                  MIN_MDA_SECTORS};
 use libstratis::engine::strat_engine::serde_structs::Recordable;
-use libstratis::engine::strat_engine::setup::{find_all, get_blockdevs, get_dmdevs, get_metadata};
+use libstratis::engine::strat_engine::setup::{find_all, get_blockdevs, get_dmdevs,
+                                              get_filesystems, get_metadata};
 use libstratis::engine::strat_engine::StratEngine;
 
 /// Dirty sectors where specified, with 1s.
@@ -367,8 +368,14 @@ pub fn test_basic_metadata(paths: &[&Path]) {
     assert!(blockdevs2.len() == pool_save2.block_devs.len());
 
     // These should work, under the assumption of a clean teardown.
-    let (tp1, _) = get_dmdevs(&uuid1, &blockdevs1, &pool_save1).unwrap();
-    let (tp2, _) = get_dmdevs(&uuid2, &blockdevs2, &pool_save2).unwrap();
+    let (tp1, mdv1) = get_dmdevs(&uuid1, &blockdevs1, &pool_save1).unwrap();
+    let (tp2, mdv2) = get_dmdevs(&uuid2, &blockdevs2, &pool_save2).unwrap();
     assert!(tp1.name().contains(&uuid1.simple().to_string()));
     assert!(tp2.name().contains(&uuid2.simple().to_string()));
+
+    let filesystems1 = get_filesystems(&uuid1, &tp1, &mdv1).unwrap();
+    assert!(filesystems1.is_empty());
+
+    let filesystems2 = get_filesystems(&uuid2, &tp2, &mdv2).unwrap();
+    assert!(filesystems2.is_empty());
 }

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -18,7 +18,7 @@ use self::devicemapper::consts::SECTOR_SIZE;
 use self::devicemapper::LinearDev;
 use self::devicemapper::Segment;
 use self::devicemapper::{DataBlocks, Sectors};
-use self::devicemapper::ThinDev;
+use self::devicemapper::{ThinDev, ThinDevId};
 use self::devicemapper::ThinPoolDev;
 
 use self::tempdir::TempDir;
@@ -186,7 +186,7 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
     let thin_dev = ThinDev::new("stratis_testing_thindev",
                                 &dm,
                                 &thinpool_dev,
-                                7,
+                                ThinDevId::new_u64(7).expect("7 is small enough"),
                                 Sectors(300000))
             .unwrap();
 


### PR DESCRIPTION
* Pull in changes from new version of devicemapper
* Factor out filesystem initialization into a separate setup step
* Make pool generate the thin id, since it has to manage it.