### PR TITLE
Change real space backing thin devs to 1 GiB

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -37,7 +37,7 @@ const META_LOWATER: u64 = 512;
 const DATA_LOWATER: DataBlocks = DataBlocks(512);
 
 const INITIAL_META_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
-const INITIAL_DATA_SIZE: Sectors = Sectors(512 * Mi / SECTOR_SIZE as u64);
+const INITIAL_DATA_SIZE: Sectors = Sectors(768 * Mi / SECTOR_SIZE as u64);
 const INITIAL_MDV_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
 
 #[derive(Debug)]


### PR DESCRIPTION
Updated the initial size of real space allocated to back
a thin pool to 768 MiB.  Stratis currently gives thin devices a
virtual size of 1 TiB.  The XFS filesystem consumes ~547 MiB for
meta data when provisioned over a 1 TiB device.  If the
INITIAL_DATA_SIZE is only 512 MiB, Stratis will need to extend the
pool as the filesystem is writing the meta data.  Thin pool
expansion is not yet in place.  This update will allow provisioning
XFS without running out of real space in the pool.
