### PR TITLE
Get rid of a TODO which is certainly in the wrong place

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -137,7 +137,6 @@ impl StratPool {
         let data_dev = try!(LinearDev::new(&device_name, dm, data_segs));
 
         let device_name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
-        // TODO Fix hard coded data blocksize and low water mark.
         Ok(try!(ThinPoolDev::new(&device_name,
                                  dm,
                                  try!(data_dev.size()),


### PR DESCRIPTION
At this point, the values, although hard-coded are not literals, they're
constants, defined elsewhere. There is an issue for the problem:
https://github.com/stratis-storage/stratisd/issues/259. We can remove the
TODO.

Signed-off-by: mulhern <amulhern@redhat.com>