### PR TITLE
Move cleanup code into a separate module

### DIFF
--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Code to handle cleanup after a failed operation.
+
+
+use super::super::errors::{EngineResult, EngineError, ErrorEnum};
+
+use super::blockdev::BlockDev;
+
+/// Wipe a Vec of blockdevs of their identifying headers.
+/// Return an error if any of the blockdevs could not be wiped.
+/// If an error occurs while wiping a blockdev, attempt to wipe all remaining.
+pub fn wipe_blockdevs(mut blockdevs: Vec<BlockDev>) -> EngineResult<()> {
+    let mut unerased_devnodes = Vec::new();
+
+    for bd in blockdevs.drain(..) {
+        let bd_devnode = bd.devnode.clone();
+        bd.wipe_metadata()
+            .unwrap_or_else(|_| unerased_devnodes.push(bd_devnode));
+    }
+
+    if unerased_devnodes.is_empty() {
+        Ok(())
+    } else {
+        let err_msg = format!("Failed to wipe already initialized devnodes: {:?}",
+                              unerased_devnodes);
+        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
+    }
+}

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -4,6 +4,7 @@
 
 mod blockdev;
 pub mod blockdevmgr;
+mod cleanup;
 pub mod device;
 pub mod dmdevice;
 pub mod engine;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -70,7 +70,10 @@ impl StratPool {
 
         if block_mgr.avail_space() < StratPool::min_initial_size() {
             let avail_size = block_mgr.avail_space().bytes();
-            try!(block_mgr.destroy_all());
+
+            // TODO: check the return value and update state machine on failure
+            let _ = block_mgr.destroy_all();
+
             return Err(EngineError::Engine(ErrorEnum::Invalid,
                                            format!("Space on pool must be at least {} bytes, \
                                                    available space is only {} bytes",


### PR DESCRIPTION
There will be very much more as time goes on.

Use newly created wipe_blockdevs() method where appropriate.

Tidy up some cleanup code adding TODOs where appropriate.

Signed-off-by: mulhern <amulhern@redhat.com>