### PR TITLE
Run thin_repair

### DIFF
--- a/src/engine/strat_engine/dmdevice.rs
+++ b/src/engine/strat_engine/dmdevice.rs
@@ -15,6 +15,7 @@ pub enum FlexRole {
     MetadataVolume,
     ThinData,
     ThinMeta,
+    ThinMetaSpare,
 }
 
 impl Display for FlexRole {
@@ -23,6 +24,7 @@ impl Display for FlexRole {
             FlexRole::MetadataVolume => write!(f, "mdv"),
             FlexRole::ThinData => write!(f, "thindata"),
             FlexRole::ThinMeta => write!(f, "thinmeta"),
+            FlexRole::ThinMetaSpare => write!(f, "thinmetaspare"),
         }
     }
 }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -50,7 +50,8 @@ impl StratEngine {
                                                                 format!("no metadata for pool {}",
                                                                         pool_uuid))));
             let blockdevs = try!(get_blockdevs(&pool_save, devices));
-            let (thinpool, mdv) = try!(get_dmdevs(pool_uuid, &blockdevs, &pool_save));
+            let (thinpool, mdv, spare_meta_segs) =
+                try!(get_dmdevs(pool_uuid, &blockdevs, &pool_save));
             let _ = try!(get_filesystems(pool_uuid, &thinpool, &mdv));
         }
         if !pools.is_empty() {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -363,6 +363,8 @@ impl Recordable<PoolSave> for StratPool {
                                      .map(&mapper)
                                      .collect());
 
+        let thin_meta_dev_spare = try!(self.thin_pool_meta_spare.iter().map(&mapper).collect());
+
         Ok(PoolSave {
                name: self.name.clone(),
                block_devs: try!(self.block_devs.record()),
@@ -370,6 +372,7 @@ impl Recordable<PoolSave> for StratPool {
                    meta_dev: meta_dev,
                    thin_meta_dev: thin_meta_dev,
                    thin_data_dev: thin_data_dev,
+                   thin_meta_dev_spare: thin_meta_dev_spare,
                },
                thinpool_dev: ThinPoolDevSave { data_block_size: self.thin_pool.data_block_size() },
            })

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -55,6 +55,7 @@ pub struct FlexDevsSave {
     pub meta_dev: Vec<(Uuid, Sectors, Sectors)>,
     pub thin_meta_dev: Vec<(Uuid, Sectors, Sectors)>,
     pub thin_data_dev: Vec<(Uuid, Sectors, Sectors)>,
+    pub thin_meta_dev_spare: Vec<(Uuid, Sectors, Sectors)>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
If ThinPoolDev::setup fails due to CheckFailed, run thin_repair. If that
succeeds then swap meta and meta_spare and continue.

Some work here to track meta_spare segments in on-disk metadata.

Relies on some dm-rs changes to expose device rename, as well as returning
moved lineardevs in CheckFailed error so we can try again.

Signed-off-by: Andy Grover <agrover@redhat.com>