### PR TITLE
Add thin pool expansion when a thin-dev exceeds the low water mark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "devicemapper 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "devicemapper 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -530,7 +530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc1914fae6f18ae347320f0ba5e4fc270e17c037ea621fe41ec7e8adf67d11b0"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4aee01fb76ada3e5e7ca642ea6664ebf7308a810739ca2aca44909a1191ac254"
-"checksum devicemapper 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b639c09dcbd5bdfe686aa247f8c46da6238ce721535099b88fbf133ec16be9a0"
+"checksum devicemapper 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "fb8fb39ec41a4f332867ff00cfab11e7d86a8ac5fa39456746cc71357551e9ae"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "406ac2a8c9eedf8af9ee1489bee9e50029278a6456c740f7454cf8a158abc816"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ fmt: ${HOME}/.cargo/bin/cargo-fmt
 build:
 	RUSTFLAGS='-D warnings' cargo build
 
-# Tests are in order of complexity, from least to greatest.
 test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_empty_pool
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_force_flag_dirty
@@ -24,7 +23,6 @@ test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_setup
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_thinpool_expand
 
-# Tests are in order of complexity, from least to greatest.
 test-real:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_empty_pool
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_force_flag_dirty

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_initialize
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_basic_metadata
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_setup
-
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_thinpool_expand
 
 # Tests are in order of complexity, from least to greatest.
 test-real:
@@ -36,6 +36,7 @@ test-real:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_initialize
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_basic_metadata
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_setup
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_thinpool_expand
 
 test:
 	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -34,4 +34,4 @@ mod engine;
 mod errors;
 mod sim_engine;
 mod structures;
-mod types;
+pub mod types;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -43,8 +43,7 @@ use super::setup::{get_blockdevs, get_metadata};
 
 const DATA_BLOCK_SIZE: Sectors = Sectors(2048);
 const META_LOWATER: u64 = 512;
-const DATA_LOWATER: DataBlocks = DataBlocks(512);
-
+pub const DATA_LOWATER: DataBlocks = DataBlocks(512);
 const INITIAL_META_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
 const INITIAL_DATA_SIZE: Sectors = Sectors(768 * Mi / SECTOR_SIZE as u64);
 const INITIAL_MDV_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
@@ -212,6 +211,25 @@ impl StratPool {
         self.block_devs
             .save_state(&now().to_timespec(), data.as_bytes())
     }
+    /// Return an extend size for the physical space backing a pool
+    /// TODO: returning the current size will double the space provisoned to
+    /// back the pool.  We should determine if this is a reasonable value.
+    fn extend_size(&self, current_size: Sectors) -> Sectors {
+        current_size
+    }
+
+    /// Expand the physical space allocated to a pool by the value from extend_size()
+    /// Return tne number of Sectors added
+    fn extend_data(&mut self, dm: &DM, current_size: Sectors) -> EngineResult<Sectors> {
+        let extend_size = self.extend_size(current_size);
+        if let Some(new_data_regions) = self.block_devs.alloc_space(extend_size) {
+            try!(self.thin_pool.extend_data(dm, new_data_regions));
+        } else {
+            return Err(EngineError::Engine(ErrorEnum::Error,
+                                           format!("No free data regions for pool expansion")));
+        }
+        Ok(extend_size)
+    }
 
     pub fn check(&mut self) -> () {
         #![allow(match_same_arms)]
@@ -255,7 +273,11 @@ impl StratPool {
                 }
 
                 if usage.used_data > usage.total_data - DATA_LOWATER {
-                    // TODO: Extend data device
+                    // Request expansion of physical space allocated to the pool
+                    match self.extend_data(&dm, usage.total_data.0 * DATA_BLOCK_SIZE) {
+                        Ok(_) => {}
+                        Err(_) => {} // TODO: Take pool offline?
+                    }
                 }
             }
             ThinPoolStatus::Fail => {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -41,11 +41,11 @@ use super::metadata::MIN_MDA_SECTORS;
 use super::serde_structs::{FilesystemSave, FlexDevsSave, PoolSave, Recordable, ThinPoolDevSave};
 use super::setup::{get_blockdevs, get_metadata};
 
-const DATA_BLOCK_SIZE: Sectors = Sectors(2048);
+pub const DATA_BLOCK_SIZE: Sectors = Sectors(2048);
 const META_LOWATER: u64 = 512;
 pub const DATA_LOWATER: DataBlocks = DataBlocks(512);
 const INITIAL_META_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
-const INITIAL_DATA_SIZE: Sectors = Sectors(768 * Mi / SECTOR_SIZE as u64);
+pub const INITIAL_DATA_SIZE: Sectors = Sectors(768 * Mi / SECTOR_SIZE as u64);
 const INITIAL_MDV_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
 
 #[derive(Debug)]

--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -29,6 +29,7 @@ use util::blockdev_tests::test_force_flag_stratis;
 use util::blockdev_tests::test_pool_blockdevs;
 use util::dm_tests::test_thinpool_device;
 use util::dm_tests::test_linear_device;
+use util::pool_tests::test_thinpool_expand;
 use util::setup_tests::test_basic_metadata;
 use util::setup_tests::test_initialize;
 use util::setup_tests::test_setup;
@@ -140,6 +141,10 @@ pub fn loop_test_thinpool_device() {
     test_with_spec(3, test_thinpool_device);
 }
 
+#[test]
+pub fn loop_test_thinpool_expand() {
+    test_with_spec(3, test_thinpool_expand);
+}
 
 #[test]
 pub fn loop_test_pool_blockdevs() {

--- a/tests/real_tests.rs
+++ b/tests/real_tests.rs
@@ -26,6 +26,7 @@ use util::blockdev_tests::test_force_flag_stratis;
 use util::blockdev_tests::test_pool_blockdevs;
 use util::dm_tests::test_thinpool_device;
 use util::dm_tests::test_linear_device;
+use util::pool_tests::test_thinpool_expand;
 use util::setup_tests::test_basic_metadata;
 use util::setup_tests::test_initialize;
 use util::setup_tests::test_setup;
@@ -108,6 +109,11 @@ pub fn real_test_linear_device() {
 #[test]
 pub fn real_test_thinpool_device() {
     test_with_spec(3, test_thinpool_device);
+}
+
+#[test]
+pub fn real_test_thinpool_expand() {
+    test_with_spec(3, test_thinpool_expand);
 }
 
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod blockdev_tests;
 pub mod dm_tests;
+pub mod pool_tests;
 pub mod setup_tests;
 pub mod simple_tests;
 pub mod logger;

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Test the functionality of stratis pools.
+extern crate devicemapper;
+extern crate env_logger;
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use self::devicemapper::DM;
+use self::devicemapper::Sectors;
+use self::devicemapper::consts::SECTOR_SIZE;
+
+use libstratis::engine::Pool;
+use libstratis::engine::strat_engine::pool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE,
+                                             StratPool};
+use libstratis::engine::strat_engine::StratEngine;
+use libstratis::engine::types::Redundancy;
+
+/// Verify that a the physical space allocated to a pool is expanded when
+/// the nuber of sectors written to a thin-dev in the pool exceeds the
+/// INITIAL_DATA_SIZE.  If we are able to write more sectors to the filesystem
+/// than are initially allocated to the pool, the pool must have been expanded.
+pub fn test_thinpool_expand(paths: &[&Path]) -> () {
+    StratEngine::initialize().unwrap();
+    let mut pool = StratPool::initialize("stratis_test_pool",
+                                         &DM::new().unwrap(),
+                                         paths,
+                                         Redundancy::NONE,
+                                         true)
+            .unwrap();
+    let &(_, fs_uuid) = pool.create_filesystems(&vec!["stratis_test_filesystem"])
+        .unwrap()
+        .first()
+        .unwrap();
+
+    let devnode = pool.get_filesystem(&fs_uuid)
+        .unwrap()
+        .devnode()
+        .unwrap();
+    // Braces to ensure f is closed before destroy
+    {
+        let mut f = OpenOptions::new().write(true).open(devnode).unwrap();
+        // Write 1 more sector than is initially allocated to a pool
+        let write_size = INITIAL_DATA_SIZE + Sectors(1);
+        let buf = &[1u8; SECTOR_SIZE];
+        for i in 0..*write_size {
+            f.write_all(buf).unwrap();
+            // Simulate handling a DM event by running a pool check at the point where
+            // the amount of free space in pool has decreased to the DATA_LOWATER value.
+            // TODO: Actually handle DM events and possibly call extend() directly,
+            // depending on the specificity of the events.
+            if i == *(INITIAL_DATA_SIZE - Sectors(*DATA_LOWATER * *DATA_BLOCK_SIZE)) {
+                pool.check();
+            }
+        }
+    }
+    pool.destroy_filesystems(&[&fs_uuid]).unwrap();
+    pool.teardown().unwrap();
+}


### PR DESCRIPTION
Attempt to expand the physical space allocated behind a thin-pool when filesystem
space consumption exceeds the low water mark.

Add tests for expansion.

Remove obsolete comments from Makefile about test order/complexity.
