### PR TITLE
Put devicemapper use directive below other crate use directives

### DIFF
--- a/src/engine/errors.rs
+++ b/src/engine/errors.rs
@@ -7,10 +7,11 @@ use std::fmt;
 use std::error;
 use std::str;
 
-use devicemapper;
 use nix;
 use uuid;
 use serde_json;
+
+use devicemapper;
 
 #[derive(Debug, Clone)]
 pub enum ErrorEnum {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -7,10 +7,9 @@
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 
-use devicemapper::Device;
-use devicemapper::Segment;
-use devicemapper::Sectors;
 use time::Timespec;
+
+use devicemapper::{Device, Sectors, Segment};
 
 use super::super::errors::EngineResult;
 use super::super::types::{DevUuid, PoolUuid};

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -10,9 +10,10 @@ use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use devicemapper::{Bytes, Device, Sectors, Segment};
 use time::Timespec;
 use uuid::Uuid;
+
+use devicemapper::{Bytes, Device, Sectors, Segment};
 
 use super::super::consts::IEC;
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -7,9 +7,9 @@ use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
-use devicemapper::DM;
 use uuid::Uuid;
 
+use devicemapper::DM;
 
 use super::super::engine::{Engine, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -12,9 +12,10 @@ use std::io::prelude::*;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 
-use devicemapper::{LinearDev, DM, Segment};
-use serde_json;
 use nix::unistd::fsync;
+use serde_json;
+
+use devicemapper::{DM, LinearDev, Segment};
 
 use super::super::engine::HasUuid;
 use super::super::errors::EngineResult;

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -10,10 +10,11 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use byteorder::ByteOrder;
 use byteorder::LittleEndian;
 use crc::crc32;
-use devicemapper::{Bytes, Sectors};
-use devicemapper::consts::SECTOR_SIZE;
 use time::Timespec;
 use uuid::Uuid;
+
+use devicemapper::{Bytes, Sectors};
+use devicemapper::consts::SECTOR_SIZE;
 
 use super::super::consts::IEC;
 use super::super::errors::{EngineResult, EngineError, ErrorEnum};

--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -15,9 +15,10 @@ use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
-use devicemapper::{Bytes, Sectors};
 use loopdev::{LoopControl, LoopDevice};
 use tempdir::TempDir;
+
+use devicemapper::{Bytes, Sectors};
 
 use libstratis::engine::IEC;
 use libstratis::engine::strat_engine::device::wipe_sectors;

--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -13,16 +13,15 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use self::tempdir::TempDir;
+use self::uuid::Uuid;
+
 use self::devicemapper::DM;
-use self::devicemapper::consts::SECTOR_SIZE;
 use self::devicemapper::LinearDev;
 use self::devicemapper::Segment;
 use self::devicemapper::{DataBlocks, Sectors};
-use self::devicemapper::{ThinDev, ThinDevId};
-use self::devicemapper::ThinPoolDev;
-
-use self::tempdir::TempDir;
-use self::uuid::Uuid;
+use self::devicemapper::{ThinDev, ThinDevId, ThinPoolDev};
+use self::devicemapper::consts::SECTOR_SIZE;
 
 use libstratis::engine::{Engine, EngineError, ErrorEnum};
 use libstratis::engine::strat_engine::blockdevmgr::{initialize, resolve_devices};


### PR DESCRIPTION
It is more specific than other non-standard crates because it is a Stratis
project.

Signed-off-by: mulhern <amulhern@redhat.com>