### PR TITLE
Add a Default implementation for Table, ActionQueue and SimEngine

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -87,7 +87,7 @@ fn run() -> StratisResult<()> {
     let engine: Rc<RefCell<Engine>> = {
         if matches.is_present("sim") {
             info!("Using SimEngine");
-            Rc::new(RefCell::new(SimEngine::new()))
+            Rc::new(RefCell::new(SimEngine::default()))
         } else {
             info!("Using StratEngine");
             Rc::new(RefCell::new(try!(StratEngine::initialize())))

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -88,7 +88,7 @@ pub struct DbusContext {
 impl DbusContext {
     pub fn new(engine: Rc<RefCell<Engine>>) -> DbusContext {
         DbusContext {
-            actions: Rc::new(RefCell::new(ActionQueue::new())),
+            actions: Rc::new(RefCell::new(ActionQueue::default())),
             engine: engine,
             next_index: Rc::new(Cell::new(0)),
         }
@@ -118,18 +118,12 @@ impl DataType for TData {
 /// An action queue.
 /// Add and remove actions are pushed onto the queue.
 /// The queue can also be drained.
-#[derive(Debug)]
-#[allow(new_without_default_derive)]
+#[derive(Debug, Default)]
 pub struct ActionQueue {
     queue: VecDeque<DeferredAction>,
 }
 
 impl ActionQueue {
-    /// Initialize an empty action queue.
-    pub fn new() -> ActionQueue {
-        ActionQueue { queue: VecDeque::new() }
-    }
-
     /// Push an Add action onto the back of the queue.
     pub fn push_add(&mut self, object_path: ObjectPath<MTFn<TData>, TData>) {
         self.queue.push_back(DeferredAction::Add(object_path))

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -47,7 +47,7 @@ impl SimPool {
             name: name.to_owned(),
             pool_uuid: Uuid::new_v4(),
             block_devs: HashMap::from_iter(device_pairs),
-            filesystems: Table::new(),
+            filesystems: Table::default(),
             redundancy: redundancy,
             rdm: rdm.clone(),
         };
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     /// Renaming a filesystem on an empty pool always works
     fn rename_empty() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
         assert!(match pool.rename_filesystem(&Uuid::new_v4(), "new_name") {
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     /// Renaming a filesystem to another filesystem should work if new name not taken
     fn rename_happens() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
         let infos = pool.create_filesystems(&["old_name"]).unwrap();
@@ -174,7 +174,7 @@ mod tests {
     fn rename_fails() {
         let old_name = "old_name";
         let new_name = "new_name";
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
         let results = pool.create_filesystems(&[old_name, new_name]).unwrap();
@@ -189,7 +189,7 @@ mod tests {
     /// Renaming should succeed if old_name absent, new present
     fn rename_no_op() {
         let new_name = "new_name";
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
         pool.create_filesystems(&[new_name]).unwrap();
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     /// Removing an empty list of filesystems should always succeed
     fn destroy_fs_empty() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
         assert!(match pool.destroy_filesystems(&[]) {
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     /// Removing a non-empty list of filesystems should succeed on empty pool
     fn destroy_fs_some() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
         assert!(pool.destroy_filesystems(&[&Uuid::new_v4()]).is_ok());
@@ -223,7 +223,7 @@ mod tests {
     #[test]
     /// Removing a non-empty list of filesystems should succeed on any pool
     fn destroy_fs_any() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
         let fs_results = pool.create_filesystems(&["fs_name"]).unwrap();
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     /// Creating an empty list of filesystems should succeed, always
     fn create_fs_none() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     /// Creating a non-empty list of filesystems always succeeds.
     fn create_fs_some() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
@@ -266,7 +266,7 @@ mod tests {
     /// Creating a an already existing filesystem fails.
     fn create_fs_conflict() {
         let fs_name = "fs_name";
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
@@ -282,7 +282,7 @@ mod tests {
     /// Requesting identical filesystems succeeds.
     fn create_fs_dups() {
         let fs_name = "fs_name";
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     /// Adding a list of devices to an empty pool should yield list.
     fn add_device_empty() {
-        let mut engine = SimEngine::new();
+        let mut engine = SimEngine::default();
         let (uuid, _) = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();

--- a/src/engine/sim_engine/randomization.rs
+++ b/src/engine/sim_engine/randomization.rs
@@ -13,6 +13,15 @@ pub struct Randomizer {
     denominator: u32,
 }
 
+impl Default for Randomizer {
+    fn default() -> Randomizer {
+        Randomizer {
+            rng: thread_rng(),
+            denominator: 0u32,
+        }
+    }
+}
+
 
 /// Implement Debug explicitly as ThreadRng does not derive it.
 /// See: https://github.com/rust-lang-nursery/rand/issues/118
@@ -23,13 +32,6 @@ impl fmt::Debug for Randomizer {
 }
 
 impl Randomizer {
-    pub fn new() -> Randomizer {
-        Randomizer {
-            rng: thread_rng(),
-            denominator: 0u32,
-        }
-    }
-
     /// Throw a denominator sided die, returning true if 1 comes up
     /// If denominator is 0, return false
     pub fn throw_die(&mut self) -> bool {
@@ -59,7 +61,7 @@ mod tests {
         /// Verify that if the denominator is 0 the result is always false,
         /// if 1, always true.
         fn denominator_result(denominator: u32) -> bool {
-            let result = Randomizer::new()
+            let result = Randomizer::default()
                 .set_probability(denominator)
                 .throw_die();
             if denominator > 1 {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -50,7 +50,7 @@ impl StratEngine {
 
         let pools = try!(find_all());
 
-        let mut table = Table::new();
+        let mut table = Table::default();
         for (pool_uuid, devices) in pools.iter() {
             let evicted = table.insert(try!(StratPool::setup(*pool_uuid, devices)));
             if !evicted.is_empty() {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -140,7 +140,7 @@ impl StratPool {
             name: name.to_owned(),
             pool_uuid: pool_uuid,
             block_devs: block_mgr,
-            filesystems: Table::new(),
+            filesystems: Table::default(),
             redundancy: redundancy,
             thin_pool: thinpool_dev,
             thin_pool_meta_spare: meta_spare_regions,
@@ -171,7 +171,7 @@ impl StratPool {
                                                            .map(|x| x.thin_id())
                                                            .collect::<Vec<ThinDevId>>());
 
-        let mut table = Table::new();
+        let mut table = Table::default();
         for fs in filesystems {
             let evicted = table.insert(fs);
             if !evicted.is_empty() {

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -13,11 +13,20 @@ use super::engine::{HasName, HasUuid};
 
 /// Map UUID and name to T items.
 #[derive(Debug)]
-#[allow(new_without_default_derive)]
 pub struct Table<T: HasName + HasUuid> {
     items: Vec<T>,
     name_map: HashMap<String, usize>,
     uuid_map: HashMap<Uuid, usize>,
+}
+
+impl<T: HasName + HasUuid> Default for Table<T> {
+    fn default() -> Table<T> {
+        Table {
+            items: Vec::default(),
+            name_map: HashMap::default(),
+            uuid_map: HashMap::default(),
+        }
+    }
 }
 
 impl<'a, T: HasName + HasUuid> IntoIterator for &'a mut Table<T> {
@@ -35,15 +44,6 @@ impl<'a, T: HasName + HasUuid> IntoIterator for &'a mut Table<T> {
 /// inserted. In order to rename a T item, it must be removed, renamed, and
 /// reinserted under the new name.
 impl<T: HasName + HasUuid> Table<T> {
-    pub fn new() -> Self {
-        Table {
-            items: Vec::new(),
-            name_map: HashMap::new(),
-            uuid_map: HashMap::new(),
-        }
-
-    }
-
     /// Empty this table of all its items, returning them in a vector.
     pub fn empty(self) -> Vec<T> {
         self.items
@@ -243,7 +243,7 @@ mod tests {
     /// Verify that the table is now empty and that removing by name yields
     /// no result.
     fn remove_existing_item() {
-        let mut t: Table<TestThing> = Table::new();
+        let mut t: Table<TestThing> = Table::default();
         table_invariant(&t);
 
         let uuid = Uuid::new_v4();
@@ -273,7 +273,7 @@ mod tests {
     /// This is good, because then you can't have a thing that is both in
     /// the table and not in the table.
     fn insert_same_keys() {
-        let mut t: Table<TestThing> = Table::new();
+        let mut t: Table<TestThing> = Table::default();
         table_invariant(&t);
 
         let uuid = Uuid::new_v4();
@@ -314,7 +314,7 @@ mod tests {
     /// Insert a thing and then insert another thing with the same name.
     /// The previously inserted thing should be returned.
     fn insert_same_name() {
-        let mut t: Table<TestThing> = Table::new();
+        let mut t: Table<TestThing> = Table::default();
         table_invariant(&t);
 
         let uuid = Uuid::new_v4();


### PR DESCRIPTION
Also for Randomizer, in order to make implementation for SimEngine easier.
Get rid of new(), and use default() where appropriate.

Signed-off-by: mulhern <amulhern@redhat.com>