### PR TITLE
Call engine.teardown() at end of test_setup() 

### DIFF
--- a/tests/util/simple_tests.rs
+++ b/tests/util/simple_tests.rs
@@ -414,4 +414,6 @@ pub fn test_setup(paths: &[&Path]) {
 
     assert!(engine.get_pool(&uuid1).is_some());
     assert!(engine.get_pool(&uuid2).is_some());
+
+    engine.teardown().unwrap();
 }


### PR DESCRIPTION
Otherwise the test leaves the DM entries on the system.

Signed-off-by: Todd Gill <tgill@redhat.com>