### PR TITLE
Get rid of some clippy complaints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs:
 	cargo doc --no-deps
 
 clippy:
-	RUSTFLAGS='-D warnings' cargo build --features "clippy"
+	RUSTFLAGS='-D warnings' cargo build --features "clippy" --verbose
 
 .PHONY:
 	fmt

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -43,16 +43,14 @@ impl SimPool {
         let device_pairs = devices
             .iter()
             .map(|p| (p.to_path_buf(), SimDev::new(rdm.clone(), p)));
-        let new_pool = SimPool {
+        SimPool {
             name: name.to_owned(),
             pool_uuid: Uuid::new_v4(),
             block_devs: HashMap::from_iter(device_pairs),
             filesystems: Table::default(),
             redundancy: redundancy,
             rdm: rdm.clone(),
-        };
-
-        new_pool
+        }
     }
 
     pub fn check(&mut self) -> () {}

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -214,6 +214,7 @@ impl StratPool {
     }
 
     pub fn check(&mut self) -> () {
+        #![allow(match_same_arms)]
         let dm = DM::new().expect("Could not get DM handle");
 
         if let Err(e) = self.mdv.check() {

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -197,9 +197,8 @@ pub fn get_blockdevs(pool_save: &PoolSave, devnodes: &[PathBuf]) -> EngineResult
         // If we've seen this device already, skip it.
         if devices.contains(&device) {
             continue;
-        } else {
-            devices.insert(device);
         }
+        devices.insert(device);
 
         let bda = try!(BDA::load(&mut try!(OpenOptions::new().read(true).open(dev))));
         let bda = try!(bda.ok_or(EngineError::Engine(ErrorEnum::NotFound,


### PR DESCRIPTION
These are all clippy motivated updates.

This gets rid of a few clippy errors and runs clippy target verbosely for greater detail.

Getting rid of these particular errors should expose the remaining, where as leaving these particular errors in obscures all the other errors.