### PR TITLE
Use AddAssign instead of Assign

### DIFF
--- a/src/engine/strat_engine/dmdevice.rs
+++ b/src/engine/strat_engine/dmdevice.rs
@@ -102,7 +102,7 @@ impl ThinDevIdPool {
     // number has been used.
     pub fn new_id(&mut self) -> EngineResult<ThinDevId> {
         let next_id = try!(ThinDevId::new_u64((self.next_id) as u64));
-        self.next_id = self.next_id + 1;
+        self.next_id += 1;
         Ok(next_id)
     }
 }


### PR DESCRIPTION
This change gets rid of clippy error assign_op_pattern.

Signed-off-by: mulhern <amulhern@redhat.com>