### PR TITLE
Simplify, extend, and document metadata

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -92,6 +92,11 @@ impl BlockDev {
         self.used.available()
     }
 
+    /// The maximum size of variable length metadata that can be accommodated.
+    pub fn max_metadata_size(&self) -> Sectors {
+        self.bda.max_data_size()
+    }
+
     // Find some sector ranges that could be allocated. If more
     // sectors are needed than our capacity, return partial results.
     pub fn request_space(&mut self, size: Sectors) -> (Sectors, Vec<Segment>) {

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -369,18 +369,20 @@ mod mda {
                 Ok(try!(MDAHeader::from_buf(&hdr_buf, per_region_size)))
             };
 
-            let mda0 = load_a_region(0)
-                .or_else(|_| load_a_region(2))
-                .ok()
-                .unwrap_or(None);
-            let mda1 = load_a_region(1)
-                .or_else(|_| load_a_region(3))
-                .ok()
-                .unwrap_or(None);
+            /// Get an MDAHeader for the given index.
+            /// If there is a failure reading the first, fall back on the
+            /// second. If there is a failure reading both, return None.
+            /// TODO: Consider whether this is the correct behavior.
+            let mut get_mda = |index: usize| -> Option<MDAHeader> {
+                load_a_region(index)
+                    .or_else(|_| load_a_region(index + 2))
+                    .ok()
+                    .unwrap_or(None)
+            };
 
             Ok(MDARegions {
                    region_size: region_size,
-                   mdas: [mda0, mda1],
+                   mdas: [get_mda(0), get_mda(1)],
                })
         }
 

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -366,14 +366,7 @@ mod mda {
                                                                    index,
                                                                    per_region_size))));
                 try!(f.read_exact(&mut hdr_buf));
-                let mda = try!(MDAHeader::from_buf(&hdr_buf, per_region_size));
-
-                // Loading checks CRC
-                if mda.is_some() {
-                    try!(mda.as_ref().expect("is_some()").load_region(f));
-                }
-
-                Ok(mda)
+                Ok(try!(MDAHeader::from_buf(&hdr_buf, per_region_size)))
             };
 
             let mda0 = load_a_region(0)

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -426,12 +426,12 @@ impl MDARegions {
             None => return Ok(None),
             Some(ref mda) => mda,
         };
+        let region_size = self.region_size.bytes();
 
         /// Load the metadata region specified by index.
         /// It is an error if the metadata can not be found.
         let mut load_region = |index: usize| -> EngineResult<Vec<u8>> {
-            let offset = MDARegions::mda_offset(index, self.region_size.bytes()) +
-                         _MDA_REGION_HDR_SIZE as u64;
+            let offset = MDARegions::mda_offset(index, region_size) + _MDA_REGION_HDR_SIZE as u64;
             try!(f.seek(SeekFrom::Start(offset)));
             mda.load_region(f)
         };

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -146,6 +146,11 @@ impl BDA {
     pub fn size(&self) -> Sectors {
         BDA_STATIC_HDR_SECTORS + self.header.mda_size + self.header.reserved_size
     }
+
+    /// The maximum size of variable length metadata that can be accommodated.
+    pub fn max_data_size(&self) -> Sectors {
+        self.regions.max_data_size()
+    }
 }
 
 #[derive(Debug)]
@@ -320,6 +325,12 @@ mod mda {
         /// Calculate the offset from start of device for an MDARegion.
         fn mda_offset(header_size: Bytes, index: usize, per_region_size: Bytes) -> u64 {
             *(header_size + per_region_size * index)
+        }
+
+        /// The maximum size of variable length metadata that this region
+        /// can accommodate.
+        pub fn max_data_size(&self) -> Sectors {
+            self.region_size
         }
 
         /// Initialize the space allotted to the MDA regions to 0.


### PR DESCRIPTION
Also, make use of some extensions to enhance ```BlockDevMgr::save_state()```. The enhancements allow it to conform, more or less entirely, to the specifications in the design doc.

A principle step is to move MDARegions and MDAHeader into their own separate module internal to metadata.
This controls the access to MDAHeader implementation so that it is only through MDARegions methods. All MDAHeader methods are private to the module.

An important step is that the region size is no longer stored in each MDAHeader, but only in the containing MDARegions struct. Since access to MDAHeader methods is completely controlled MDARegions methods can verify that the data is not too big to be written. This change enable the simplification of MDARegions methods, since MDAHeader do not have Option fields, but can themselves be Option fields of their MDARegions. Moreover, ```MDAHeader::to_buf()``` can simply take a reference to an MDAHeader, rather than a selection of its fields.

An important change in the behavior is that loading an MDAHeader does not check the crc of the variable length metadata.

The maximum size of variable length metadata that can be written to a particular blockdev is now exported for the use of ```BlockDevMgr::save_state()```. ```BlockDevMgr::save_state()``` now conforms to its specification in the design doc with the caveat that the maximum number of blockdevs written to is designated by a constant, and perhaps should be configurable instead.
