### PR TITLE
Get rid of a bunch of needless borrows

### DIFF
--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -98,7 +98,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let default_return = MessageItem::Bool(false);
 
     let filesystem_path = m.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let filesystem_data = get_data!(filesystem_path; default_return; return_message);
 
@@ -147,7 +147,7 @@ fn get_filesystem_property<F>(i: &mut IterAppend,
     let object_path = p.path.get_name();
 
     let filesystem_path = p.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("tree must contain implicit argument");
     let filesystem_data = try!(ref_ok_or(filesystem_path.get_data(),
                                          MethodErr::failed(&format!("no data for object path {}",

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -50,7 +50,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let default_return = MessageItem::Array(vec![], return_sig.into());
 
     let pool_path = m.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
 
@@ -102,7 +102,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let default_return = MessageItem::Array(vec![], return_sig.into());
 
     let pool_path = m.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
 
@@ -158,7 +158,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let default_return = MessageItem::Array(vec![], return_sig.into());
 
     let pool_path = m.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
 
@@ -201,7 +201,7 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let default_return = MessageItem::Bool(false);
 
     let pool_path = m.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
 
@@ -235,7 +235,7 @@ fn get_pool_name(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result
     let dbus_context = p.tree.get_data();
     let object_path = p.path.get_name();
     let pool_path = p.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let data = try!(ref_ok_or(pool_path.get_data(),
                               MethodErr::failed(&format!("no data for object path {}",

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -84,7 +84,7 @@ pub fn ref_ok_or<'a, E, T>(opt: &'a Option<T>, err: E) -> Result<&'a T, E> {
 pub fn get_uuid(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<(), MethodErr> {
     let object_path = p.path.get_name();
     let path = p.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let data = try!(ref_ok_or(path.get_data(),
                               MethodErr::failed(&format!("no data for object path {}",
@@ -98,7 +98,7 @@ pub fn get_uuid(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<
 pub fn get_parent(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<(), MethodErr> {
     let object_path = p.path.get_name();
     let path = p.tree
-        .get(&object_path)
+        .get(object_path)
         .expect("implicit argument must be in tree");
     let data = try!(ref_ok_or(path.get_data(),
                               MethodErr::failed(&format!("no data for object path {}",


### PR DESCRIPTION
ObjectPath::get_name() returns a reference. It is not necessary to make
a reference of the reference.

This is another clippy error.

Signed-off-by: mulhern <amulhern@redhat.com>