### PR TITLE
Style changes, mostly in setup.rs

### DIFF
--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -162,8 +162,7 @@ impl MetadataVol {
 
     /// Tear down a Metadata Volume.
     pub fn teardown(self, dm: &DM) -> EngineResult<()> {
-        let v: Vec<&str> = Vec::new();
-        try!(unmount_fs(&self.mount_pt, &v));
+        try!(unmount_fs(&self.mount_pt, &[] as &[&str]));
         try!(self.dev.teardown(dm));
 
         Ok(())

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -195,10 +195,9 @@ pub fn get_blockdevs(pool_save: &PoolSave, devnodes: &[PathBuf]) -> EngineResult
         let device = try!(Device::from_str(&dev.to_string_lossy()));
 
         // If we've seen this device already, skip it.
-        if devices.contains(&device) {
+        if !devices.insert(device) {
             continue;
         }
-        devices.insert(device);
 
         let bda = try!(BDA::load(&mut try!(OpenOptions::new().read(true).open(dev))));
         let bda = try!(bda.ok_or(EngineError::Engine(ErrorEnum::NotFound,

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -111,15 +111,11 @@ pub fn get_metadata(pool_uuid: PoolUuid, devnodes: &[PathBuf]) -> EngineResult<O
     let mut bdas = Vec::new();
     for devnode in devnodes {
         let bda = try!(BDA::load(&mut try!(OpenOptions::new().read(true).open(devnode))));
-        if bda.is_none() {
-            continue;
+        if let Some(bda) = bda {
+            if *bda.pool_uuid() == pool_uuid {
+                bdas.push((devnode, bda));
+            }
         }
-        let bda = bda.expect("unreachable if bda is None");
-
-        if *bda.pool_uuid() != pool_uuid {
-            continue;
-        }
-        bdas.push((devnode, bda));
     }
 
     // We may have had no devices with BDAs for this pool, so return if no BDAs.

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -98,11 +98,6 @@ pub fn find_all() -> EngineResult<HashMap<PoolUuid, Vec<PathBuf>>> {
 /// Returns None if no metadata found for this pool.
 pub fn get_metadata(pool_uuid: PoolUuid, devnodes: &[PathBuf]) -> EngineResult<Option<PoolSave>> {
 
-    // No device nodes means no metadata
-    if devnodes.is_empty() {
-        return Ok(None);
-    }
-
     // Get pairs of device nodes and matching BDAs
     // If no BDA, or BDA UUID does not match pool UUID, skip.
     // If there is an error reading the BDA, error. There could have been


### PR DESCRIPTION
These are style changes that do not change the meaning of the code, and attempt to use Rust higher-level idioms (e.g. `filter_map` and `and_then`) to minimize the use of lower-level things (e.g. `continue` and `expect`).

