### PR TITLE
Make get_blockdevs() consistent with get_metadata()

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -153,7 +153,7 @@ impl StratPool {
                                 .ok_or(EngineError::Engine(ErrorEnum::NotFound,
                                                            format!("no metadata for pool {}",
                                                                    uuid))));
-        let blockdevs = try!(get_blockdevs(&metadata, devnodes));
+        let blockdevs = try!(get_blockdevs(uuid, &metadata, devnodes));
 
         let uuid_map: HashMap<DevUuid, Device> = blockdevs
             .iter()

--- a/tests/util/setup_tests.rs
+++ b/tests/util/setup_tests.rs
@@ -104,8 +104,8 @@ pub fn test_basic_metadata(paths: &[&Path]) {
     let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
     assert!(pool_save1 == metadata1);
     assert!(pool_save2 == metadata2);
-    let blockdevs1 = get_blockdevs(&pool_save1, devnodes1).unwrap();
-    let blockdevs2 = get_blockdevs(&pool_save2, devnodes2).unwrap();
+    let blockdevs1 = get_blockdevs(uuid1, &pool_save1, devnodes1).unwrap();
+    let blockdevs2 = get_blockdevs(uuid2, &pool_save2, devnodes2).unwrap();
     assert!(blockdevs1.len() == pool_save1.block_devs.len());
     assert!(blockdevs2.len() == pool_save2.block_devs.len());
 
@@ -118,8 +118,8 @@ pub fn test_basic_metadata(paths: &[&Path]) {
     let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
     assert!(pool_save1 == metadata1);
     assert!(pool_save2 == metadata2);
-    let blockdevs1 = get_blockdevs(&pool_save1, devnodes1).unwrap();
-    let blockdevs2 = get_blockdevs(&pool_save2, devnodes2).unwrap();
+    let blockdevs1 = get_blockdevs(uuid1, &pool_save1, devnodes1).unwrap();
+    let blockdevs2 = get_blockdevs(uuid2, &pool_save2, devnodes2).unwrap();
     assert!(blockdevs1.len() == pool_save1.block_devs.len());
     assert!(blockdevs2.len() == pool_save2.block_devs.len());
 }


### PR DESCRIPTION
It now ignores devices without a BDA or devices which do not belong to the
specified pool just like get_metadata() does.

This fixes a bug where the method could fail if it was given a devnode that
did not belong to the pool. It would fail in the last stage, when it found that
it had constructed a blockdev that didn't match the metadata.

Signed-off-by: mulhern <amulhern@redhat.com>