### PR TITLE
Add an optional size parameter to StratFilesystem:initialize()

### DIFF
--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -35,10 +35,11 @@ impl StratFilesystem {
                       fs_id: FilesystemUuid,
                       name: &str,
                       dm: &DM,
-                      thin_pool: &mut ThinPool)
+                      thin_pool: &mut ThinPool,
+                      size: Option<Sectors>)
                       -> EngineResult<StratFilesystem> {
         let device_name = format_thin_name(pool_uuid, ThinRole::Filesystem(fs_id));
-        let thin_dev = try!(thin_pool.make_thin_device(dm, &device_name));
+        let thin_dev = try!(thin_pool.make_thin_device(dm, &device_name, size));
         let fs = StratFilesystem {
             fs_id: fs_id,
             name: name.to_owned(),

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -405,7 +405,8 @@ impl Pool for StratPool {
                                                                   uuid,
                                                                   name,
                                                                   &dm,
-                                                                  &mut self.thin_pool));
+                                                                  &mut self.thin_pool,
+                                                                  None));
             try!(self.mdv.save_fs(&new_filesystem));
             self.filesystems.insert(new_filesystem);
             result.push((**name, uuid));

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -104,12 +104,16 @@ impl ThinPool {
     }
 
     /// Make a new thin device.
-    pub fn make_thin_device(&mut self, dm: &DM, name: &str) -> EngineResult<ThinDev> {
+    pub fn make_thin_device(&mut self,
+                            dm: &DM,
+                            name: &str,
+                            size: Option<Sectors>)
+                            -> EngineResult<ThinDev> {
         Ok(try!(ThinDev::new(name,
                              dm,
                              &self.thin_pool,
                              try!(self.id_gen.new_id()),
-                             Bytes(IEC::Ti).sectors())))
+                             size.unwrap_or(Bytes(IEC::Ti).sectors()))))
     }
 
     /// Setup a previously constructed thin device.


### PR DESCRIPTION
Allowing the caller to over-ride the default of 1 TiB will make
testing expand on smaller devices possible.

Signed-off-by: Todd Gill <tgill@redhat.com>