### PR TITLE
Eliminate a few clippy needless-borrow messages

### DIFF
--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -271,7 +271,7 @@ pub fn handle(c: &Connection,
               dbus_context: &DbusContext)
               -> Result<(), dbus::Error> {
     if let ConnectionItem::MethodCall(ref msg) = item {
-        if let Some(v) = tree.handle(&msg) {
+        if let Some(v) = tree.handle(msg) {
             // Probably the wisest is to ignore any send errors here -
             // maybe the remote has disconnected during our processing.
             for m in v {

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -107,7 +107,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_pool!(engine; pool_uuid; default_return; return_message);
 
-    let msg = match pool.rename_filesystem(&filesystem_data.uuid, &new_name) {
+    let msg = match pool.rename_filesystem(&filesystem_data.uuid, new_name) {
         Ok(RenameAction::NoSource) => {
             let error_message = format!("pool {} doesn't know about filesystem {}",
                                         pool_uuid,

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -202,14 +202,14 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let pool_path = m.tree
         .get(object_path)
         .expect("implicit argument must be in tree");
-    let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
+    let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
 
     let msg = match dbus_context
               .engine
               .borrow_mut()
               .rename_pool(&pool_uuid, new_name) {
         Ok(RenameAction::NoSource) => {
-            let error_message = format!("engine doesn't know about pool {}", pool_uuid);
+            let error_message = format!("engine doesn't know about pool {}", &pool_uuid);
             let (rc, rs) = code_to_message_items(DbusErrorEnum::INTERNAL_ERROR, error_message);
             return_message.append3(default_return, rc, rs)
         }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -104,12 +104,12 @@ impl StratPool {
         // that are trying to re-adopt the device with the attributes that
         // have been passed.
         let meta_dev = try!(LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
-                                           &dm,
+                                           dm,
                                            meta_regions));
         try!(wipe_sectors(&try!(meta_dev.devnode()), Sectors(0), INITIAL_META_SIZE));
 
         let data_dev = try!(LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
-                                           &dm,
+                                           dm,
                                            data_regions));
 
         let thinpool = try!(ThinPool::new(pool_uuid,

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -81,7 +81,7 @@ impl ThinPool {
                 Ok(ThinPool {
                        thin_pool: dev,
                        meta_spare: spare_segments,
-                       id_gen: ThinDevIdPool::new_from_ids(&thin_ids),
+                       id_gen: ThinDevIdPool::new_from_ids(thin_ids),
                    })
             }
             Err(DmError::Dm(devicemapper::ErrorEnum::CheckFailed(meta_dev, data_dev), _)) => {
@@ -96,7 +96,7 @@ impl ThinPool {
                                                           new_meta_dev,
                                                           data_dev)),
                        meta_spare: new_spare_segments,
-                       id_gen: ThinDevIdPool::new_from_ids(&thin_ids),
+                       id_gen: ThinDevIdPool::new_from_ids(thin_ids),
                    })
             }
             Err(err) => Err(err.into()),


### PR DESCRIPTION
Some by removing the &, some by changing the surrounding code.

Signed-off-by: mulhern <amulhern@redhat.com>