### PR TITLE
Tear down thindevs as part of StratPool::teardown

### DIFF
--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -86,6 +86,11 @@ impl StratFilesystem {
     pub fn thin_id(&self) -> ThinDevId {
         self.thin_dev.id()
     }
+
+    /// Tear down the filesystem.
+    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
+        Ok(try!(self.thin_dev.teardown(dm)))
+    }
 }
 
 impl HasName for StratFilesystem {


### PR DESCRIPTION
This should let tearing down the thinpool itself succeed.

fixes #471

Signed-off-by: Andy Grover <agrover@redhat.com>