### PR TITLE
No longer specify trusty distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 os: linux
-dist: trusty
 group: edge
 
 before_install:


### PR DESCRIPTION
It is now the default.

Signed-off-by: mulhern <amulhern@redhat.com>