### PR TITLE
Some metadata improvements

### DIFF
--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -177,17 +177,24 @@ impl StaticHeader {
         }
     }
 
+
+    /// Read data from f into buffer of length _BDA_STATIC_HDR_SIZE.
+    fn read_into_buf<F>(f: &mut F) -> EngineResult<[u8; _BDA_STATIC_HDR_SIZE]>
+        where F: Read + Seek
+    {
+        f.seek(SeekFrom::Start(0))?;
+        let mut buf = [0u8; _BDA_STATIC_HDR_SIZE];
+        f.read(&mut buf)?;
+        Ok(buf)
+    }
+
     /// Try to find a valid StaticHeader on a device.
     /// If there is no StaticHeader on the device, return None.
     /// If there is a problem reading a header, return an error.
     fn setup<F>(f: &mut F) -> EngineResult<Option<StaticHeader>>
         where F: Read + Seek
     {
-        f.seek(SeekFrom::Start(0))?;
-        let mut buf = [0u8; _BDA_STATIC_HDR_SIZE];
-        f.read(&mut buf)?;
-
-        StaticHeader::setup_from_buf(&buf)
+        StaticHeader::setup_from_buf(&StaticHeader::read_into_buf(f)?)
     }
 
     /// Try to find a valid StaticHeader in a buffer.
@@ -215,11 +222,7 @@ impl StaticHeader {
     pub fn determine_ownership<F>(f: &mut F) -> EngineResult<DevOwnership>
         where F: Read + Seek
     {
-
-
-        f.seek(SeekFrom::Start(0))?;
-        let mut buf = [0u8; _BDA_STATIC_HDR_SIZE];
-        f.read(&mut buf)?;
+        let buf = StaticHeader::read_into_buf(f)?;
 
         // Using setup() as a test of ownership sets a high bar. It is
         // not sufficient to have STRAT_MAGIC to be considered "Ours",

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -858,6 +858,38 @@ mod tests {
     }
 
     #[test]
+    /// Construct a BDA input stream of all 0s of size _BDA_STATIC_HDR_SIZE.
+    /// Verify that loading the StaticHeader and loading the BDA yield None.
+    fn all_zero_bda() {
+        let mut buf = Cursor::new(vec![0u8; _BDA_STATIC_HDR_SIZE]);
+        assert!(StaticHeader::setup(&mut buf).unwrap().is_none());
+        assert!(BDA::load(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    /// Make a buffer that is too short to have a StaticHeader on it.
+    /// Verify that loading the Static Header and loading the BDA yield None.
+    fn very_short_bda() {
+        let mut buf = Cursor::new(vec![0u8; SECTOR_SIZE]);
+        assert!(StaticHeader::setup(&mut buf).unwrap().is_none());
+        assert!(BDA::load(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    /// Make a buffer just large enough to contain a single static header.
+    /// Verify that the StaticHeader is read and that there is a failure reading
+    /// the BDA.
+    fn just_one_static_header() {
+        let mut vec = vec![0u8; 2 * SECTOR_SIZE];
+        vec[SECTOR_SIZE..2 * SECTOR_SIZE].clone_from_slice(&random_static_header(0, 0)
+                                                                .sigblock_to_buf());
+        let mut buf = Cursor::new(vec);
+        assert!(StaticHeader::setup(&mut buf).unwrap().is_some());
+
+        assert!(BDA::load(&mut buf).is_err());
+    }
+
+    #[test]
     /// Construct an arbitrary StaticHeader object.
     /// Initialize a BDA.
     /// Verify that the last update time is None.

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -30,6 +30,10 @@ const MDA_RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)
 
 const STRAT_MAGIC: &'static [u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
 
+const SIGBLOCK_REGION_ONE: (usize, usize) = (SECTOR_SIZE, 2 * SECTOR_SIZE);
+const SIGBLOCK_REGION_TWO: (usize, usize) = (9 * SECTOR_SIZE, 10 * SECTOR_SIZE);
+
+
 #[derive(Debug)]
 pub struct BDA {
     header: StaticHeader,
@@ -203,8 +207,8 @@ impl StaticHeader {
     /// verify that it matches the next.
     /// Return None if the static header's magic number is wrong.
     fn setup_from_buf(buf: &[u8; _BDA_STATIC_HDR_SIZE]) -> EngineResult<Option<StaticHeader>> {
-        let sigblock_spots = [&buf[SECTOR_SIZE..2 * SECTOR_SIZE],
-                              &buf[9 * SECTOR_SIZE..10 * SECTOR_SIZE]];
+        let sigblock_spots = [&buf[SIGBLOCK_REGION_ONE.0..SIGBLOCK_REGION_ONE.1],
+                              &buf[SIGBLOCK_REGION_TWO.0..SIGBLOCK_REGION_TWO.1]];
 
         // TODO: repair static header if one incorrect?
         for buf in &sigblock_spots {

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -187,9 +187,6 @@ impl StaticHeader {
         let mut buf = [0u8; _BDA_STATIC_HDR_SIZE];
         f.read(&mut buf)?;
 
-        // TODO: repair static header if one incorrect?
-        // Note: this would require some adjustment or some revision to
-        // setup_from_buf().
         StaticHeader::setup_from_buf(&buf)
     }
 
@@ -202,6 +199,7 @@ impl StaticHeader {
         let sigblock_spots = [&buf[SECTOR_SIZE..2 * SECTOR_SIZE],
                               &buf[9 * SECTOR_SIZE..10 * SECTOR_SIZE]];
 
+        // TODO: repair static header if one incorrect?
         for buf in &sigblock_spots {
             match StaticHeader::sigblock_from_buf(buf) {
                 Ok(val) => return Ok(val),


### PR DESCRIPTION
This PR does the following:

* Adds some more tests.
* Fixes a bug in ```MDARegions::initialize()```.
* Improves StaticHeader implementation by abstracting some methods, simplifying some others, and refining ```sigblock_from_buf()``` so that it takes into account the possibility of a partial read.
* Improves ```MDARegions::load()``` by having it return an error if there is truly an error in reading an MDA region.
* Gets rid of one TODO.
* Gets rid of two clippy errors.