### PR TITLE
Expand XFS when filesystem space goes below low water mark

### DIFF
--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -22,6 +22,8 @@ use dbus::tree::PropInfo;
 
 use uuid::Uuid;
 
+use devicemapper::Sectors;
+
 use engine::{Pool, RenameAction};
 
 use super::filesystem::create_dbus_filesystem;
@@ -56,7 +58,10 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_pool!(engine; pool_uuid; default_return; return_message);
 
-    let result = pool.create_filesystems(&filesystems.collect::<Vec<&str>>());
+    let result =
+        pool.create_filesystems(&filesystems
+                                     .map(|x| (x, None))
+                                     .collect::<Vec<(&str, Option<Sectors>)>>());
 
     let msg = match result {
         Ok(ref infos) => {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -31,9 +31,10 @@ pub trait Pool: HasName + HasUuid {
     /// Creates the filesystems specified by specs.
     /// Returns a list of the names of filesystems actually created.
     /// Returns an error if any of the specified names are already in use
-    /// for filesystems in this pool.
+    /// for filesystems in this pool. If the same name is passed multiple
+    /// times, the size associated with the last item is used.
     fn create_filesystems<'a, 'b>(&'a mut self,
-                                  specs: &[&'b str])
+                                  specs: &[(&'b str, Option<Sectors>)])
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>>;
 
     /// Adds blockdevs specified by paths to pool.

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -167,7 +167,7 @@ mod tests {
             .unwrap();
         {
             let pool = engine.get_pool(&uuid).unwrap();
-            pool.create_filesystems(&["test"]).unwrap();
+            pool.create_filesystems(&[("test", None)]).unwrap();
         }
         assert!(engine.destroy_pool(&uuid).is_err());
     }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -92,21 +92,21 @@ impl Pool for SimPool {
     }
 
     fn create_filesystems<'a, 'b>(&'a mut self,
-                                  specs: &[&'b str])
+                                  specs: &[(&'b str, Option<Sectors>)])
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>> {
-        let names: HashSet<_, RandomState> = HashSet::from_iter(specs);
-        for name in &names {
+        let names: HashMap<_, _> = HashMap::from_iter(specs.iter().map(|&tup| (tup.0, tup.1)));
+        for name in names.keys() {
             if self.filesystems.contains_name(name) {
                 return Err(EngineError::Engine(ErrorEnum::AlreadyExists, name.to_string()));
             }
         }
 
         let mut result = Vec::new();
-        for name in &names {
+        for name in names.keys() {
             let uuid = Uuid::new_v4();
             let new_filesystem = SimFilesystem::new(uuid, name);
             self.filesystems.insert(new_filesystem);
-            result.push((**name, uuid));
+            result.push((*name, uuid));
         }
 
         Ok(result)
@@ -194,7 +194,7 @@ mod tests {
         let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
-        let infos = pool.create_filesystems(&["old_name"]).unwrap();
+        let infos = pool.create_filesystems(&[("old_name", None)]).unwrap();
         assert!(match pool.rename_filesystem(&infos[0].1, "new_name") {
                     Ok(RenameAction::Renamed) => true,
                     _ => false,
@@ -209,7 +209,8 @@ mod tests {
         let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
-        let results = pool.create_filesystems(&[old_name, new_name]).unwrap();
+        let results = pool.create_filesystems(&[(old_name, None), (new_name, None)])
+            .unwrap();
         let old_uuid = results.iter().find(|x| x.0 == old_name).unwrap().1;
         assert!(match pool.rename_filesystem(&old_uuid, new_name) {
                     Err(EngineError::Engine(ErrorEnum::AlreadyExists, _)) => true,
@@ -224,7 +225,7 @@ mod tests {
         let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
-        pool.create_filesystems(&[new_name]).unwrap();
+        pool.create_filesystems(&[(new_name, None)]).unwrap();
         assert!(match pool.rename_filesystem(&Uuid::new_v4(), new_name) {
                     Ok(RenameAction::NoSource) => true,
                     _ => false,
@@ -258,7 +259,7 @@ mod tests {
         let mut engine = SimEngine::default();
         let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
-        let fs_results = pool.create_filesystems(&["fs_name"]).unwrap();
+        let fs_results = pool.create_filesystems(&[("fs_name", None)]).unwrap();
         let fs_uuid = fs_results[0].1;
         assert!(match pool.destroy_filesystems(&[&fs_uuid, &Uuid::new_v4()]) {
                     Ok(filesystems) => filesystems == vec![&fs_uuid],
@@ -288,7 +289,7 @@ mod tests {
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
-        assert!(match pool.create_filesystems(&["name"]) {
+        assert!(match pool.create_filesystems(&[("name", None)]) {
                     Ok(names) => (names.len() == 1) & (names[0].0 == "name"),
                     _ => false,
                 });
@@ -303,8 +304,8 @@ mod tests {
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
-        pool.create_filesystems(&[fs_name]).unwrap();
-        assert!(match pool.create_filesystems(&[fs_name]) {
+        pool.create_filesystems(&[(fs_name, None)]).unwrap();
+        assert!(match pool.create_filesystems(&[(fs_name, None)]) {
                     Err(EngineError::Engine(ErrorEnum::AlreadyExists, _)) => true,
                     _ => false,
                 });
@@ -319,7 +320,7 @@ mod tests {
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_pool(&uuid).unwrap();
-        assert!(match pool.create_filesystems(&[fs_name, fs_name]) {
+        assert!(match pool.create_filesystems(&[(fs_name, None), (fs_name, None)]) {
                     Ok(names) => (names.len() == 1) & (names[0].0 == fs_name),
                     _ => false,
                 });

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -4,6 +4,7 @@
 
 /// Code to handle management of a pool's thinpool device.
 
+use std::borrow::BorrowMut;
 use std::process::Command;
 
 use uuid::Uuid;
@@ -164,11 +165,12 @@ impl ThinPool {
     }
 
     /// The status of the thin pool as calculated by DM.
-    pub fn check(&self, dm: &DM) -> EngineResult<ThinPoolStatus> {
+    pub fn check(&mut self, dm: &DM) -> EngineResult<ThinPoolStatus> {
         let thinpool = try!(self.thin_pool.status(dm));
         try!(self.mdv.check());
 
         let filesystems: Vec<_> = try!(self.filesystems
+                                           .borrow_mut()
                                            .into_iter()
                                            .map(|fs| fs.check(dm))
                                            .collect());

--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -30,6 +30,7 @@ use util::blockdev_tests::test_force_flag_stratis;
 use util::blockdev_tests::test_pool_blockdevs;
 use util::dm_tests::test_thinpool_device;
 use util::dm_tests::test_linear_device;
+use util::filesystem_tests::test_xfs_expand;
 use util::pool_tests::test_filesystem_rename;
 use util::pool_tests::test_thinpool_expand;
 use util::pool_tests::test_thinpool_thindev_destroy;
@@ -209,4 +210,9 @@ pub fn loop_test_filesystem_rename() {
 #[test]
 pub fn loop_test_pool_setup() {
     test_with_spec(2, test_pool_setup);
+}
+
+#[test]
+pub fn loop_test_xfs_expand() {
+    test_with_spec(3, test_xfs_expand);
 }

--- a/tests/real_tests.rs
+++ b/tests/real_tests.rs
@@ -27,6 +27,7 @@ use util::blockdev_tests::test_force_flag_stratis;
 use util::blockdev_tests::test_pool_blockdevs;
 use util::dm_tests::test_thinpool_device;
 use util::dm_tests::test_linear_device;
+use util::filesystem_tests::test_xfs_expand;
 use util::pool_tests::test_filesystem_rename;
 use util::pool_tests::test_thinpool_expand;
 use util::pool_tests::test_thinpool_thindev_destroy;
@@ -179,4 +180,9 @@ pub fn real_test_filesystem_rename() {
 #[test]
 pub fn real_test_pool_setup() {
     test_with_spec(2, test_pool_setup);
+}
+
+#[test]
+pub fn real_test_xfs_expand() {
+    test_with_spec(3, test_xfs_expand);
 }

--- a/tests/util/filesystem_tests.rs
+++ b/tests/util/filesystem_tests.rs
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Test the functionality of stratis filesystems.
+extern crate devicemapper;
+extern crate uuid;
+extern crate env_logger;
+extern crate nix;
+extern crate tempdir;
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use self::nix::mount::{MsFlags, mount, umount};
+
+use self::tempdir::TempDir;
+
+use self::devicemapper::consts::IEC;
+use self::devicemapper::{Bytes, DM};
+use self::devicemapper::consts::SECTOR_SIZE;
+
+use libstratis::engine::Pool;
+use libstratis::engine::Filesystem;
+use libstratis::engine::strat_engine::filesystem::{FILESYSTEM_LOWATER, fs_usage};
+use libstratis::engine::strat_engine::pool::StratPool;
+use libstratis::engine::types::Redundancy;
+
+/// Verify that the logical space allocated to a filesystem is expanded when
+/// the number of sectors written to the filesystem causes the free space to
+/// dip below the FILESYSTEM_LOWATER mark. Verify that the space has been
+/// expanded by calling filesystem.check() then looking at the total space
+/// compared to the original size.
+pub fn test_xfs_expand(paths: &[&Path]) -> () {
+    let dm = DM::new().unwrap();
+    // Create a filesytem as small as possible.  Allocate 1 MiB bigger than
+    // the low water mark.
+    let fs_size = FILESYSTEM_LOWATER + Bytes(IEC::Mi).sectors();
+
+    let (mut pool, _) =
+        StratPool::initialize("stratis_test_pool", &dm, paths, Redundancy::NONE, true).unwrap();
+    let &(_, fs_uuid) = pool.create_filesystems(&[("stratis_test_filesystem", Some(fs_size))])
+        .unwrap()
+        .first()
+        .unwrap();
+    // Braces to ensure f is closed before destroy and the borrow of pool is complete
+    {
+        let filesystem = pool.get_strat_filesystem(&fs_uuid).unwrap();
+        let devnode = filesystem.devnode().unwrap();
+        // Write 2 MiB of data. The filesystem's free space is now 1 MiB below
+        // FILESYSTEM_LOWATER.
+        let write_size = Bytes(IEC::Mi * 2).sectors();
+        let tmp_dir = TempDir::new("stratis_testing").unwrap();
+        mount(Some(&devnode),
+              tmp_dir.path(),
+              Some("xfs"),
+              MsFlags::empty(),
+              None as Option<&str>)
+                .unwrap();
+        let buf = &[1u8; SECTOR_SIZE];
+        for i in 0..*write_size {
+            let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));
+            let mut f = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(file_path)
+                .unwrap();
+            if f.write_all(buf).is_err() {
+                break;
+            }
+        }
+        let (orig_fs_total_bytes, _) = fs_usage(&tmp_dir.path()).unwrap();
+        // Simulate handling a DM event by running a filesystem check.
+        filesystem.check(&dm).unwrap();
+        let (fs_total_bytes, _) = fs_usage(&tmp_dir.path()).unwrap();
+        assert!(fs_total_bytes > orig_fs_total_bytes);
+        umount(tmp_dir.path()).unwrap();
+    }
+    pool.destroy_filesystems(&[&fs_uuid]).unwrap();
+    pool.teardown().unwrap();
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod blockdev_tests;
 pub mod dm_tests;
+pub mod filesystem_tests;
 pub mod pool_tests;
 pub mod setup_tests;
 pub mod simple_tests;

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -22,8 +22,8 @@ use libstratis::engine::strat_engine::pool::{DATA_BLOCK_SIZE, DATA_LOWATER, INIT
                                              StratPool};
 use libstratis::engine::types::{Redundancy, RenameAction};
 
-/// Verify that a the physical space allocated to a pool is expanded when
-/// the nuber of sectors written to a thin-dev in the pool exceeds the
+/// Verify that the physical space allocated to a pool is expanded when
+/// the number of sectors written to a thin-dev in the pool exceeds the
 /// INITIAL_DATA_SIZE.  If we are able to write more sectors to the filesystem
 /// than are initially allocated to the pool, the pool must have been expanded.
 pub fn test_thinpool_expand(paths: &[&Path]) -> () {

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -33,7 +33,7 @@ pub fn test_thinpool_expand(paths: &[&Path]) -> () {
                                               Redundancy::NONE,
                                               true)
             .unwrap();
-    let &(_, fs_uuid) = pool.create_filesystems(&vec!["stratis_test_filesystem"])
+    let &(_, fs_uuid) = pool.create_filesystems(&vec![("stratis_test_filesystem", None)])
         .unwrap()
         .first()
         .unwrap();
@@ -74,7 +74,7 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
     let (uuid1, _) = engine.create_pool(&name1, paths, None, false).unwrap();
     let fs_uuid = {
         let mut pool = engine.get_pool(&uuid1).unwrap();
-        let &(fs_name, fs_uuid) = pool.create_filesystems(&[name1])
+        let &(fs_name, fs_uuid) = pool.create_filesystems(&[(name1, None)])
             .unwrap()
             .first()
             .unwrap();
@@ -110,7 +110,7 @@ pub fn test_thinpool_thindev_destroy(paths: &[&Path]) -> () {
                                               Redundancy::NONE,
                                               true)
             .unwrap();
-    let &(_, fs_uuid) = pool.create_filesystems(&["stratis_test_filesystem"])
+    let &(_, fs_uuid) = pool.create_filesystems(&[("stratis_test_filesystem", None)])
         .unwrap()
         .first()
         .unwrap();

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -33,7 +33,8 @@ pub fn test_thinpool_expand(paths: &[&Path]) -> () {
                                               Redundancy::NONE,
                                               true)
             .unwrap();
-    let &(_, fs_uuid) = pool.create_filesystems(&vec![("stratis_test_filesystem", None)])
+
+    let &(_, fs_uuid) = pool.create_filesystems(&[("stratis_test_filesystem", None)])
         .unwrap()
         .first()
         .unwrap();

--- a/tests/util/setup_tests.rs
+++ b/tests/util/setup_tests.rs
@@ -195,7 +195,7 @@ pub fn test_pool_setup(paths: &[&Path]) {
 
     let (mut pool, _) = StratPool::initialize("name", &dm, paths, Redundancy::NONE, false).unwrap();
 
-    let (_, fs_uuid) = pool.create_filesystems(&["fsname"]).unwrap()[0];
+    let (_, fs_uuid) = pool.create_filesystems(&[("fsname", None)]).unwrap()[0];
 
     let tmp_dir = TempDir::new("stratis_testing").unwrap();
     let new_file = tmp_dir.path().join("stratis_test.txt");


### PR DESCRIPTION
The core of the PR is focused on expanding the logical space for XFS when the low water mark is crossed.  The expansion is requested via xfs_growfs.

To facilitate testing the changes a size parameter was added to Pool:: create_filesystems().