### PR TITLE
Add size parameter to Pool::create_filesystems

### DIFF
--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -56,7 +56,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_pool!(engine; pool_uuid; default_return; return_message);
 
-    let result = pool.create_filesystems(&filesystems.collect::<Vec<&str>>());
+    let result = pool.create_filesystems(&filesystems.collect::<Vec<&str>>(), None);
 
     let msg = match result {
         Ok(ref infos) => {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -37,7 +37,8 @@ pub trait Pool: HasName + HasUuid {
     /// Returns an error if any of the specified names are already in use
     /// for filesystems in this pool.
     fn create_filesystems<'a, 'b>(&'a mut self,
-                                  specs: &[&'b str])
+                                  specs: &[&'b str],
+                                  size: Option<Sectors>)
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>>;
 
     /// Adds blockdevs specified by paths to pool.

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -167,7 +167,7 @@ mod tests {
             .unwrap();
         {
             let pool = engine.get_pool(&uuid).unwrap();
-            pool.create_filesystems(&["test"]).unwrap();
+            pool.create_filesystems(&["test"], None).unwrap();
         }
         assert!(engine.destroy_pool(&uuid).is_err());
     }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -386,7 +386,8 @@ impl StratPool {
 
 impl Pool for StratPool {
     fn create_filesystems<'a, 'b>(&'a mut self,
-                                  specs: &[&'b str])
+                                  specs: &[&'b str],
+                                  size: Option<Sectors>)
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>> {
         let names: HashSet<_, RandomState> = HashSet::from_iter(specs);
         for name in &names {
@@ -405,7 +406,7 @@ impl Pool for StratPool {
                                                                   name,
                                                                   &dm,
                                                                   &mut self.thin_pool,
-                                                                  None));
+                                                                  size));
             try!(self.mdv.save_fs(&new_filesystem));
             self.filesystems.insert(new_filesystem);
             result.push((**name, uuid));

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -31,7 +31,7 @@ pub fn test_thinpool_expand(paths: &[&Path]) -> () {
                                               Redundancy::NONE,
                                               true)
             .unwrap();
-    let &(_, fs_uuid) = pool.create_filesystems(&vec!["stratis_test_filesystem"])
+    let &(_, fs_uuid) = pool.create_filesystems(&vec!["stratis_test_filesystem"], None)
         .unwrap()
         .first()
         .unwrap();
@@ -72,7 +72,7 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
     let (uuid1, _) = engine.create_pool(&name1, paths, None, false).unwrap();
     let fs_uuid = {
         let mut pool = engine.get_pool(&uuid1).unwrap();
-        let &(fs_name, fs_uuid) = pool.create_filesystems(&[name1])
+        let &(fs_name, fs_uuid) = pool.create_filesystems(&[name1], None)
             .unwrap()
             .first()
             .unwrap();


### PR DESCRIPTION
This can be very handy for testing purposes. If it's not given than the
pool implementation will pick a default size.

Signed-off-by: Andy Grover <agrover@redhat.com>