### PR TITLE
Move /dev/stratis creation from StratEngine::initialize to MDV::setup

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::create_dir;
-use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -19,8 +17,6 @@ use super::super::types::{PoolUuid, Redundancy, RenameAction};
 use super::cleanup::teardown_pools;
 use super::pool::StratPool;
 use super::setup::find_all;
-
-pub const DEV_PATH: &'static str = "/dev/stratis";
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DevOwnership {
@@ -42,12 +38,6 @@ impl StratEngine {
     /// Returns an error if there was an error reading device nodes.
     /// Returns an error if there was an error setting up any of the pools.
     pub fn initialize() -> EngineResult<StratEngine> {
-        if let Err(err) = create_dir(DEV_PATH) {
-            if err.kind() != ErrorKind::AlreadyExists {
-                return Err(From::from(err));
-            }
-        }
-
         let pools = try!(find_all());
 
         let mut table = Table::default();

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -22,12 +22,13 @@ use super::super::engine::HasUuid;
 use super::super::errors::EngineResult;
 use super::super::types::{FilesystemUuid, PoolUuid};
 
-use super::engine::DEV_PATH;
 use super::filesystem::{create_fs, StratFilesystem};
 use super::serde_structs::{FilesystemSave, Recordable};
 
 // TODO: Monitor fs size and extend linear and fs if needed
 // TODO: Document format of stuff on MDV in SWDD (currently ad-hoc)
+
+const DEV_PATH: &'static str = "/dev/stratis";
 
 const FILESYSTEM_DIR: &'static str = "filesystems";
 
@@ -46,6 +47,12 @@ impl MetadataVol {
 
     /// Set up an existing Metadata Volume.
     pub fn setup(pool_uuid: &PoolUuid, dev: LinearDev) -> EngineResult<MetadataVol> {
+        if let Err(err) = create_dir(DEV_PATH) {
+            if err.kind() != ErrorKind::AlreadyExists {
+                return Err(From::from(err));
+            }
+        }
+
         let filename = format!(".mdv-{}", pool_uuid.simple());
         let mount_pt: PathBuf = vec![DEV_PATH, &filename].iter().collect();
 


### PR DESCRIPTION
MDV setup will fail unless /dev/stratis exists. It should be possible to
setup a pool without setting up the engine. Have each pool ensure
/dev/stratis exists as part of MDV setup, rather than relying on
StratEngine::initialize().

Signed-off-by: Andy Grover <agrover@redhat.com>