### PR TITLE
Remove rename() from Filesystem trait

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -23,8 +23,6 @@ pub trait HasName: Debug {
 pub trait Dev: Debug {}
 
 pub trait Filesystem: HasName + HasUuid {
-    /// Rename this filesystem.
-    fn rename(&mut self, name: &str) -> ();
     /// Destroy this filesystem
     fn destroy(self) -> EngineResult<()>;
     /// path of the device node

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -21,13 +21,14 @@ impl SimFilesystem {
             name: name.to_owned(),
         }
     }
+
+    /// Set the name of this filesystem to name.
+    pub fn rename(&mut self, name: &str) {
+        self.name = name.to_owned();
+    }
 }
 
 impl Filesystem for SimFilesystem {
-    fn rename(&mut self, name: &str) {
-        self.name = name.to_owned();
-    }
-
     fn destroy(self) -> EngineResult<()> {
         Ok(())
     }

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -91,6 +91,11 @@ impl StratFilesystem {
     pub fn teardown(self, dm: &DM) -> EngineResult<()> {
         Ok(try!(self.thin_dev.teardown(dm)))
     }
+
+    /// Set the name of this filesystem to name.
+    pub fn rename(&mut self, name: &str) {
+        self.name = name.to_owned();
+    }
 }
 
 impl HasName for StratFilesystem {
@@ -106,10 +111,6 @@ impl HasUuid for StratFilesystem {
 }
 
 impl Filesystem for StratFilesystem {
-    fn rename(&mut self, name: &str) {
-        self.name = name.to_owned();
-    }
-
     fn destroy(self) -> EngineResult<()> {
         let dm = try!(DM::new());
         match self.thin_dev.teardown(&dm) {


### PR DESCRIPTION
It isn't part of the API of the Filesystem trait.
It's intented use is to be called by Pool level methods, not directly over the
D-Bus.

Signed-off-by: mulhern <amulhern@redhat.com>