### PR TITLE
Use the mnt crate to get the mountpoint of a filesystem.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "loopdev 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mnt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,6 +250,14 @@ dependencies = [
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mnt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -561,6 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
+"checksum mnt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43daa0eb417767aa91368f10142682b7be3570519badaf20aa7f5444700901ec"
 "checksum newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47e49f6982987135c5e9620ab317623e723bd06738fd85377e8d55f57c8b6487"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Andy Grover <agrover@redhat.com>", "Mulhern <amulhern@redhat.com>", 
 dbus = "0.5.2"
 clap = "1"
 nix = "0"
+mnt = "0.3"
 devicemapper = "0.6"
 crc = "1"
 byteorder = "0.3.13"

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -6,6 +6,8 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use mnt::get_mount;
+
 use devicemapper::DM;
 use devicemapper::Sectors;
 use devicemapper::{ThinDev, ThinDevId, ThinStatus};
@@ -85,6 +87,22 @@ impl StratFilesystem {
     /// The thin id for the thin device that backs this filesystem.
     pub fn thin_id(&self) -> ThinDevId {
         self.thin_dev.id()
+    }
+
+    /// Get the mount_point for this filesystem
+    pub fn get_mount_point(&self) -> EngineResult<PathBuf> {
+        match get_mount(&try!(self.devnode())) {
+            Ok(list) => {
+                match list {
+                    Some(mount) => Ok(mount.file),
+                    None => {
+                        Err(EngineError::Engine(ErrorEnum::Error,
+                                                "No mount point for filesystem".into()))
+                    }
+                }
+            }
+            Err(e) => Err(EngineError::Engine(ErrorEnum::Error, e.description().into())),
+        }
     }
 
     /// Tear down the filesystem.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate devicemapper;
 extern crate clap;
 #[macro_use]
 extern crate nix;
+extern crate mnt;
 extern crate crc;
 extern crate byteorder;
 extern crate uuid;


### PR DESCRIPTION
Will be used in future PR to get the XFS stats for a filesystem.

Signed-off-by: Todd Gill <tgill@redhat.com>