### PR TITLE
Make setup when devicemapper devices exist succeed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_pool_rename
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_blockdevmgr_used
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_filesystem_rename
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_pool_setup
 
 test-real:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_empty_pool
@@ -40,6 +41,7 @@ test-real:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_pool_rename
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_blockdevmgr_used
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_filesystem_rename
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_pool_setup
 
 test:
 	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -88,7 +88,6 @@ impl ThinPool {
     /// If initial setup fails due to a thin_check failure, attempt to fix
     /// the problem by running thin_repair. If failure recurs, return an
     /// error.
-    // FIXME: Check for still existing device mapper devices.
     #[allow(too_many_arguments)]
     pub fn setup(pool_uuid: PoolUuid,
                  dm: &DM,

--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -36,6 +36,7 @@ use util::pool_tests::test_thinpool_thindev_destroy;
 use util::setup_tests::test_basic_metadata;
 use util::setup_tests::test_initialize;
 use util::setup_tests::test_pool_rename;
+use util::setup_tests::test_pool_setup;
 use util::setup_tests::test_setup;
 use util::simple_tests::test_empty_pool;
 use util::simple_tests::test_teardown;
@@ -203,4 +204,9 @@ pub fn loop_test_blockdevmgr_used() {
 #[test]
 pub fn loop_test_filesystem_rename() {
     test_with_spec(2, test_filesystem_rename);
+}
+
+#[test]
+pub fn loop_test_pool_setup() {
+    test_with_spec(2, test_pool_setup);
 }

--- a/tests/real_tests.rs
+++ b/tests/real_tests.rs
@@ -33,6 +33,7 @@ use util::pool_tests::test_thinpool_thindev_destroy;
 use util::setup_tests::test_basic_metadata;
 use util::setup_tests::test_initialize;
 use util::setup_tests::test_pool_rename;
+use util::setup_tests::test_pool_setup;
 use util::setup_tests::test_setup;
 use util::simple_tests::test_empty_pool;
 use util::simple_tests::test_teardown;
@@ -173,4 +174,9 @@ pub fn real_test_blockdevmgr_used() {
 #[test]
 pub fn real_test_filesystem_rename() {
     test_with_spec(2, test_filesystem_rename);
+}
+
+#[test]
+pub fn real_test_pool_setup() {
+    test_with_spec(2, test_pool_setup);
 }


### PR DESCRIPTION
If the metadata filesystem is already mounted do not remount it.