### PR TITLE
Use expects() more appropriately

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -277,7 +277,7 @@ impl StratPool {
 
     pub fn check(&mut self) -> () {
         #![allow(match_same_arms)]
-        let dm = DM::new().expect("Could not get DM handle");
+        let dm = DM::new().unwrap();
 
         let result = match self.thin_pool.check(&dm) {
             Ok(r) => r,

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -108,16 +108,22 @@ impl RangeAllocator {
                 (None, Some((next_off, next_len))) => {
                     // Contig with next, make new entry
                     self.used.insert(off, len + next_len);
-                    self.used.remove(&next_off).expect("must exist");
+                    self.used
+                        .remove(&next_off)
+                        .expect("matched Some((next_off, ...");
                 }
                 (Some((prev_off, prev_len)), None) => {
                     // Contig with prev, just extend prev
-                    *self.used.get_mut(&prev_off).expect("must exist") = prev_len + len;
+                    *self.used
+                         .get_mut(&prev_off)
+                         .expect("matched Some((prev_off, ...") = prev_len + len;
                 }
                 (Some((prev_off, prev_len)), Some((next_off, next_len))) => {
                     // Contig with both, remove next and extend prev
                     self.used.remove(&next_off);
-                    *self.used.get_mut(&prev_off).expect("must exist") = prev_len + len + next_len;
+                    *self.used
+                         .get_mut(&prev_off)
+                         .expect("matched Some((prev_off, ...") = prev_len + len + next_len;
                 }
             }
         }


### PR DESCRIPTION
Use ```expects()``` to convey information and if there is no information to convey, turn them into ```unwraps()```.

https://github.com/rust-lang-nursery/rust-clippy/issues/1921#issuecomment-319693657