### PR TITLE
Add `.iter()` to Table

### DIFF
--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -98,7 +98,7 @@ impl Engine for SimEngine {
     }
 
     fn pools(&self) -> Vec<&Pool> {
-        self.pools.into_iter().map(|x| x as &Pool).collect()
+        self.pools.iter().map(|x| x as &Pool).collect()
     }
 }
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -156,7 +156,7 @@ impl Pool for SimPool {
 
     fn filesystems(&self) -> Vec<&Filesystem> {
         self.filesystems
-            .into_iter()
+            .iter()
             .map(|x| x as &Filesystem)
             .collect()
     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -129,6 +129,6 @@ impl Engine for StratEngine {
     }
 
     fn pools(&self) -> Vec<&Pool> {
-        self.pools.into_iter().map(|x| x as &Pool).collect()
+        self.pools.iter().map(|x| x as &Pool).collect()
     }
 }

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -279,7 +279,7 @@ impl ThinPool {
 
     pub fn filesystems(&self) -> Vec<&Filesystem> {
         self.filesystems
-            .into_iter()
+            .iter()
             .map(|x| x as &Filesystem)
             .collect()
     }

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::iter::IntoIterator;
 use std::slice::{Iter, IterMut};
+use std::vec::IntoIter;
 
 use uuid::Uuid;
 
@@ -33,7 +34,7 @@ impl<'a, T: HasName + HasUuid> IntoIterator for &'a mut Table<T> {
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 
-    fn into_iter(mut self) -> IterMut<'a, T> {
+    fn into_iter(mut self) -> Self::IntoIter {
         self.items.iter_mut()
     }
 }
@@ -42,8 +43,17 @@ impl<'a, T: HasName + HasUuid> IntoIterator for &'a Table<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
-    fn into_iter(self) -> Iter<'a, T> {
+    fn into_iter(self) -> Self::IntoIter {
         self.items.iter()
+    }
+}
+
+impl<T: HasName + HasUuid> IntoIterator for Table<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
     }
 }
 
@@ -177,6 +187,14 @@ impl<T: HasName + HasUuid> Table<T> {
             (Some(name_item), None) => vec![name_item],
             (Some(name_item), Some(uuid_item)) => vec![name_item, uuid_item],
         }
+    }
+
+    pub fn iter(&self) -> Iter<T> {
+        self.items.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<T> {
+        self.items.iter_mut()
     }
 }
 


### PR DESCRIPTION
This commit adds `.iter()` to `Table` and also adds an
additional version of IntoIterator. This brings it completely
in line with the `Vec` interface of the standard library.

This is referring to https://github.com/stratis-storage/stratisd/issues/492