### PR TITLE
Convert all `try!` to use `?` operator

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+use_try_shorthand = true

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -42,10 +42,10 @@ use libstratis::stratis::{StratisResult, StratisError, VERSION};
 /// Try to write the error from the program to stderr, vehemently.
 /// Return an error if stderr unavailable or writing was a failure.
 fn write_err(err: StratisError) -> StratisResult<()> {
-    let mut out = try!(term::stderr().ok_or(StratisError::StderrNotFound));
-    try!(out.fg(term::color::RED));
-    try!(writeln!(out, "{}", err.description()));
-    try!(out.reset());
+    let mut out = term::stderr().ok_or(StratisError::StderrNotFound)?;
+    out.fg(term::color::RED)?;
+    writeln!(out, "{}", err.description())?;
+    out.reset()?;
     Ok(())
 }
 
@@ -89,12 +89,11 @@ fn run() -> StratisResult<()> {
             Rc::new(RefCell::new(SimEngine::default()))
         } else {
             info!("Using StratEngine");
-            Rc::new(RefCell::new(try!(StratEngine::initialize())))
+            Rc::new(RefCell::new(StratEngine::initialize()?))
         }
     };
 
-    let (dbus_conn, mut tree, dbus_context) =
-        try!(libstratis::dbus_api::connect(Rc::clone(&engine)));
+    let (dbus_conn, mut tree, dbus_context) = libstratis::dbus_api::connect(Rc::clone(&engine))?;
 
     // Get a list of fds to poll for
     let mut fds: Vec<_> = dbus_conn

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -47,10 +47,10 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let name: &str = try!(get_next_arg(&mut iter, 0));
-    let redundancy: (bool, u16) = try!(get_next_arg(&mut iter, 1));
-    let force: bool = try!(get_next_arg(&mut iter, 2));
-    let devs: Array<&str, _> = try!(get_next_arg(&mut iter, 3));
+    let name: &str = get_next_arg(&mut iter, 0)?;
+    let redundancy: (bool, u16) = get_next_arg(&mut iter, 1)?;
+    let force: bool = get_next_arg(&mut iter, 2)?;
+    let devs: Array<&str, _> = get_next_arg(&mut iter, 3)?;
 
     let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
@@ -98,7 +98,7 @@ fn destroy_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let object_path: dbus::Path<'static> = try!(get_next_arg(&mut iter, 0));
+    let object_path: dbus::Path<'static> = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
 
@@ -169,7 +169,7 @@ fn configure_simulator(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message = m.msg;
     let mut iter = message.iter_init();
 
-    let denominator: u32 = try!(get_next_arg(&mut iter, 0));
+    let denominator: u32 = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
     let result = dbus_context
@@ -256,7 +256,7 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>, db
 #[allow(type_complexity)]
 pub fn connect(engine: Rc<RefCell<Engine>>)
                -> Result<(Connection, Tree<MTFn<TData>, TData>, DbusContext), dbus::Error> {
-    let c = try!(Connection::get_private(BusType::System));
+    let c = Connection::get_private(BusType::System)?;
 
     let local_engine = Rc::clone(&engine);
 
@@ -272,9 +272,9 @@ pub fn connect(engine: Rc<RefCell<Engine>>)
         }
     }
 
-    try!(tree.set_registered(&c, true));
+    tree.set_registered(&c, true)?;
 
-    try!(c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32));
+    c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32)?;
 
     Ok((c, tree, dbus_context))
 }
@@ -297,7 +297,7 @@ pub fn handle(c: &Connection,
         for action in b_actions.drain() {
             match action {
                 DeferredAction::Add(path) => {
-                    try!(c.register_object_path(path.get_name()));
+                    c.register_object_path(path.get_name())?;
                     tree.insert(path);
                 }
                 DeferredAction::Remove(path) => {

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -89,7 +89,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let new_name: &str = try!(get_next_arg(&mut iter, 0));
+    let new_name: &str = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
@@ -149,42 +149,40 @@ fn get_filesystem_property<F>(i: &mut IterAppend,
         .get(object_path)
         .expect("tree must contain implicit argument");
 
-    let filesystem_data = try!(filesystem_path
-                        .get_data()
-                        .as_ref()
-                        .ok_or_else(|| {
-                                        MethodErr::failed(&format!("no data for object path {}",
-                                                                   object_path))
-                                    }));
+    let filesystem_data =
+        filesystem_path
+            .get_data()
+            .as_ref()
+            .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
 
-    let pool_path = try!(p.tree
-                 .get(&filesystem_data.parent)
-                 .ok_or_else(|| {
-                                 MethodErr::failed(&format!("no path for parent object path {}",
-                                                            &filesystem_data.parent))
-                             }));
+    let pool_path = p.tree
+        .get(&filesystem_data.parent)
+        .ok_or_else(|| {
+                        MethodErr::failed(&format!("no path for parent object path {}",
+                                                   &filesystem_data.parent))
+                    })?;
 
-    let pool_uuid = try!(pool_path
-                        .get_data()
-                        .as_ref()
-                        .ok_or_else(|| {
-                                        MethodErr::failed(&format!("no data for object path {}",
-                                                                   object_path))
-                                    }))
-            .uuid;
+    let pool_uuid = pool_path
+        .get_data()
+        .as_ref()
+        .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?
+        .uuid;
 
     let engine = dbus_context.engine.borrow();
-    let pool = try!(engine
-                 .get_pool(&pool_uuid)
-                 .ok_or_else(|| {
-                                 MethodErr::failed(&format!("no pool corresponding to uuid {}",
-                                                            &pool_uuid))
-                             }));
+    let pool =
+        engine
+            .get_pool(&pool_uuid)
+            .ok_or_else(|| {
+                            MethodErr::failed(&format!("no pool corresponding to uuid {}",
+                                                       &pool_uuid))
+                        })?;
     let filesystem_uuid = &filesystem_data.uuid;
-    let filesystem = try!(pool.get_filesystem(filesystem_uuid)
-        .ok_or_else(|| MethodErr::failed(&format!("no name for filesystem with uuid {}",
-                                          &filesystem_uuid))));
-    i.append(try!(getter(filesystem)));
+    let filesystem = pool.get_filesystem(filesystem_uuid)
+        .ok_or_else(|| {
+                        MethodErr::failed(&format!("no name for filesystem with uuid {}",
+                                                   &filesystem_uuid))
+                    })?;
+    i.append(getter(filesystem)?);
     Ok(())
 }
 
@@ -194,12 +192,12 @@ fn get_filesystem_devnode(i: &mut IterAppend,
                           -> Result<(), MethodErr> {
 
     fn get_devnode(filesystem: &Filesystem) -> Result<MessageItem, MethodErr> {
-        let devnode = try!(filesystem
+        let devnode = filesystem
             .devnode()
             .map_err(|_| {
-                     MethodErr::failed(&format!("no devnode for filesystem with uuid {}",
-                                                filesystem.uuid()))
-            }));
+                         MethodErr::failed(&format!("no devnode for filesystem with uuid {}",
+                                                    filesystem.uuid()))
+                     })?;
         Ok(MessageItem::Str(format!("{}", devnode.display())))
     }
 

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -42,7 +42,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let filesystems: Array<&str, _> = try!(get_next_arg(&mut iter, 0));
+    let filesystems: Array<&str, _> = get_next_arg(&mut iter, 0)?;
     let dbus_context = m.tree.get_data();
 
     let object_path = m.path.get_name();
@@ -97,7 +97,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let filesystems: Array<dbus::Path<'static>, _> = try!(get_next_arg(&mut iter, 0));
+    let filesystems: Array<dbus::Path<'static>, _> = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
@@ -152,8 +152,8 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let force: bool = try!(get_next_arg(&mut iter, 0));
-    let devs: Array<&str, _> = try!(get_next_arg(&mut iter, 1));
+    let force: bool = get_next_arg(&mut iter, 0)?;
+    let devs: Array<&str, _> = get_next_arg(&mut iter, 1)?;
 
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
@@ -197,7 +197,7 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let new_name: &str = try!(get_next_arg(&mut iter, 0));
+    let new_name: &str = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
@@ -250,24 +250,22 @@ fn get_pool_property<F>(i: &mut IterAppend,
         .get(object_path)
         .expect("implicit argument must be in tree");
 
-    let pool_uuid = try!(pool_path
-                        .get_data()
-                        .as_ref()
-                        .ok_or_else(|| {
-                                        MethodErr::failed(&format!("no data for object path {}",
-                                                                   object_path))
-                                    }))
-            .uuid;
+    let pool_uuid = pool_path
+        .get_data()
+        .as_ref()
+        .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?
+        .uuid;
 
     let engine = dbus_context.engine.borrow();
-    let pool = try!(engine
-                 .get_pool(&pool_uuid)
-                 .ok_or_else(|| {
-                                 MethodErr::failed(&format!("no pool corresponding to uuid {}",
-                                                            &pool_uuid))
-                             }));
+    let pool =
+        engine
+            .get_pool(&pool_uuid)
+            .ok_or_else(|| {
+                            MethodErr::failed(&format!("no pool corresponding to uuid {}",
+                                                       &pool_uuid))
+                        })?;
 
-    i.append(try!(getter(pool)));
+    i.append(getter(pool)?);
     Ok(())
 }
 
@@ -284,9 +282,9 @@ fn get_pool_total_physical_used(i: &mut IterAppend,
                                        pool.uuid()))
         };
 
-        try!(pool.total_physical_used()
-                 .map(|u| Ok(MessageItem::Str(format!("{}", *u))))
-                 .map_err(err_func))
+        pool.total_physical_used()
+            .map(|u| Ok(MessageItem::Str(format!("{}", *u))))
+            .map_err(err_func)?
     }
 
     get_pool_property(i, p, get_used)

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -28,8 +28,8 @@ pub fn get_next_arg<'a, T>(iter: &mut Iter<'a>, loc: u16) -> Result<T, MethodErr
     if iter.arg_type() == ArgType::Invalid {
         return Err(MethodErr::no_arg());
     };
-    let value: T = try!(iter.read::<T>()
-                            .map_err(|_| MethodErr::invalid_arg(&loc)));
+    let value: T = iter.read::<T>()
+        .map_err(|_| MethodErr::invalid_arg(&loc))?;
     Ok(value)
 }
 
@@ -79,12 +79,10 @@ pub fn get_uuid(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<
         .get(object_path)
         .expect("implicit argument must be in tree");
 
-    let data = try!(path.get_data()
-                        .as_ref()
-                        .ok_or_else(|| {
-                                        MethodErr::failed(&format!("no data for object path {}",
-                                                                   object_path))
-                                    }));
+    let data =
+        path.get_data()
+            .as_ref()
+            .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
 
     i.append(MessageItem::Str(format!("{}", data.uuid.simple())));
     Ok(())
@@ -98,12 +96,10 @@ pub fn get_parent(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Resul
         .get(object_path)
         .expect("implicit argument must be in tree");
 
-    let data = try!(path.get_data()
-                        .as_ref()
-                        .ok_or_else(|| {
-                                        MethodErr::failed(&format!("no data for object path {}",
-                                                                   object_path))
-                                    }));
+    let data =
+        path.get_data()
+            .as_ref()
+            .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
 
     i.append(MessageItem::ObjectPath(data.parent.clone()));
     Ok(())

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -29,9 +29,9 @@ macro_rules! destroy_pool {
         } else {
             return Ok(false);
         }
-        try!($s.pools.remove_by_uuid($uuid)
+        $s.pools.remove_by_uuid($uuid)
              .expect("Must succeed since $s.pool.get_by_uuid() returned a value")
-             .destroy());
+             .destroy()?;
         Ok(true)
     }
 }

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -43,12 +43,12 @@ impl BlockDev {
     }
 
     pub fn wipe_metadata(self) -> EngineResult<()> {
-        let mut f = try!(OpenOptions::new().write(true).open(&self.devnode));
+        let mut f = OpenOptions::new().write(true).open(&self.devnode)?;
         BDA::wipe(&mut f)
     }
 
     pub fn save_state(&mut self, time: &DateTime<Utc>, metadata: &[u8]) -> EngineResult<()> {
-        let mut f = try!(OpenOptions::new().write(true).open(&self.devnode));
+        let mut f = OpenOptions::new().write(true).open(&self.devnode)?;
         self.bda.save_state(time, metadata, &mut f)
     }
 

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -32,14 +32,14 @@ pub fn write_sectors<P: AsRef<Path>>(path: P,
                                      length: Sectors,
                                      buf: &[u8; SECTOR_SIZE])
                                      -> EngineResult<()> {
-    let mut f = try!(OpenOptions::new().write(true).open(path));
+    let mut f = OpenOptions::new().write(true).open(path)?;
 
-    try!(f.seek(SeekFrom::Start(*offset)));
+    f.seek(SeekFrom::Start(*offset))?;
     for _ in 0..*length {
-        try!(f.write_all(buf));
+        f.write_all(buf)?;
     }
 
-    try!(f.flush());
+    f.flush()?;
     Ok(())
 }
 

--- a/src/engine/strat_engine/dmdevice.rs
+++ b/src/engine/strat_engine/dmdevice.rs
@@ -101,7 +101,7 @@ impl ThinDevIdPool {
     // TODO: Improve this so that it is guaranteed only to fail if every 24 bit
     // number has been used.
     pub fn new_id(&mut self) -> EngineResult<ThinDevId> {
-        let next_id = try!(ThinDevId::new_u64((self.next_id) as u64));
+        let next_id = ThinDevId::new_u64((self.next_id) as u64)?;
         self.next_id += 1;
         Ok(next_id)
     }

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -51,17 +51,16 @@ impl BDA {
         let hdr_buf = header.sigblock_to_buf();
 
         // Write 8K header. Static_Header copies go in sectors 1 and 9.
-        try!(f.seek(SeekFrom::Start(0)));
-        try!(f.write_all(&zeroed[..SECTOR_SIZE]));
-        try!(f.write_all(&hdr_buf));
-        try!(f.write_all(&zeroed[SECTOR_SIZE * 7..]));
-        try!(f.flush());
-        try!(f.write_all(&hdr_buf));
-        try!(f.write_all(&zeroed[SECTOR_SIZE * 6..]));
-        try!(f.flush());
+        f.seek(SeekFrom::Start(0))?;
+        f.write_all(&zeroed[..SECTOR_SIZE])?;
+        f.write_all(&hdr_buf)?;
+        f.write_all(&zeroed[SECTOR_SIZE * 7..])?;
+        f.flush()?;
+        f.write_all(&hdr_buf)?;
+        f.write_all(&zeroed[SECTOR_SIZE * 6..])?;
+        f.flush()?;
 
-        let regions =
-            try!(mda::MDARegions::initialize(BDA_STATIC_HDR_SIZE, header.mda_size, &mut f));
+        let regions = mda::MDARegions::initialize(BDA_STATIC_HDR_SIZE, header.mda_size, &mut f)?;
 
         Ok(BDA {
                header: header,
@@ -74,12 +73,12 @@ impl BDA {
     pub fn load<F>(f: &mut F) -> EngineResult<Option<BDA>>
         where F: Read + Seek
     {
-        let header = match try!(StaticHeader::setup(f)) {
+        let header = match StaticHeader::setup(f)? {
             Some(header) => header,
             None => return Ok(None),
         };
 
-        let regions = try!(mda::MDARegions::load(BDA_STATIC_HDR_SIZE, header.mda_size, f));
+        let regions = mda::MDARegions::load(BDA_STATIC_HDR_SIZE, header.mda_size, f)?;
 
         Ok(Some(BDA {
                     header: header,
@@ -95,9 +94,9 @@ impl BDA {
         let zeroed = [0u8; _BDA_STATIC_HDR_SIZE];
 
         // Wiping Static Header should do it
-        try!(f.seek(SeekFrom::Start(0)));
-        try!(f.write_all(&zeroed));
-        try!(f.flush());
+        f.seek(SeekFrom::Start(0))?;
+        f.write_all(&zeroed)?;
+        f.flush()?;
         Ok(())
     }
 
@@ -184,9 +183,9 @@ impl StaticHeader {
     fn setup<F>(f: &mut F) -> EngineResult<Option<StaticHeader>>
         where F: Read + Seek
     {
-        try!(f.seek(SeekFrom::Start(0)));
+        f.seek(SeekFrom::Start(0))?;
         let mut buf = [0u8; _BDA_STATIC_HDR_SIZE];
-        try!(f.read(&mut buf));
+        f.read(&mut buf)?;
 
         // TODO: repair static header if one incorrect?
         // Note: this would require some adjustment or some revision to
@@ -220,9 +219,9 @@ impl StaticHeader {
     {
 
 
-        try!(f.seek(SeekFrom::Start(0)));
+        f.seek(SeekFrom::Start(0))?;
         let mut buf = [0u8; _BDA_STATIC_HDR_SIZE];
-        try!(f.read(&mut buf));
+        f.read(&mut buf)?;
 
         // Using setup() as a test of ownership sets a high bar. It is
         // not sufficient to have STRAT_MAGIC to be considered "Ours",
@@ -273,12 +272,12 @@ impl StaticHeader {
 
         let blkdev_size = Sectors(LittleEndian::read_u64(&buf[20..28]));
 
-        let pool_uuid = try!(Uuid::parse_str(try!(from_utf8(&buf[32..64]))));
-        let dev_uuid = try!(Uuid::parse_str(try!(from_utf8(&buf[64..96]))));
+        let pool_uuid = Uuid::parse_str(from_utf8(&buf[32..64])?)?;
+        let dev_uuid = Uuid::parse_str(from_utf8(&buf[64..96])?)?;
 
         let mda_size = Sectors(LittleEndian::read_u64(&buf[96..104]));
 
-        try!(mda::validate_mda_size(mda_size));
+        mda::validate_mda_size(mda_size)?;
 
         Ok(Some(StaticHeader {
                     pool_uuid: pool_uuid,
@@ -345,13 +344,13 @@ mod mda {
             let region_size = size / NUM_MDA_REGIONS;
             let per_region_size = region_size.bytes();
             for region in 0..NUM_MDA_REGIONS {
-                try!(f.seek(SeekFrom::Start(MDARegions::mda_offset(header_size,
-                                                                   region,
-                                                                   per_region_size))));
-                try!(f.write_all(&hdr_buf));
+                f.seek(SeekFrom::Start(MDARegions::mda_offset(header_size,
+                                                                 region,
+                                                                 per_region_size)))?;
+                f.write_all(&hdr_buf)?;
             }
 
-            try!(f.flush());
+            f.flush()?;
 
             Ok(MDARegions {
                    region_size: region_size,
@@ -376,11 +375,11 @@ mod mda {
             // been corrrupted, return an error.
             let mut load_a_region = |index: usize| -> EngineResult<Option<MDAHeader>> {
                 let mut hdr_buf = [0u8; _MDA_REGION_HDR_SIZE];
-                try!(f.seek(SeekFrom::Start(MDARegions::mda_offset(header_size,
-                                                                   index,
-                                                                   per_region_size))));
-                try!(f.read_exact(&mut hdr_buf));
-                Ok(try!(MDAHeader::from_buf(&hdr_buf, per_region_size)))
+                f.seek(SeekFrom::Start(MDARegions::mda_offset(header_size,
+                                                                 index,
+                                                                 per_region_size)))?;
+                f.read_exact(&mut hdr_buf)?;
+                Ok(MDAHeader::from_buf(&hdr_buf, per_region_size)?)
             };
 
             // Get an MDAHeader for the given index.
@@ -392,7 +391,7 @@ mod mda {
 
             Ok(MDARegions {
                    region_size: region_size,
-                   mdas: [try!(get_mda(0)), try!(get_mda(1))],
+                   mdas: [get_mda(0)?, get_mda(1)?],
                })
         }
 
@@ -418,7 +417,7 @@ mod mda {
 
             let region_size = self.region_size.bytes();
             let used = Bytes(data.len() as u64);
-            try!(check_mda_region_size(used, region_size));
+            check_mda_region_size(used, region_size)?;
 
             let header = MDAHeader {
                 last_updated: *time,
@@ -429,12 +428,10 @@ mod mda {
 
             // Write data to a region specified by index.
             let mut save_region = |index: usize| -> EngineResult<()> {
-                try!(f.seek(SeekFrom::Start(MDARegions::mda_offset(header_size,
-                                                                   index,
-                                                                   region_size))));
-                try!(f.write_all(&hdr_buf));
-                try!(f.write_all(data));
-                try!(f.flush());
+                f.seek(SeekFrom::Start(MDARegions::mda_offset(header_size, index, region_size)))?;
+                f.write_all(&hdr_buf)?;
+                f.write_all(data)?;
+                f.flush()?;
 
                 Ok(())
             };
@@ -442,8 +439,8 @@ mod mda {
             // TODO: Consider if there is an action that should be taken if
             // saving to one or the other region fails.
             let older_region = self.older();
-            try!(save_region(older_region));
-            try!(save_region(older_region + 2));
+            save_region(older_region)?;
+            save_region(older_region + 2)?;
 
             self.mdas[older_region] = Some(header);
 
@@ -469,7 +466,7 @@ mod mda {
             let mut load_region = |index: usize| -> EngineResult<Vec<u8>> {
                 let offset = MDARegions::mda_offset(header_size, index, region_size) +
                              _MDA_REGION_HDR_SIZE as u64;
-                try!(f.seek(SeekFrom::Start(offset)));
+                f.seek(SeekFrom::Start(offset))?;
                 mda.load_region(f)
             };
 
@@ -548,7 +545,7 @@ mod mda {
                 0 => Ok(None),
                 secs => {
                     let used = Bytes(LittleEndian::read_u64(&buf[8..16]));
-                    try!(check_mda_region_size(used, region_size));
+                    check_mda_region_size(used, region_size)?;
 
                     // Signed cast is safe, highest order bit of each value
                     // read is guaranteed to be 0.
@@ -599,7 +596,7 @@ mod mda {
             assert!(*self.used <= std::usize::MAX as u64);
             let mut data_buf = vec![0u8; *self.used as usize];
 
-            try!(f.read_exact(&mut data_buf));
+            f.read_exact(&mut data_buf)?;
 
             if self.data_crc != crc32::checksum_ieee(&data_buf) {
                 return Err(EngineError::Engine(ErrorEnum::Invalid, "MDA region data CRC".into()));

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -61,8 +61,7 @@ impl StratPool {
                       -> EngineResult<(StratPool, Vec<PathBuf>)> {
         let pool_uuid = Uuid::new_v4();
 
-        let mut block_mgr =
-            try!(BlockDevMgr::initialize(&pool_uuid, paths, MIN_MDA_SECTORS, force));
+        let mut block_mgr = BlockDevMgr::initialize(&pool_uuid, paths, MIN_MDA_SECTORS, force)?;
 
         if block_mgr.avail_space() < StratPool::min_initial_size() {
             let avail_size = block_mgr.avail_space().bytes();
@@ -99,33 +98,33 @@ impl StratPool {
         // superblock DM issue error messages because it triggers code paths
         // that are trying to re-adopt the device with the attributes that
         // have been passed.
-        let meta_dev = try!(LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
-                                           dm,
-                                           meta_regions));
-        try!(wipe_sectors(&try!(meta_dev.devnode()),
-                          Sectors(0),
-                          INITIAL_META_SIZE.sectors()));
+        let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
+                                      dm,
+                                      meta_regions)?;
+        wipe_sectors(&meta_dev.devnode()?,
+                     Sectors(0),
+                     INITIAL_META_SIZE.sectors())?;
 
-        let data_dev = try!(LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
-                                           dm,
-                                           data_regions));
+        let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
+                                      dm,
+                                      data_regions)?;
 
         let mdv_regions = block_mgr
             .alloc_space(INITIAL_MDV_SIZE)
             .expect("blockmgr must not fail, already checked for space");
 
         let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
-        let mdv_dev = try!(LinearDev::new(&mdv_name, dm, mdv_regions));
-        let mdv = try!(MetadataVol::initialize(&pool_uuid, mdv_dev));
+        let mdv_dev = LinearDev::new(&mdv_name, dm, mdv_regions)?;
+        let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
 
-        let thinpool = try!(ThinPool::new(pool_uuid,
-                                          dm,
-                                          DATA_BLOCK_SIZE,
-                                          DATA_LOWATER,
-                                          meta_spare_regions,
-                                          meta_dev,
-                                          data_dev,
-                                          mdv));
+        let thinpool = ThinPool::new(pool_uuid,
+                                     dm,
+                                     DATA_BLOCK_SIZE,
+                                     DATA_LOWATER,
+                                     meta_spare_regions,
+                                     meta_dev,
+                                     data_dev,
+                                     mdv)?;
 
         let devnodes = block_mgr.devnodes();
 
@@ -137,7 +136,7 @@ impl StratPool {
             thin_pool: thinpool,
         };
 
-        try!(pool.write_metadata());
+        pool.write_metadata()?;
 
         Ok((pool, devnodes))
     }
@@ -146,11 +145,12 @@ impl StratPool {
     // TODO: Clean up after errors that occur after some action has been
     // taken on the environment.
     pub fn setup(uuid: PoolUuid, devnodes: &[PathBuf]) -> EngineResult<StratPool> {
-        let metadata = try!(try!(get_metadata(uuid, devnodes))
-                                .ok_or_else(|| EngineError::Engine(ErrorEnum::NotFound,
-                                                           format!("no metadata for pool {}",
-                                                                   uuid))));
-        let blockdevs = try!(get_blockdevs(uuid, &metadata, devnodes));
+        let metadata = get_metadata(uuid, devnodes)?
+            .ok_or_else(|| {
+                            EngineError::Engine(ErrorEnum::NotFound,
+                                                format!("no metadata for pool {}", uuid))
+                        })?;
+        let blockdevs = get_blockdevs(uuid, &metadata, devnodes)?;
 
         let uuid_map: HashMap<DevUuid, Device> = blockdevs
             .iter()
@@ -161,11 +161,13 @@ impl StratPool {
         // This can fail if there is no entry for the UUID in the map
         // from UUIDs to device numbers.
         let lookup = |triple: &(Uuid, Sectors, Sectors)| -> EngineResult<Segment> {
-            let device = try!(uuid_map
-                                  .get(&triple.0)
-                                  .ok_or_else(|| EngineError::Engine(ErrorEnum::NotFound,
-                                                             format!("missing device for UUID {:?}",
-                                                                     &triple.0))));
+            let device = uuid_map
+                .get(&triple.0)
+                .ok_or_else(|| {
+                                EngineError::Engine(ErrorEnum::NotFound,
+                                                    format!("missing device for UUID {:?}",
+                                                            &triple.0))
+                            })?;
             Ok(Segment {
                    device: *device,
                    start: triple.1,
@@ -173,62 +175,60 @@ impl StratPool {
                })
         };
 
-        let meta_segments: Vec<Segment> = try!(metadata
-                                                   .flex_devs
-                                                   .meta_dev
-                                                   .iter()
-                                                   .map(&lookup)
-                                                   .collect());
+        let flex_devs = &metadata.flex_devs;
 
-        let thin_meta_segments: Vec<Segment> = try!(metadata
-                                                        .flex_devs
-                                                        .thin_meta_dev
-                                                        .iter()
-                                                        .map(&lookup)
-                                                        .collect());
+        let meta_segments = flex_devs
+            .meta_dev
+            .iter()
+            .map(&lookup)
+            .collect::<EngineResult<Vec<_>>>()?;
 
-        let thin_data_segments: Vec<Segment> = try!(metadata
-                                                        .flex_devs
-                                                        .thin_data_dev
-                                                        .iter()
-                                                        .map(&lookup)
-                                                        .collect());
+        let thin_meta_segments = flex_devs
+            .thin_meta_dev
+            .iter()
+            .map(&lookup)
+            .collect::<EngineResult<Vec<_>>>()?;
 
-        let thin_meta_spare_segments: Vec<Segment> = try!(metadata
-                                                              .flex_devs
-                                                              .thin_meta_dev_spare
-                                                              .iter()
-                                                              .map(&lookup)
-                                                              .collect());
+        let thin_data_segments = flex_devs
+            .thin_data_dev
+            .iter()
+            .map(&lookup)
+            .collect::<EngineResult<Vec<_>>>()?;
 
-        let dm = try!(DM::new());
+        let thin_meta_spare_segments = flex_devs
+            .thin_meta_dev_spare
+            .iter()
+            .map(&lookup)
+            .collect::<EngineResult<Vec<_>>>()?;
+
+        let dm = DM::new()?;
 
         // This is the cleanup zone.
-        let meta_dev = try!(LinearDev::new(&format_flex_name(&uuid, FlexRole::ThinMeta),
-                                           &dm,
-                                           thin_meta_segments));
+        let meta_dev = LinearDev::new(&format_flex_name(&uuid, FlexRole::ThinMeta),
+                                      &dm,
+                                      thin_meta_segments)?;
 
-        let data_dev = try!(LinearDev::new(&format_flex_name(&uuid, FlexRole::ThinData),
-                                           &dm,
-                                           thin_data_segments));
+        let data_dev = LinearDev::new(&format_flex_name(&uuid, FlexRole::ThinData),
+                                      &dm,
+                                      thin_data_segments)?;
 
-        let mdv_dev = try!(LinearDev::new(&format_flex_name(&uuid, FlexRole::MetadataVolume),
-                                          &dm,
-                                          meta_segments));
-        let mdv = try!(MetadataVol::setup(&uuid, mdv_dev));
-        let filesystem_metadatas = try!(mdv.filesystems());
+        let mdv_dev = LinearDev::new(&format_flex_name(&uuid, FlexRole::MetadataVolume),
+                                     &dm,
+                                     meta_segments)?;
+        let mdv = MetadataVol::setup(&uuid, mdv_dev)?;
+        let filesystem_metadatas = mdv.filesystems()?;
         let thin_ids: Vec<ThinDevId> = filesystem_metadatas.iter().map(|x| x.thin_id).collect();
 
-        let thinpool = try!(ThinPool::setup(uuid,
-                                            &dm,
-                                            metadata.thinpool_dev.data_block_size,
-                                            DATA_LOWATER,
-                                            &thin_ids,
-                                            thin_meta_spare_segments,
-                                            meta_dev,
-                                            data_dev,
-                                            mdv,
-                                            filesystem_metadatas));
+        let thinpool = ThinPool::setup(uuid,
+                                       &dm,
+                                       metadata.thinpool_dev.data_block_size,
+                                       DATA_LOWATER,
+                                       &thin_ids,
+                                       thin_meta_spare_segments,
+                                       meta_dev,
+                                       data_dev,
+                                       mdv,
+                                       filesystem_metadatas)?;
 
         Ok(StratPool {
                name: metadata.name,
@@ -248,7 +248,7 @@ impl StratPool {
 
     /// Write current metadata to pool members.
     pub fn write_metadata(&mut self) -> EngineResult<()> {
-        let data = try!(serde_json::to_string(&try!(self.record())));
+        let data = serde_json::to_string(&self.record()?)?;
         self.block_devs.save_state(data.as_bytes())
     }
     /// Return an extend size for the physical space backing a pool
@@ -265,7 +265,7 @@ impl StratPool {
         if let Some(new_data_regions) =
             self.block_devs
                 .alloc_space(*extend_size * DATA_BLOCK_SIZE) {
-            try!(self.thin_pool.extend_data(dm, new_data_regions));
+            self.thin_pool.extend_data(dm, new_data_regions)?;
         } else {
             let err_msg = format!("Insufficient space to accomodate request for {} data blocks",
                                   *extend_size);
@@ -335,9 +335,9 @@ impl StratPool {
     /// Teardown a pool.
     /// Take down the device mapper devices belonging to the pool.
     pub fn teardown(self) -> EngineResult<()> {
-        let dm = try!(DM::new());
+        let dm = DM::new()?;
 
-        try!(self.thin_pool.teardown(&dm));
+        self.thin_pool.teardown(&dm)?;
 
         Ok(())
     }
@@ -373,11 +373,11 @@ impl Pool for StratPool {
         }
 
         // TODO: Roll back on filesystem initialization failure.
-        let dm = try!(DM::new());
+        let dm = DM::new()?;
         let mut result = Vec::new();
         for (name, size) in names {
-            let fs_uuid = try!(self.thin_pool
-                                   .create_filesystem(&self.pool_uuid, name, &dm, size));
+            let fs_uuid = self.thin_pool
+                .create_filesystem(&self.pool_uuid, name, &dm, size)?;
             result.push((name, fs_uuid));
         }
 
@@ -385,28 +385,28 @@ impl Pool for StratPool {
     }
 
     fn add_blockdevs(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<PathBuf>> {
-        let bdev_paths = try!(self.block_devs.add(&self.pool_uuid, paths, force));
-        try!(self.write_metadata());
+        let bdev_paths = self.block_devs.add(&self.pool_uuid, paths, force)?;
+        self.write_metadata()?;
         Ok(bdev_paths)
     }
 
     fn destroy(self) -> EngineResult<()> {
-        let dm = try!(DM::new());
+        let dm = DM::new()?;
 
-        try!(self.thin_pool.teardown(&dm));
+        self.thin_pool.teardown(&dm)?;
 
-        try!(self.block_devs.destroy_all());
+        self.block_devs.destroy_all()?;
         Ok(())
     }
 
     fn destroy_filesystems<'a, 'b>(&'a mut self,
                                    fs_uuids: &[&'b FilesystemUuid])
                                    -> EngineResult<Vec<&'b FilesystemUuid>> {
-        let dm = try!(DM::new());
+        let dm = DM::new()?;
 
         let mut removed = Vec::new();
         for uuid in fs_uuids {
-            try!(self.thin_pool.destroy_filesystem(&dm, uuid));
+            self.thin_pool.destroy_filesystem(&dm, uuid)?;
             removed.push(*uuid);
         }
 
@@ -467,41 +467,43 @@ impl Recordable<PoolSave> for StratPool {
     fn record(&self) -> EngineResult<PoolSave> {
 
         let mapper = |seg: &Segment| -> EngineResult<(Uuid, Sectors, Sectors)> {
-            let bd = try!(self.block_devs
-                     .get_by_device(seg.device)
-                     .ok_or_else(|| EngineError::Engine(ErrorEnum::NotFound,
-                                                format!("no block device found for device {:?}",
-                                                        seg.device))));
+            let bd = self.block_devs
+                .get_by_device(seg.device)
+                .ok_or_else(|| {
+                                EngineError::Engine(ErrorEnum::NotFound,
+                                                    format!("no block device found for device {:?}",
+                                                            seg.device))
+                            })?;
             Ok((*bd.uuid(), seg.start, seg.length))
         };
 
-        let meta_dev = try!(self.thin_pool
-                                .thin_pool_mdv_segments()
-                                .iter()
-                                .map(&mapper)
-                                .collect());
+        let meta_dev = self.thin_pool
+            .thin_pool_mdv_segments()
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
 
-        let thin_meta_dev = try!(self.thin_pool
-                                     .thin_pool_meta_segments()
-                                     .iter()
-                                     .map(&mapper)
-                                     .collect());
+        let thin_meta_dev = self.thin_pool
+            .thin_pool_meta_segments()
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
 
-        let thin_data_dev = try!(self.thin_pool
-                                     .thin_pool_data_segments()
-                                     .iter()
-                                     .map(&mapper)
-                                     .collect());
+        let thin_data_dev = self.thin_pool
+            .thin_pool_data_segments()
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
 
-        let thin_meta_dev_spare = try!(self.thin_pool
-                                           .spare_segments()
-                                           .iter()
-                                           .map(&mapper)
-                                           .collect());
+        let thin_meta_dev_spare = self.thin_pool
+            .spare_segments()
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
 
         Ok(PoolSave {
                name: self.name.clone(),
-               block_devs: try!(self.block_devs.record()),
+               block_devs: self.block_devs.record()?,
                flex_devs: FlexDevsSave {
                    meta_dev: meta_dev,
                    thin_meta_dev: thin_meta_dev,

--- a/src/engine/strat_engine/range_alloc.rs
+++ b/src/engine/strat_engine/range_alloc.rs
@@ -26,7 +26,7 @@ impl RangeAllocator {
             limit: limit,
             used: BTreeMap::new(),
         };
-        try!(allocator.insert_ranges(initial_used));
+        allocator.insert_ranges(initial_used)?;
         Ok(allocator)
     }
 
@@ -62,7 +62,7 @@ impl RangeAllocator {
     /// efficiency.
     fn insert_ranges(&mut self, ranges: &[(Sectors, Sectors)]) -> EngineResult<()> {
         for &(off, len) in ranges {
-            try!(self.check_for_overflow(off, len));
+            self.check_for_overflow(off, len)?;
 
             let prev = self.used
                 .range(..off)


### PR DESCRIPTION
As there are no guidelines on the usage of `try!` vs `?`, this pull request changes all occurences to `?`.
Mostly done automated via `rustfmt`.

Makes the code more idomatic and less cluttered with parentheses.

If the `try!` is part of the coding guidelines, this PR can be ignored and closed.