### PR TITLE
Put more StratPool functionality into ThinPool

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -68,30 +68,7 @@ impl StratPool {
 
         }
 
-        let meta_regions = block_mgr
-            .alloc_space(ThinPool::initial_metadata_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let meta_spare_regions = block_mgr
-            .alloc_space(ThinPool::initial_metadata_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let data_regions = block_mgr
-            .alloc_space(ThinPool::initial_data_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let mdv_regions = block_mgr
-            .alloc_space(ThinPool::initial_mdv_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let thinpool = ThinPool::new(pool_uuid,
-                                     dm,
-                                     DATA_BLOCK_SIZE,
-                                     DATA_LOWATER,
-                                     meta_spare_regions,
-                                     meta_regions,
-                                     data_regions,
-                                     mdv_regions)?;
+        let thinpool = ThinPool::new(pool_uuid, dm, DATA_BLOCK_SIZE, DATA_LOWATER, &mut block_mgr)?;
 
         let devnodes = block_mgr.devnodes();
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -117,42 +117,12 @@ impl StratPool {
                })
         };
 
-        let flex_devs = &metadata.flex_devs;
-
-        let meta_segments = flex_devs
-            .meta_dev
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_meta_segments = flex_devs
-            .thin_meta_dev
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_data_segments = flex_devs
-            .thin_data_dev
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_meta_spare_segments = flex_devs
-            .thin_meta_dev_spare
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let dm = DM::new()?;
-
         let thinpool = ThinPool::setup(uuid,
-                                       &dm,
+                                       &DM::new()?,
                                        metadata.thinpool_dev.data_block_size,
                                        DATA_LOWATER,
-                                       thin_meta_spare_segments,
-                                       thin_meta_segments,
-                                       thin_data_segments,
-                                       meta_segments)?;
+                                       &metadata.flex_devs,
+                                       lookup)?;
 
         Ok(StratPool {
                name: metadata.name,

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -94,7 +94,7 @@ impl StratPool {
         // Obtain a Segment from a Uuid, Sectors, Sectors triple.
         // This can fail if there is no entry for the UUID in the map
         // from UUIDs to device numbers.
-        let lookup = |triple: &(Uuid, Sectors, Sectors)| -> EngineResult<Segment> {
+        let lookup = |triple: &(DevUuid, Sectors, Sectors)| -> EngineResult<Segment> {
             let device = uuid_map
                 .get(&triple.0)
                 .ok_or_else(|| {
@@ -338,7 +338,7 @@ impl HasName for StratPool {
 impl Recordable<PoolSave> for StratPool {
     fn record(&self) -> EngineResult<PoolSave> {
 
-        let mapper = |seg: &Segment| -> EngineResult<(Uuid, Sectors, Sectors)> {
+        let mapper = |seg: &Segment| -> EngineResult<(DevUuid, Sectors, Sectors)> {
             let bd = self.block_devs
                 .get_by_device(seg.device)
                 .ok_or_else(|| {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -12,16 +12,15 @@ use serde_json;
 use uuid::Uuid;
 
 use devicemapper as dm;
-use devicemapper::Device;
 use devicemapper::DM;
-use devicemapper::{DataBlocks, Sectors, Segment};
+use devicemapper::{DataBlocks, Sectors};
 use devicemapper::{ThinPoolWorkingStatus, ThinPoolDev};
 
 use super::super::engine::{Filesystem, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, RenameAction, Redundancy};
+use super::super::types::{FilesystemUuid, PoolUuid, RenameAction, Redundancy};
 
-use super::blockdevmgr::BlockDevMgr;
+use super::blockdevmgr::{BlockDevMgr, uuid_to_device_number};
 use super::filesystem::{StratFilesystem, FilesystemStatus};
 use super::metadata::MIN_MDA_SECTORS;
 use super::serde_structs::{PoolSave, Recordable};
@@ -86,35 +85,12 @@ impl StratPool {
                         })?;
         let blockdevs = get_blockdevs(uuid, &metadata, devnodes)?;
 
-        let uuid_map: HashMap<DevUuid, Device> = blockdevs
-            .iter()
-            .map(|bd| (*bd.uuid(), *bd.device()))
-            .collect();
-
-        // Obtain a Segment from a Uuid, Sectors, Sectors triple.
-        // This can fail if there is no entry for the UUID in the map
-        // from UUIDs to device numbers.
-        let lookup = |triple: &(DevUuid, Sectors, Sectors)| -> EngineResult<Segment> {
-            let device = uuid_map
-                .get(&triple.0)
-                .ok_or_else(|| {
-                                EngineError::Engine(ErrorEnum::NotFound,
-                                                    format!("missing device for UUID {:?}",
-                                                            &triple.0))
-                            })?;
-            Ok(Segment {
-                   device: *device,
-                   start: triple.1,
-                   length: triple.2,
-               })
-        };
-
         let thinpool = ThinPool::setup(uuid,
                                        &DM::new()?,
                                        metadata.thinpool_dev.data_block_size,
                                        DATA_LOWATER,
                                        &metadata.flex_devs,
-                                       lookup)?;
+                                       uuid_to_device_number(&blockdevs))?;
 
         Ok(StratPool {
                name: metadata.name,
@@ -337,23 +313,11 @@ impl HasName for StratPool {
 
 impl Recordable<PoolSave> for StratPool {
     fn record(&self) -> EngineResult<PoolSave> {
-
-        let mapper = |seg: &Segment| -> EngineResult<(DevUuid, Sectors, Sectors)> {
-            let bd = self.block_devs
-                .get_by_device(seg.device)
-                .ok_or_else(|| {
-                                EngineError::Engine(ErrorEnum::NotFound,
-                                                    format!("no block device found for device {:?}",
-                                                            seg.device))
-                            })?;
-            Ok((*bd.uuid(), seg.start, seg.length))
-        };
-
-
         Ok(PoolSave {
                name: self.name.clone(),
                block_devs: self.block_devs.record()?,
-               flex_devs: self.thin_pool.flexdevssave(&mapper)?,
+               flex_devs: self.thin_pool
+                   .flexdevssave(self.block_devs.device_number_to_uuid())?,
                thinpool_dev: self.thin_pool
                    .record()
                    .expect("this function never fails"),

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -12,14 +12,12 @@ use serde_json;
 use uuid::Uuid;
 
 use devicemapper as dm;
-use devicemapper::consts::SECTOR_SIZE;
 use devicemapper::Device;
 use devicemapper::DM;
-use devicemapper::{DataBlocks, MetaBlocks, Sectors, Segment};
+use devicemapper::{DataBlocks, Sectors, Segment};
 use devicemapper::LinearDev;
 use devicemapper::{ThinDevId, ThinPoolWorkingStatus, ThinPoolDev};
 
-use super::super::consts::IEC::Mi;
 use super::super::engine::{Filesystem, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, RenameAction, Redundancy};
@@ -32,13 +30,9 @@ use super::mdv::MetadataVol;
 use super::metadata::MIN_MDA_SECTORS;
 use super::serde_structs::{PoolSave, Recordable};
 use super::setup::{get_blockdevs, get_metadata};
-use super::thinpool::{META_LOWATER, ThinPool};
+use super::thinpool::{INITIAL_MDV_SIZE, INITIAL_META_SIZE, META_LOWATER, ThinPool};
 
-pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER};
-
-const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4096);
-pub const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);
-const INITIAL_MDV_SIZE: Sectors = Sectors(16 * Mi / SECTOR_SIZE as u64);
+pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE};
 
 #[derive(Debug)]
 pub struct StratPool {
@@ -63,7 +57,7 @@ impl StratPool {
 
         let mut block_mgr = BlockDevMgr::initialize(&pool_uuid, paths, MIN_MDA_SECTORS, force)?;
 
-        if block_mgr.avail_space() < StratPool::min_initial_size() {
+        if block_mgr.avail_space() < ThinPool::initial_size() {
             let avail_size = block_mgr.avail_space().bytes();
 
             // TODO: check the return value and update state machine on failure
@@ -72,7 +66,7 @@ impl StratPool {
             return Err(EngineError::Engine(ErrorEnum::Invalid,
                                            format!("Space on pool must be at least {} bytes, \
                                                    available space is only {} bytes",
-                                                   StratPool::min_initial_size().bytes(),
+                                                   ThinPool::initial_size().bytes(),
                                                    avail_size)));
 
 
@@ -237,13 +231,6 @@ impl StratPool {
                redundancy: Redundancy::NONE,
                thin_pool: thinpool,
            })
-    }
-
-    /// Minimum initial size for a pool.
-    pub fn min_initial_size() -> Sectors {
-        // One extra meta for spare
-        (INITIAL_META_SIZE.sectors() * 2u64) + *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE +
-        INITIAL_MDV_SIZE
     }
 
     /// Write current metadata to pool members.

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -53,22 +53,14 @@ impl StratPool {
 
         let mut block_mgr = BlockDevMgr::initialize(&pool_uuid, paths, MIN_MDA_SECTORS, force)?;
 
-        if block_mgr.avail_space() < ThinPool::initial_size() {
-            let avail_size = block_mgr.avail_space().bytes();
-
-            // TODO: check the return value and update state machine on failure
-            let _ = block_mgr.destroy_all();
-
-            return Err(EngineError::Engine(ErrorEnum::Invalid,
-                                           format!("Space on pool must be at least {} bytes, \
-                                                   available space is only {} bytes",
-                                                   ThinPool::initial_size().bytes(),
-                                                   avail_size)));
-
-
-        }
-
-        let thinpool = ThinPool::new(pool_uuid, dm, DATA_BLOCK_SIZE, DATA_LOWATER, &mut block_mgr)?;
+        let thinpool = ThinPool::new(pool_uuid, dm, DATA_BLOCK_SIZE, DATA_LOWATER, &mut block_mgr);
+        let thinpool = match thinpool {
+            Ok(thinpool) => thinpool,
+            Err(err) => {
+                let _ = block_mgr.destroy_all();
+                return Err(err);
+            }
+        };
 
         let devnodes = block_mgr.devnodes();
 

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -13,6 +13,7 @@ use devicemapper as dm;
 use devicemapper::{DM, DataBlocks, DmError, LinearDev, MetaBlocks, Sectors, Segment, ThinDev,
                    ThinDevId, ThinPoolDev};
 use devicemapper::ErrorEnum::CheckFailed;
+use devicemapper::consts::SECTOR_SIZE;
 
 use super::super::consts::IEC;
 use super::super::engine::{Filesystem, HasName};
@@ -32,6 +33,11 @@ pub const DATA_LOWATER: DataBlocks = DataBlocks(512);
 pub const META_LOWATER: MetaBlocks = MetaBlocks(512);
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
+
+pub const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4096);
+pub const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);
+pub const INITIAL_MDV_SIZE: Sectors = Sectors(16 * IEC::Mi / SECTOR_SIZE as u64);
+
 
 /// A ThinPool struct contains the thinpool itself, the spare
 /// segments for its metadata device, and the filesystems and filesystem
@@ -164,6 +170,15 @@ impl ThinPool {
                mdv: mdv,
            })
     }
+
+
+    /// Initial size for a pool.
+    pub fn initial_size() -> Sectors {
+        // One extra meta for spare
+        (INITIAL_META_SIZE.sectors() * 2u64) + *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE +
+        INITIAL_MDV_SIZE
+    }
+
 
     /// The status of the thin pool as calculated by DM.
     pub fn check(&mut self, dm: &DM) -> EngineResult<ThinPoolStatus> {

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -18,7 +18,7 @@ use super::super::consts::IEC;
 use super::super::engine::{Filesystem, HasName};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
-use super::super::types::{PoolUuid, FilesystemUuid, RenameAction};
+use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, RenameAction};
 
 use super::blockdevmgr::BlockDevMgr;
 use super::device::wipe_sectors;
@@ -150,7 +150,7 @@ impl ThinPool {
                     flex_devs: &FlexDevsSave,
                     mapper: F)
                     -> EngineResult<ThinPool>
-        where F: Fn(&(Uuid, Sectors, Sectors)) -> EngineResult<Segment>
+        where F: Fn(&(DevUuid, Sectors, Sectors)) -> EngineResult<Segment>
     {
         let mdv_segments = flex_devs
             .meta_dev
@@ -315,7 +315,7 @@ impl ThinPool {
     /// May return an error if mapper can not locate the UUID corresponding
     /// to a device node.
     pub fn flexdevssave<F>(&self, mapper: F) -> EngineResult<FlexDevsSave>
-        where F: Fn(&Segment) -> EngineResult<(Uuid, Sectors, Sectors)>
+        where F: Fn(&Segment) -> EngineResult<(DevUuid, Sectors, Sectors)>
     {
         Ok(FlexDevsSave {
                meta_dev: self.mdv

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -13,7 +13,6 @@ use devicemapper as dm;
 use devicemapper::{DM, DataBlocks, DmError, LinearDev, MetaBlocks, Sectors, Segment, ThinDev,
                    ThinDevId, ThinPoolDev};
 use devicemapper::ErrorEnum::CheckFailed;
-use devicemapper::consts::SECTOR_SIZE;
 
 use super::super::consts::IEC;
 use super::super::engine::{Filesystem, HasName};
@@ -21,6 +20,7 @@ use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
 use super::super::types::{PoolUuid, FilesystemUuid, RenameAction};
 
+use super::device::wipe_sectors;
 use super::dmdevice::{FlexRole, ThinDevIdPool, ThinPoolRole, ThinRole, format_flex_name,
                       format_thinpool_name, format_thin_name};
 use super::filesystem::{StratFilesystem, FilesystemStatus};
@@ -34,9 +34,9 @@ pub const META_LOWATER: MetaBlocks = MetaBlocks(512);
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
-pub const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4096);
+const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4096);
 pub const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);
-pub const INITIAL_MDV_SIZE: Sectors = Sectors(16 * IEC::Mi / SECTOR_SIZE as u64);
+const INITIAL_MDV_SIZE: Sectors = Sectors(32 * IEC::Ki); // 16 MiB
 
 
 /// A ThinPool struct contains the thinpool itself, the spare
@@ -68,10 +68,33 @@ impl ThinPool {
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
                spare_segments: Vec<Segment>,
-               meta_dev: LinearDev,
-               data_dev: LinearDev,
-               mdv: MetadataVol)
+               meta_segments: Vec<Segment>,
+               data_segments: Vec<Segment>,
+               mdv_segments: Vec<Segment>)
                -> EngineResult<ThinPool> {
+        // When constructing a thin-pool, Stratis reserves the first N
+        // sectors on a block device by creating a linear device with a
+        // starting offset. DM writes the super block in the first block.
+        // DM requires this first block to be zeros when the meta data for
+        // the thin-pool is initially created. If we don't zero the
+        // superblock DM issue error messages because it triggers code paths
+        // that are trying to re-adopt the device with the attributes that
+        // have been passed.
+        let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
+                                      dm,
+                                      meta_segments)?;
+        wipe_sectors(&meta_dev.devnode()?,
+                     Sectors(0),
+                     INITIAL_META_SIZE.sectors())?;
+
+        let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
+                                      dm,
+                                      data_segments)?;
+
+        let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
+        let mdv_dev = LinearDev::new(&mdv_name, dm, mdv_segments)?;
+        let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
+
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
         let thinpool_dev = ThinPoolDev::new(&name,
                                             dm,
@@ -101,13 +124,20 @@ impl ThinPool {
                  dm: &DM,
                  data_block_size: Sectors,
                  low_water_mark: DataBlocks,
-                 thin_ids: &[ThinDevId],
                  spare_segments: Vec<Segment>,
-                 meta_dev: LinearDev,
-                 data_dev: LinearDev,
-                 mdv: MetadataVol,
-                 fs_save: Vec<FilesystemSave>)
+                 meta_segments: Vec<Segment>,
+                 data_segments: Vec<Segment>,
+                 mdv_segments: Vec<Segment>)
                  -> EngineResult<ThinPool> {
+        let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
+                                      dm,
+                                      meta_segments)?;
+
+        let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
+                                      dm,
+                                      data_segments)?;
+
+
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
         let size = data_dev.size()?;
 
@@ -137,6 +167,12 @@ impl ThinPool {
         };
         let (thinpool_dev, spare_segments) = res?;
 
+        let mdv_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::MetadataVolume),
+                                     dm,
+                                     mdv_segments)?;
+        let mdv = MetadataVol::setup(&pool_uuid, mdv_dev)?;
+        let filesystem_metadatas = mdv.filesystems()?;
+
         // TODO: not fail completely if one filesystem setup fails?
         let filesystems = {
             // Set up a filesystem from its metadata.
@@ -147,7 +183,7 @@ impl ThinPool {
                 Ok(StratFilesystem::setup(fssave.uuid, &fssave.name, thin_dev))
             };
 
-            fs_save
+            filesystem_metadatas
                 .iter()
                 .map(get_filesystem)
                 .collect::<EngineResult<Vec<_>>>()?
@@ -162,10 +198,11 @@ impl ThinPool {
             }
         }
 
+        let thin_ids: Vec<ThinDevId> = filesystem_metadatas.iter().map(|x| x.thin_id).collect();
         Ok(ThinPool {
                thin_pool: thinpool_dev,
                meta_spare: spare_segments,
-               id_gen: ThinDevIdPool::new_from_ids(thin_ids),
+               id_gen: ThinDevIdPool::new_from_ids(&thin_ids),
                filesystems: fs_table,
                mdv: mdv,
            })
@@ -175,10 +212,24 @@ impl ThinPool {
     /// Initial size for a pool.
     pub fn initial_size() -> Sectors {
         // One extra meta for spare
-        (INITIAL_META_SIZE.sectors() * 2u64) + *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE +
-        INITIAL_MDV_SIZE
+        ThinPool::initial_metadata_size() * 2u64 + ThinPool::initial_data_size() +
+        ThinPool::initial_mdv_size()
     }
 
+    /// Initial size for a pool's meta data device.
+    pub fn initial_metadata_size() -> Sectors {
+        INITIAL_META_SIZE.sectors()
+    }
+
+    /// Initial size for a pool's data device.
+    pub fn initial_data_size() -> Sectors {
+        *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE
+    }
+
+    /// Initial size for a pool's filesystem metadata volume.
+    pub fn initial_mdv_size() -> Sectors {
+        INITIAL_MDV_SIZE
+    }
 
     /// The status of the thin pool as calculated by DM.
     pub fn check(&mut self, dm: &DM) -> EngineResult<ThinPoolStatus> {

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -33,8 +33,9 @@ pub const META_LOWATER: MetaBlocks = MetaBlocks(512);
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
-/// A ThinPool struct contains the thinpool itself, but also the spare
-/// segments for its metadata device.
+/// A ThinPool struct contains the thinpool itself, the spare
+/// segments for its metadata device, and the filesystems and filesystem
+/// metadata associated with it.
 #[derive(Debug)]
 pub struct ThinPool {
     thin_pool: ThinPoolDev,

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -115,10 +115,6 @@ impl ThinPool {
                                       dm,
                                       data_segments)?;
 
-        let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
-        let mdv_dev = LinearDev::new(&mdv_name, dm, mdv_segments)?;
-        let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
-
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
         let thinpool_dev = ThinPoolDev::new(&name,
                                             dm,
@@ -127,6 +123,11 @@ impl ThinPool {
                                             low_water_mark,
                                             meta_dev,
                                             data_dev)?;
+
+        let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
+        let mdv_dev = LinearDev::new(&mdv_name, dm, mdv_segments)?;
+        let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
+
         Ok(ThinPool {
                thin_pool: thinpool_dev,
                meta_spare: spare_segments,

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -24,7 +24,7 @@ use super::dmdevice::{FlexRole, ThinDevIdPool, ThinPoolRole, ThinRole, format_fl
                       format_thinpool_name, format_thin_name};
 use super::filesystem::{StratFilesystem, FilesystemStatus};
 use super::mdv::MetadataVol;
-use super::serde_structs::{FilesystemSave, Recordable, ThinPoolDevSave};
+use super::serde_structs::{FilesystemSave, FlexDevsSave, Recordable, ThinPoolDevSave};
 
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2048);
@@ -197,24 +197,35 @@ impl ThinPool {
         Ok(())
     }
 
-    /// Get an immutable reference to the sparse segments of the ThinPool.
-    pub fn spare_segments(&self) -> &[Segment] {
-        &self.meta_spare
-    }
-
-    /// The segments belonging to the thin pool meta device.
-    pub fn thin_pool_meta_segments(&self) -> &[Segment] {
-        self.thin_pool.meta_dev().segments()
-    }
-
-    /// The segments belonging to the thin pool data device.
-    pub fn thin_pool_data_segments(&self) -> &[Segment] {
-        self.thin_pool.data_dev().segments()
-    }
-
-    /// The segments belonging to the MDV.
-    pub fn thin_pool_mdv_segments(&self) -> &[Segment] {
-        self.mdv.segments()
+    /// Return the FlexDevsSave data structure for variable length metadata.
+    /// May return an error if mapper can not locate the UUID corresponding
+    /// to a device node.
+    pub fn flexdevssave<F>(&self, mapper: F) -> EngineResult<FlexDevsSave>
+        where F: Fn(&Segment) -> EngineResult<(Uuid, Sectors, Sectors)>
+    {
+        Ok(FlexDevsSave {
+               meta_dev: self.mdv
+                   .segments()
+                   .iter()
+                   .map(&mapper)
+                   .collect::<EngineResult<Vec<_>>>()?,
+               thin_meta_dev: self.thin_pool
+                   .meta_dev()
+                   .segments()
+                   .iter()
+                   .map(&mapper)
+                   .collect::<EngineResult<Vec<_>>>()?,
+               thin_data_dev: self.thin_pool
+                   .data_dev()
+                   .segments()
+                   .iter()
+                   .map(&mapper)
+                   .collect::<EngineResult<Vec<_>>>()?,
+               thin_meta_dev_spare: self.meta_spare
+                   .iter()
+                   .map(&mapper)
+                   .collect::<EngineResult<Vec<_>>>()?,
+           })
     }
 
     /// Get the devicemapper::ThinPoolDev for this pool. Used for testing.
@@ -241,7 +252,7 @@ impl ThinPool {
             }
         };
 
-        let spare_total = self.spare_segments().iter().map(|s| s.length).sum();
+        let spare_total = self.meta_spare.iter().map(|s| s.length).sum();
         let meta_dev_total = self.thin_pool
             .meta_dev()
             .segments()

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -20,6 +20,7 @@ use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
 use super::super::types::{PoolUuid, FilesystemUuid, RenameAction};
 
+use super::blockdevmgr::BlockDevMgr;
 use super::device::wipe_sectors;
 use super::dmdevice::{FlexRole, ThinDevIdPool, ThinPoolRole, ThinRole, format_flex_name,
                       format_thinpool_name, format_thin_name};
@@ -62,16 +63,31 @@ pub struct ThinPoolStatus {
 
 impl ThinPool {
     /// Make a new thin pool.
-    #[allow(too_many_arguments)]
+    /// Precondition: block_mgr can allocate the space required.
     pub fn new(pool_uuid: PoolUuid,
                dm: &DM,
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
-               spare_segments: Vec<Segment>,
-               meta_segments: Vec<Segment>,
-               data_segments: Vec<Segment>,
-               mdv_segments: Vec<Segment>)
+               block_mgr: &mut BlockDevMgr)
                -> EngineResult<ThinPool> {
+        assert!(block_mgr.avail_space() >= ThinPool::initial_size());
+
+        let meta_segments = block_mgr
+            .alloc_space(ThinPool::initial_metadata_size())
+            .expect("blockmgr must not fail, already checked for space");
+
+        let spare_segments = block_mgr
+            .alloc_space(ThinPool::initial_metadata_size())
+            .expect("blockmgr must not fail, already checked for space");
+
+        let data_segments = block_mgr
+            .alloc_space(ThinPool::initial_data_size())
+            .expect("blockmgr must not fail, already checked for space");
+
+        let mdv_segments = block_mgr
+            .alloc_space(ThinPool::initial_mdv_size())
+            .expect("blockmgr must not fail, already checked for space");
+
         // When constructing a thin-pool, Stratis reserves the first N
         // sectors on a block device by creating a linear device with a
         // starting offset. DM writes the super block in the first block.
@@ -85,7 +101,7 @@ impl ThinPool {
                                       meta_segments)?;
         wipe_sectors(&meta_dev.devnode()?,
                      Sectors(0),
-                     INITIAL_META_SIZE.sectors())?;
+                     ThinPool::initial_metadata_size())?;
 
         let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
                                       dm,
@@ -217,17 +233,17 @@ impl ThinPool {
     }
 
     /// Initial size for a pool's meta data device.
-    pub fn initial_metadata_size() -> Sectors {
+    fn initial_metadata_size() -> Sectors {
         INITIAL_META_SIZE.sectors()
     }
 
     /// Initial size for a pool's data device.
-    pub fn initial_data_size() -> Sectors {
+    fn initial_data_size() -> Sectors {
         *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE
     }
 
     /// Initial size for a pool's filesystem metadata volume.
-    pub fn initial_mdv_size() -> Sectors {
+    fn initial_mdv_size() -> Sectors {
         INITIAL_MDV_SIZE
     }
 


### PR DESCRIPTION
This PR moves a significant amount of ThinPool related functionality into the ThinPool implementation. In particular,

1. It generates the appropriate FlexDevsSave struct to return to the ```ThinPool::record()``` method. This makes sense at this point, since all the data required for the FlexDevsSave struct is part of the ThinPool now. It does not implement Recordable for FlexDevsSave, because it requires a closure as an argument.
2. The calculation of ```min_initial_size()``` is moved down to ThinPool, as it is really the ThinPool's minimum initial size that is calculated. The name is changed to ```initial_size()```, its the checking of the relation that makes it a minimum.
3. ```ThinPool::new()``` now handles allocating the segments it requires and setting up necessary device mapper devices. To do this, it takes a mut reference to a BlockDevMgr.
4. ```ThinPool::setup()``` now handles locating the segments corresponding to each device mapper device and setting up the devices as appropriate. To do this, it takes a reference to its corresponding FlexDevsSave struct.

Much of this is enabled by the previous refactoring, which moved all the data that is required to build a FlexDevsSave struct into the the ThinPool. Consequently, passing a FlexDevsSave struct as an argument or returning it from a function is a meaningful thing for ThinPool to do.

The principle motivation of this refactoring is better encapsulation and consolidation of the handling of segment lists into a single implementation.