### PR TITLE
Do not cache cargo for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ addons:
 
 language: rust
 
-cache: cargo
-
 matrix:
     allow_failures:
         - env: TASK=clippy


### PR DESCRIPTION
This seems to result in odd compilation errors for our test build.
The evidence is that if the cache is manually cleared, generally the loop
tests succeed, but if not there is a strange compilation error about a
missing item in a manifest file for one of our dependencies.

Signed-off-by: mulhern <amulhern@redhat.com>