### PR TITLE
Add dm snapshot support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.3.10"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+tempdir = "0.3.5"
 log = "0.3"
 env_logger="0.3.5"
 libc = "0.2"
@@ -29,5 +30,4 @@ features = ["serde", "v4"]
 
 [dev-dependencies]
 quickcheck = "0.4"
-tempdir = "0.3.5"
 loopdev = "0.1.1"

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_blockdevmgr_used
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_filesystem_rename
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_pool_setup
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test loop_test_filesystem_snapshot
 
 test-real:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_empty_pool
@@ -54,6 +55,7 @@ test-real:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_blockdevmgr_used
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_filesystem_rename
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_pool_setup
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --test real_test_filesystem_snapshot
 
 test:
 	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -43,7 +43,7 @@ impl StratFilesystem {
                       -> EngineResult<StratFilesystem> {
         let fs = StratFilesystem::setup(fs_id, name, thin_dev);
 
-        create_fs(fs.devnode().as_path())?;
+        create_fs(&fs.devnode(), fs_id)?;
         Ok(fs)
     }
 
@@ -178,11 +178,13 @@ pub fn xfs_growfs(mount_point: &Path) -> EngineResult<()> {
 }
 
 /// Create a filesystem on devnode.
-pub fn create_fs(devnode: &Path) -> EngineResult<()> {
+pub fn create_fs(devnode: &Path, uuid: &FilesystemUuid) -> EngineResult<()> {
     if Command::new("mkfs.xfs")
            .arg("-f")
            .arg("-q")
            .arg(&devnode)
+           .arg("-m")
+           .arg(format!("uuid={}", uuid))
            .status()?
            .success() {
         Ok(())

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -5,11 +5,13 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use devicemapper::{Bytes, DmDevice, DM, IEC, SECTOR_SIZE, Sectors, ThinDev, ThinDevId, ThinStatus,
-                   ThinPoolDev};
+use devicemapper::{Bytes, DmDevice, DM, DmName, IEC, SECTOR_SIZE, Sectors, ThinDev, ThinDevId,
+                   ThinStatus, ThinPoolDev};
 
 use nix::sys::statvfs::statvfs;
 use nix::sys::statvfs::vfs::Statvfs;
+use nix::mount::{mount, MsFlags, umount};
+use tempdir::TempDir;
 
 use super::super::engine::{Filesystem, HasName, HasUuid};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
@@ -53,6 +55,52 @@ impl StratFilesystem {
             fs_id: fs_id,
             name: name.to_owned(),
             thin_dev: thin_dev,
+        }
+    }
+
+    /// Create a snapshot of the ThinDev under the filesystem. Return the
+    /// resulting ThinDev to the caller.
+    pub fn snapshot(&self,
+                    dm: &DM,
+                    thin_pool: &ThinPoolDev,
+                    snapshot_name: &DmName,
+                    snapshot_fs_uuid: FilesystemUuid,
+                    snapshot_thin_id: ThinDevId)
+                    -> EngineResult<StratFilesystem> {
+
+        match self.thin_dev
+                  .snapshot(dm, thin_pool, snapshot_name, snapshot_thin_id) {
+            Ok(thin_dev) => {
+                // If the source is mounted, XFS puts a dummy record in the
+                // log to enforce replay of the snapshot to deal with any
+                // orphaned inodes. The dummy record put the log in a dirty
+                // state. xfs_admin won't allow a filesystem UUID
+                // to be updated when the log is dirty.  To clear the log
+                // we mount/unmount the filesystem before updating the UUID.
+                //
+                // If the source is unmounted the XFS log will be clean so
+                // we can skip the mount/unmount.
+                if self.get_mount_point()?.is_some() {
+                    let tmp_dir = TempDir::new("stratis_mp_")?;
+                    // Mount the snapshot with the "nouuid" option. mount
+                    // will fail due to duplicate UUID otherwise.
+                    mount(Some(&thin_dev.devnode()),
+                          tmp_dir.path(),
+                          Some("xfs"),
+                          MsFlags::empty(),
+                          Some("nouuid"))?;
+                    umount(tmp_dir.path())?;
+                }
+                set_uuid(&thin_dev.devnode(), snapshot_fs_uuid)?;
+                Ok(StratFilesystem::setup(snapshot_fs_uuid, snapshot_name.as_ref(), thin_dev))
+            }
+            Err(e) => {
+                Err(EngineError::Engine(ErrorEnum::Error,
+                                        format!("failed to create {} snapshot for {} - {}",
+                                                snapshot_name,
+                                                self.name,
+                                                e)))
+            }
         }
     }
 
@@ -190,6 +238,21 @@ pub fn create_fs(devnode: &Path, uuid: &FilesystemUuid) -> EngineResult<()> {
         Ok(())
     } else {
         let err_msg = format!("Failed to create new filesystem at {:?}", devnode);
+        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
+    }
+}
+
+/// Generate a new UUID filesystem on the devnode.
+pub fn set_uuid(devnode: &Path, snapshot_fs_uuid: FilesystemUuid) -> EngineResult<()> {
+    if Command::new("xfs_admin")
+           .arg("-U")
+           .arg(format!("{}", snapshot_fs_uuid))
+           .arg(&devnode)
+           .status()?
+           .success() {
+        Ok(())
+    } else {
+        let err_msg = format!("Failed to generate UUID for filesystem at {:?}", devnode);
         Err(EngineError::Engine(ErrorEnum::Error, err_msg))
     }
 }

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -22,8 +22,9 @@ use super::super::engine::HasUuid;
 use super::super::errors::EngineResult;
 use super::super::types::{FilesystemUuid, PoolUuid};
 
-use super::filesystem::{create_fs, StratFilesystem};
+use super::filesystem::StratFilesystem;
 use super::serde_structs::{FilesystemSave, Recordable};
+use super::util::create_fs;
 
 // TODO: Monitor fs size and extend linear and fs if needed
 // TODO: Document format of stuff on MDV in SWDD (currently ad-hoc)

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -79,13 +79,13 @@ impl<'a> Drop for MountedMDV<'a> {
 
 impl MetadataVol {
     /// Initialize a new Metadata Volume.
-    pub fn initialize(pool_uuid: &PoolUuid, dev: LinearDev) -> EngineResult<MetadataVol> {
-        create_fs(dev.devnode().as_path())?;
+    pub fn initialize(pool_uuid: PoolUuid, dev: LinearDev) -> EngineResult<MetadataVol> {
+        create_fs(&dev.devnode(), pool_uuid)?;
         MetadataVol::setup(pool_uuid, dev)
     }
 
     /// Set up an existing Metadata Volume.
-    pub fn setup(pool_uuid: &PoolUuid, dev: LinearDev) -> EngineResult<MetadataVol> {
+    pub fn setup(pool_uuid: PoolUuid, dev: LinearDev) -> EngineResult<MetadataVol> {
         if let Err(err) = create_dir(DEV_PATH) {
             if err.kind() != ErrorKind::AlreadyExists {
                 return Err(From::from(err));

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -16,5 +16,6 @@ pub mod serde_structs;
 pub mod setup;
 mod range_alloc;
 mod thinpool;
+pub mod util;
 
 pub use self::engine::StratEngine;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -129,6 +129,12 @@ impl StratPool {
     pub fn has_filesystems(&self) -> bool {
         self.thin_pool.has_filesystems()
     }
+
+    pub fn snapshot_filesystem(&mut self, filesystem_uuid: Uuid) -> EngineResult<FilesystemUuid> {
+        let dm = DM::new()?;
+        self.thin_pool
+            .snapshot_filesystem(&dm, self.pool_uuid, filesystem_uuid)
+    }
 }
 
 impl Pool for StratPool {

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -101,7 +101,7 @@ impl ThinPool {
 
         let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
         let mdv_dev = LinearDev::setup(dm, &mdv_name, None, &map_to_dm(&mdv_segments))?;
-        let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
+        let mdv = MetadataVol::initialize(pool_uuid, mdv_dev)?;
 
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
         let thinpool_dev = ThinPoolDev::new(dm,
@@ -195,7 +195,7 @@ impl ThinPool {
                                        &format_flex_name(&pool_uuid, FlexRole::MetadataVolume),
                                        None,
                                        &map_to_dm(&mdv_segments))?;
-        let mdv = MetadataVol::setup(&pool_uuid, mdv_dev)?;
+        let mdv = MetadataVol::setup(pool_uuid, mdv_dev)?;
         let filesystem_metadatas = mdv.filesystems()?;
 
         // TODO: not fail completely if one filesystem setup fails?

--- a/src/engine/strat_engine/util.rs
+++ b/src/engine/strat_engine/util.rs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Utilities to support Stratis.
+
+use std::path::Path;
+use std::process::Command;
+
+use uuid::Uuid;
+
+use super::super::errors::{EngineError, EngineResult, ErrorEnum};
+
+
+/// Create a filesystem on devnode.
+pub fn create_fs(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
+    if Command::new("mkfs.xfs")
+           .arg("-f")
+           .arg("-q")
+           .arg(&devnode)
+           .arg("-m")
+           .arg(format!("uuid={}", uuid))
+           .status()?
+           .success() {
+        Ok(())
+    } else {
+        let err_msg = format!("Failed to create new filesystem at {:?}", devnode);
+        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
+    }
+}
+
+/// Use the xfs_growfs command to expand a filesystem mounted at the given
+/// mount point.
+pub fn xfs_growfs(mount_point: &Path) -> EngineResult<()> {
+    if Command::new("xfs_growfs")
+           .arg(mount_point)
+           .arg("-d")
+           .status()?
+           .success() {
+        Ok(())
+    } else {
+        let err_msg = format!("Failed to expand filesystem {:?}", mount_point);
+        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
+    }
+}
+
+/// Set a new UUID for filesystem on the devnode.
+pub fn set_uuid(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
+    if Command::new("xfs_admin")
+           .arg("-U")
+           .arg(format!("{}", uuid))
+           .arg(&devnode)
+           .status()?
+           .success() {
+        Ok(())
+    } else {
+        let err_msg = format!("Failed to set UUID for filesystem at {:?}", devnode);
+        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate byteorder;
 extern crate uuid;
 extern crate chrono;
 extern crate dbus;
+extern crate tempdir;
 extern crate term;
 extern crate rand;
 extern crate serde;

--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -156,25 +156,25 @@ pub fn loop_test_linear_device() {
 
 #[test]
 pub fn loop_test_thinpool_device() {
-    /// This test requires more than 1 GiB.
+    // This test requires more than 1 GiB.
     test_with_spec(DeviceLimits::Range(2, 3), test_thinpool_device);
 }
 
 #[test]
 pub fn loop_test_thinpool_expand() {
-    /// This test requires more than 1 GiB.
+    // This test requires more than 1 GiB.
     test_with_spec(DeviceLimits::Range(2, 3), test_thinpool_expand);
 }
 
 #[test]
 pub fn loop_test_thinpool_thindev_destroy() {
-    /// This test requires more than 1 GiB.
+    // This test requires more than 1 GiB.
     test_with_spec(DeviceLimits::Range(2, 3), test_thinpool_thindev_destroy);
 }
 
 #[test]
 pub fn loop_test_pool_blockdevs() {
-    /// This test requires more than 1 GiB.
+    // This test requires more than 1 GiB.
     test_with_spec(DeviceLimits::Range(2, 3), test_pool_blockdevs);
 }
 

--- a/tests/loopbacked_tests.rs
+++ b/tests/loopbacked_tests.rs
@@ -32,6 +32,7 @@ use util::dm_tests::test_thinpool_device;
 use util::dm_tests::test_linear_device;
 use util::filesystem_tests::test_xfs_expand;
 use util::pool_tests::test_filesystem_rename;
+use util::pool_tests::test_filesystem_snapshot;
 use util::pool_tests::test_thinpool_expand;
 use util::pool_tests::test_thinpool_thindev_destroy;
 use util::setup_tests::test_basic_metadata;
@@ -230,4 +231,9 @@ pub fn loop_test_pool_setup() {
 #[test]
 pub fn loop_test_xfs_expand() {
     test_with_spec(DeviceLimits::Range(1, 3), test_xfs_expand);
+}
+
+#[test]
+pub fn loop_test_filesystem_snapshot() {
+    test_with_spec(DeviceLimits::Range(2, 3), test_filesystem_snapshot);
 }

--- a/tests/real_tests.rs
+++ b/tests/real_tests.rs
@@ -30,6 +30,7 @@ use util::dm_tests::test_thinpool_device;
 use util::dm_tests::test_linear_device;
 use util::filesystem_tests::test_xfs_expand;
 use util::pool_tests::test_filesystem_rename;
+use util::pool_tests::test_filesystem_snapshot;
 use util::pool_tests::test_thinpool_expand;
 use util::pool_tests::test_thinpool_thindev_destroy;
 use util::setup_tests::test_basic_metadata;
@@ -229,4 +230,9 @@ pub fn real_test_pool_setup() {
 #[test]
 pub fn real_test_xfs_expand() {
     test_with_spec(DeviceLimits::AtLeast(1), test_xfs_expand);
+}
+
+#[test]
+pub fn real_test_filesystem_snapshot() {
+    test_with_spec(DeviceLimits::AtLeast(2), test_filesystem_snapshot);
 }

--- a/tests/util/dm_tests.rs
+++ b/tests/util/dm_tests.rs
@@ -24,9 +24,8 @@ use self::devicemapper::{Bytes, DM, DataBlocks, DmDevice, DmName, IEC, LinearDev
 
 use libstratis::engine::strat_engine::blockdevmgr::{BlockDevMgr, initialize, map_to_dm};
 use libstratis::engine::strat_engine::device::{blkdev_size, resolve_devices, wipe_sectors};
-use libstratis::engine::strat_engine::filesystem::create_fs;
 use libstratis::engine::strat_engine::metadata::MIN_MDA_SECTORS;
-
+use libstratis::engine::strat_engine::util::create_fs;
 
 /// Verify that the sum of the lengths of the available range of the
 /// blockdevs in the linear device equals the size of the linear device.

--- a/tests/util/dm_tests.rs
+++ b/tests/util/dm_tests.rs
@@ -118,7 +118,7 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
                                 Sectors(300000))
             .unwrap();
 
-    create_fs(&thin_dev.devnode()).unwrap();
+    create_fs(&thin_dev.devnode(), Uuid::new_v4()).unwrap();
 
     let tmp_dir = TempDir::new("stratis_testing").unwrap();
     mount(Some(&thin_dev.devnode()),

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -149,7 +149,7 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
     let name2 = "name2";
     let (uuid1, _) = engine.create_pool(&name1, paths, None, false).unwrap();
     let fs_uuid = {
-        let mut pool = engine.get_mut_pool(&uuid1).unwrap();
+        let pool = engine.get_mut_pool(&uuid1).unwrap();
         let &(fs_name, fs_uuid) = pool.create_filesystems(&[(name1, None)])
             .unwrap()
             .first()


### PR DESCRIPTION
A snapshot uses the DM create_snap feature.  See "Internal snapshots" in:

https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt

Once created a snapshot of a filesytem is no different than any other
thin-provisioned device.

filesystem.rs deals with updating the XFS UUID to avoid any duplicate
UUIDs.