### PR TITLE
Transfer some functionality from StratPool to ThinPool

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -115,7 +115,7 @@ impl BlockDev {
 }
 
 impl Recordable<BlockDevSave> for BlockDev {
-    fn record(&self) -> EngineResult<BlockDevSave> {
-        Ok(BlockDevSave { devnode: self.devnode.clone() })
+    fn record(&self) -> BlockDevSave {
+        BlockDevSave { devnode: self.devnode.clone() }
     }
 }

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
-use devicemapper::{Device, Sectors, Segment};
+use devicemapper::{Device, Sectors};
 
 use super::super::errors::EngineResult;
 use super::super::types::{DevUuid, PoolUuid};
@@ -42,7 +42,7 @@ impl BlockDev {
         &self.dev
     }
 
-    pub fn wipe_metadata(self) -> EngineResult<()> {
+    pub fn wipe_metadata(&self) -> EngineResult<()> {
         let mut f = OpenOptions::new().write(true).open(&self.devnode)?;
         BDA::wipe(&mut f)
     }
@@ -53,14 +53,14 @@ impl BlockDev {
     }
 
     /// List the available-for-upper-layer-use range in this blockdev.
-    pub fn avail_range(&self) -> Segment {
+    pub fn avail_range(&self) -> (Sectors, Sectors) {
         let start = self.metadata_size();
         let size = self.current_capacity();
         // Blockdev size is at least MIN_DEV_SIZE, so this can fail only if
         // size of metadata area exceeds 1 GiB. Initial metadata area size
         // is 4 MiB.
         assert!(start <= size);
-        Segment::new(self.dev, start, size - start)
+        (start, size - start)
     }
 
     /// The device's UUID.
@@ -80,12 +80,8 @@ impl BlockDev {
 
     // Find some sector ranges that could be allocated. If more
     // sectors are needed than our capacity, return partial results.
-    pub fn request_space(&mut self, size: Sectors) -> (Sectors, Vec<Segment>) {
-        let (size, segs) = self.used.request(size);
-        (size,
-         segs.iter()
-             .map(|&(start, len)| Segment::new(self.dev, start, len))
-             .collect())
+    pub fn request_space(&mut self, size: Sectors) -> (Sectors, Vec<(Sectors, Sectors)>) {
+        self.used.request(size)
     }
 
     // ALL SIZE METHODS

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -87,9 +87,14 @@ impl BlockDevMgr {
         Ok(BlockDevMgr::new(initialize(pool_uuid, devices, mda_size, force)?))
     }
 
-    // Obtain a BlockDev by its UUID.
-    pub fn get_by_uuid(&self, uuid: &DevUuid) -> Option<&BlockDev> {
-        self.block_devs.iter().find(|d| d.uuid() == uuid)
+    /// Get a function that maps UUIDs to Devices.
+    pub fn uuid_to_devno(&self) -> Box<Fn(&DevUuid) -> Option<Device>> {
+        let uuid_map: HashMap<DevUuid, Device> = self.block_devs
+            .iter()
+            .map(|bd| (*bd.uuid(), *bd.device()))
+            .collect();
+
+        Box::new(move |uuid: &DevUuid| -> Option<Device> { uuid_map.get(uuid).cloned() })
     }
 
     pub fn add(&mut self,

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -30,6 +30,32 @@ const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
 const MAX_NUM_TO_WRITE: usize = 10;
 
 #[derive(Debug)]
+pub struct BlkDevSegment {
+    pub uuid: DevUuid,
+    pub segment: Segment,
+}
+
+impl BlkDevSegment {
+    pub fn new(uuid: DevUuid, segment: Segment) -> BlkDevSegment {
+        BlkDevSegment { uuid, segment }
+    }
+
+    pub fn to_segment(&self) -> Segment {
+        self.segment.clone()
+    }
+}
+
+/// Build a Vec<Segment> from BlkDevSegments. This is useful for calls
+/// to the devicemapper library.
+pub fn map_to_dm(bsegs: &[BlkDevSegment]) -> Vec<Segment> {
+    bsegs
+        .into_iter()
+        .map(|bseg| bseg.to_segment())
+        .collect::<Vec<_>>()
+}
+
+
+#[derive(Debug)]
 pub struct BlockDevMgr {
     block_devs: Vec<BlockDev>,
     last_update_time: Option<DateTime<Utc>>,
@@ -53,11 +79,6 @@ impl BlockDevMgr {
         Ok(BlockDevMgr::new(initialize(pool_uuid, devices, mda_size, force)?))
     }
 
-    /// Obtain a BlockDev by its Device.
-    pub fn get_by_device(&self, device: Device) -> Option<&BlockDev> {
-        self.block_devs.iter().find(|d| d.device() == &device)
-    }
-
     // Obtain a BlockDev by its UUID.
     pub fn get_by_uuid(&self, uuid: &DevUuid) -> Option<&BlockDev> {
         self.block_devs.iter().find(|d| d.uuid() == uuid)
@@ -76,12 +97,12 @@ impl BlockDevMgr {
     }
 
     pub fn destroy_all(self) -> EngineResult<()> {
-        wipe_blockdevs(self.block_devs)
+        wipe_blockdevs(&self.block_devs)
     }
 
     /// If available space is less than size, return None, else return
     /// the segments allocated.
-    pub fn alloc_space(&mut self, size: Sectors) -> Option<Vec<Segment>> {
+    pub fn alloc_space(&mut self, size: Sectors) -> Option<Vec<BlkDevSegment>> {
         let mut needed: Sectors = size;
         let mut segs = Vec::new();
 
@@ -95,7 +116,12 @@ impl BlockDevMgr {
             }
 
             let (gotten, r_segs) = bd.request_space(needed);
-            segs.extend(r_segs);
+            let blkdev_segs = r_segs
+                .into_iter()
+                .map(|(start, length)| {
+                         BlkDevSegment::new(*bd.uuid(), Segment::new(*bd.device(), start, length))
+                     });
+            segs.extend(blkdev_segs);
             needed -= gotten;
         }
 
@@ -177,11 +203,14 @@ impl BlockDevMgr {
     }
 }
 
-impl Recordable<HashMap<Uuid, BlockDevSave>> for BlockDevMgr {
+impl Recordable<HashMap<DevUuid, BlockDevSave>> for BlockDevMgr {
     fn record(&self) -> EngineResult<HashMap<Uuid, BlockDevSave>> {
         self.block_devs
             .iter()
-            .map(|bd| bd.record().and_then(|bdsave| Ok((*bd.uuid(), bdsave))))
+            .map(|bd| {
+                     let uuid = *bd.uuid();
+                     bd.record().and_then(|bdsave| Ok((uuid, bdsave)))
+                 })
             .collect()
     }
 }
@@ -279,7 +308,7 @@ pub fn initialize(pool_uuid: &PoolUuid,
         } else {
             // TODO: check the return values and update state machine on failure
             let _ = BDA::wipe(&mut f);
-            let _ = wipe_blockdevs(bds);
+            let _ = wipe_blockdevs(&bds);
 
             return Err(bda.unwrap_err());
         }

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -45,6 +45,14 @@ impl BlkDevSegment {
     }
 }
 
+impl Recordable<Vec<(Uuid, Sectors, Sectors)>> for Vec<BlkDevSegment> {
+    fn record(&self) -> Vec<(Uuid, Sectors, Sectors)> {
+        self.iter()
+            .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
+            .collect::<Vec<_>>()
+    }
+}
+
 /// Build a Vec<Segment> from BlkDevSegments. This is useful for calls
 /// to the devicemapper library.
 pub fn map_to_dm(bsegs: &[BlkDevSegment]) -> Vec<Segment> {
@@ -204,13 +212,10 @@ impl BlockDevMgr {
 }
 
 impl Recordable<HashMap<DevUuid, BlockDevSave>> for BlockDevMgr {
-    fn record(&self) -> EngineResult<HashMap<Uuid, BlockDevSave>> {
+    fn record(&self) -> HashMap<Uuid, BlockDevSave> {
         self.block_devs
             .iter()
-            .map(|bd| {
-                     let uuid = *bd.uuid();
-                     bd.record().and_then(|bdsave| Ok((uuid, bdsave)))
-                 })
+            .map(|bd| (*bd.uuid(), bd.record()))
             .collect()
     }
 }

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -4,21 +4,20 @@
 
 // Code to handle cleanup after a failed operation.
 
-
 use super::super::engine::HasUuid;
 use super::super::errors::{EngineResult, EngineError, ErrorEnum};
 
 use super::blockdev::BlockDev;
 use super::pool::StratPool;
 
-/// Wipe a Vec of blockdevs of their identifying headers.
+/// Wipe some blockdevs of their identifying headers.
 /// Return an error if any of the blockdevs could not be wiped.
 /// If an error occurs while wiping a blockdev, attempt to wipe all remaining.
-pub fn wipe_blockdevs(blockdevs: Vec<BlockDev>) -> EngineResult<()> {
+pub fn wipe_blockdevs(blockdevs: &[BlockDev]) -> EngineResult<()> {
     let mut unerased_devnodes = Vec::new();
 
     for bd in blockdevs {
-        let bd_devnode = bd.devnode.clone();
+        let bd_devnode = bd.devnode.to_owned();
         bd.wipe_metadata()
             .unwrap_or_else(|_| unerased_devnodes.push(bd_devnode));
     }

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -14,10 +14,10 @@ use super::pool::StratPool;
 /// Wipe a Vec of blockdevs of their identifying headers.
 /// Return an error if any of the blockdevs could not be wiped.
 /// If an error occurs while wiping a blockdev, attempt to wipe all remaining.
-pub fn wipe_blockdevs(mut blockdevs: Vec<BlockDev>) -> EngineResult<()> {
+pub fn wipe_blockdevs(blockdevs: Vec<BlockDev>) -> EngineResult<()> {
     let mut unerased_devnodes = Vec::new();
 
-    for bd in blockdevs.drain(..) {
+    for bd in blockdevs {
         let bd_devnode = bd.devnode.clone();
         bd.wipe_metadata()
             .unwrap_or_else(|_| unerased_devnodes.push(bd_devnode));
@@ -33,9 +33,9 @@ pub fn wipe_blockdevs(mut blockdevs: Vec<BlockDev>) -> EngineResult<()> {
 }
 
 /// Teardown pools.
-pub fn teardown_pools(mut pools: Vec<StratPool>) -> EngineResult<()> {
+pub fn teardown_pools(pools: Vec<StratPool>) -> EngineResult<()> {
     let mut untorndown_pools = Vec::new();
-    for pool in pools.drain(..) {
+    for pool in pools {
         let pool_uuid = *pool.uuid();
         pool.teardown()
             .unwrap_or_else(|_| untorndown_pools.push(pool_uuid));

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -145,13 +145,13 @@ impl Filesystem for StratFilesystem {
 }
 
 impl Recordable<FilesystemSave> for StratFilesystem {
-    fn record(&self) -> EngineResult<FilesystemSave> {
-        Ok(FilesystemSave {
-               name: self.name.clone(),
-               uuid: self.fs_id,
-               thin_id: self.thin_dev.id(),
-               size: self.thin_dev.size(),
-           })
+    fn record(&self) -> FilesystemSave {
+        FilesystemSave {
+            name: self.name.clone(),
+            uuid: self.fs_id,
+            thin_id: self.thin_dev.id(),
+            size: self.thin_dev.size(),
+        }
     }
 }
 

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -92,7 +92,7 @@ impl MetadataVol {
     // ensure file contents are not truncated if operation is
     // interrupted.
     pub fn save_fs(&self, fs: &StratFilesystem) -> EngineResult<()> {
-        let data = serde_json::to_string(&fs.record()?)?;
+        let data = serde_json::to_string(&fs.record())?;
         let path = self.mount_pt
             .join(FILESYSTEM_DIR)
             .join(fs.uuid().simple().to_string())

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -17,7 +17,7 @@ use nix::mount::{MsFlags, mount, umount};
 use nix::unistd::fsync;
 use serde_json;
 
-use devicemapper::{DmDevice, DM, LinearDev, Segment};
+use devicemapper::{DmDevice, DM, LinearDev};
 
 use super::super::engine::HasUuid;
 use super::super::errors::EngineResult;
@@ -174,11 +174,6 @@ impl MetadataVol {
         }
 
         Ok(filesystems)
-    }
-
-    /// Return the segments used.
-    pub fn segments(&self) -> &[Segment] {
-        self.dev.segments()
     }
 
     /// Tear down a Metadata Volume.

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -102,7 +102,7 @@ impl StratPool {
 
     /// Write current metadata to pool members.
     pub fn write_metadata(&mut self) -> EngineResult<()> {
-        let data = serde_json::to_string(&self.record()?)?;
+        let data = serde_json::to_string(&self.record())?;
         self.block_devs.save_state(data.as_bytes())
     }
 
@@ -311,14 +311,12 @@ impl HasName for StratPool {
 }
 
 impl Recordable<PoolSave> for StratPool {
-    fn record(&self) -> EngineResult<PoolSave> {
-        Ok(PoolSave {
-               name: self.name.clone(),
-               block_devs: self.block_devs.record()?,
-               flex_devs: self.thin_pool.flexdevssave()?,
-               thinpool_dev: self.thin_pool
-                   .record()
-                   .expect("this function never fails"),
-           })
+    fn record(&self) -> PoolSave {
+        PoolSave {
+            name: self.name.clone(),
+            block_devs: self.block_devs.record(),
+            flex_devs: self.thin_pool.record(),
+            thinpool_dev: self.thin_pool.record(),
+        }
     }
 }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -116,42 +116,12 @@ impl StratPool {
                })
         };
 
-        let flex_devs = &metadata.flex_devs;
-
-        let meta_segments = flex_devs
-            .meta_dev
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_meta_segments = flex_devs
-            .thin_meta_dev
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_data_segments = flex_devs
-            .thin_data_dev
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_meta_spare_segments = flex_devs
-            .thin_meta_dev_spare
-            .iter()
-            .map(&lookup)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let dm = DM::new()?;
-
         let thinpool = ThinPool::setup(uuid,
-                                       &dm,
+                                       &DM::new()?,
                                        metadata.thinpool_dev.data_block_size,
                                        DATA_LOWATER,
-                                       thin_meta_spare_segments,
-                                       thin_meta_segments,
-                                       thin_data_segments,
-                                       meta_segments)?;
+                                       &metadata.flex_devs,
+                                       lookup)?;
 
         Ok(StratPool {
                name: metadata.name,

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -12,24 +12,20 @@ use serde_json;
 use uuid::Uuid;
 
 use devicemapper as dm;
-use devicemapper::{Device, DmDevice, DM};
+use devicemapper::{Device, DM};
 use devicemapper::{DataBlocks, Sectors, Segment};
-use devicemapper::LinearDev;
-use devicemapper::{ThinDevId, ThinPoolWorkingStatus, ThinPoolDev};
+use devicemapper::{ThinPoolWorkingStatus, ThinPoolDev};
 
 use super::super::engine::{Filesystem, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, RenameAction, Redundancy};
 
 use super::blockdevmgr::BlockDevMgr;
-use super::device::wipe_sectors;
-use super::dmdevice::{FlexRole, format_flex_name};
 use super::filesystem::{StratFilesystem, FilesystemStatus};
-use super::mdv::MetadataVol;
 use super::metadata::MIN_MDA_SECTORS;
 use super::serde_structs::{PoolSave, Recordable};
 use super::setup::{get_blockdevs, get_metadata};
-use super::thinpool::{INITIAL_MDV_SIZE, INITIAL_META_SIZE, META_LOWATER, ThinPool};
+use super::thinpool::{META_LOWATER, ThinPool};
 
 pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE};
 
@@ -72,50 +68,29 @@ impl StratPool {
         }
 
         let meta_regions = block_mgr
-            .alloc_space(INITIAL_META_SIZE.sectors())
+            .alloc_space(ThinPool::initial_metadata_size())
             .expect("blockmgr must not fail, already checked for space");
 
         let meta_spare_regions = block_mgr
-            .alloc_space(INITIAL_META_SIZE.sectors())
+            .alloc_space(ThinPool::initial_metadata_size())
             .expect("blockmgr must not fail, already checked for space");
 
         let data_regions = block_mgr
-            .alloc_space(*INITIAL_DATA_SIZE * DATA_BLOCK_SIZE)
+            .alloc_space(ThinPool::initial_data_size())
             .expect("blockmgr must not fail, already checked for space");
-
-        // When constructing a thin-pool, Stratis reserves the first N
-        // sectors on a block device by creating a linear device with a
-        // starting offset. DM writes the super block in the first block.
-        // DM requires this first block to be zeros when the meta data for
-        // the thin-pool is initially created. If we don't zero the
-        // superblock DM issue error messages because it triggers code paths
-        // that are trying to re-adopt the device with the attributes that
-        // have been passed.
-        let meta_dev = LinearDev::new(format_flex_name(&pool_uuid, FlexRole::ThinMeta).as_ref(),
-                                      dm,
-                                      meta_regions)?;
-        wipe_sectors(&meta_dev.devnode(), Sectors(0), INITIAL_META_SIZE.sectors())?;
-
-        let data_dev = LinearDev::new(format_flex_name(&pool_uuid, FlexRole::ThinData).as_ref(),
-                                      dm,
-                                      data_regions)?;
 
         let mdv_regions = block_mgr
-            .alloc_space(INITIAL_MDV_SIZE)
+            .alloc_space(ThinPool::initial_mdv_size())
             .expect("blockmgr must not fail, already checked for space");
-
-        let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
-        let mdv_dev = LinearDev::new(mdv_name.as_ref(), dm, mdv_regions)?;
-        let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
 
         let thinpool = ThinPool::new(pool_uuid,
                                      dm,
                                      DATA_BLOCK_SIZE,
                                      DATA_LOWATER,
                                      meta_spare_regions,
-                                     meta_dev,
-                                     data_dev,
-                                     mdv)?;
+                                     meta_regions,
+                                     data_regions,
+                                     mdv_regions)?;
 
         let devnodes = block_mgr.devnodes();
 
@@ -133,8 +108,6 @@ impl StratPool {
     }
 
     /// Setup a StratPool using its UUID and the list of devnodes it has.
-    // TODO: Clean up after errors that occur after some action has been
-    // taken on the environment.
     pub fn setup(uuid: PoolUuid, devnodes: &HashMap<Device, PathBuf>) -> EngineResult<StratPool> {
         let metadata = get_metadata(uuid, devnodes)?
             .ok_or_else(|| {
@@ -194,32 +167,14 @@ impl StratPool {
 
         let dm = DM::new()?;
 
-        // This is the cleanup zone.
-        let meta_dev = LinearDev::new(format_flex_name(&uuid, FlexRole::ThinMeta).as_ref(),
-                                      &dm,
-                                      thin_meta_segments)?;
-
-        let data_dev = LinearDev::new(format_flex_name(&uuid, FlexRole::ThinData).as_ref(),
-                                      &dm,
-                                      thin_data_segments)?;
-
-        let mdv_dev = LinearDev::new(format_flex_name(&uuid, FlexRole::MetadataVolume).as_ref(),
-                                     &dm,
-                                     meta_segments)?;
-        let mdv = MetadataVol::setup(&uuid, mdv_dev)?;
-        let filesystem_metadatas = mdv.filesystems()?;
-        let thin_ids: Vec<ThinDevId> = filesystem_metadatas.iter().map(|x| x.thin_id).collect();
-
         let thinpool = ThinPool::setup(uuid,
                                        &dm,
                                        metadata.thinpool_dev.data_block_size,
                                        DATA_LOWATER,
-                                       &thin_ids,
                                        thin_meta_spare_segments,
-                                       meta_dev,
-                                       data_dev,
-                                       mdv,
-                                       filesystem_metadatas)?;
+                                       thin_meta_segments,
+                                       thin_data_segments,
+                                       meta_segments)?;
 
         Ok(StratPool {
                name: metadata.name,

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -31,7 +31,7 @@ use super::dmdevice::{FlexRole, format_flex_name};
 use super::filesystem::{StratFilesystem, FilesystemStatus};
 use super::mdv::MetadataVol;
 use super::metadata::MIN_MDA_SECTORS;
-use super::serde_structs::{FlexDevsSave, PoolSave, Recordable};
+use super::serde_structs::{PoolSave, Recordable};
 use super::setup::{get_blockdevs, get_metadata};
 use super::thinpool::{META_LOWATER, ThinPool};
 
@@ -469,39 +469,11 @@ impl Recordable<PoolSave> for StratPool {
             Ok((*bd.uuid(), seg.start, seg.length))
         };
 
-        let meta_dev = self.thin_pool
-            .thin_pool_mdv_segments()
-            .iter()
-            .map(&mapper)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_meta_dev = self.thin_pool
-            .thin_pool_meta_segments()
-            .iter()
-            .map(&mapper)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_data_dev = self.thin_pool
-            .thin_pool_data_segments()
-            .iter()
-            .map(&mapper)
-            .collect::<EngineResult<Vec<_>>>()?;
-
-        let thin_meta_dev_spare = self.thin_pool
-            .spare_segments()
-            .iter()
-            .map(&mapper)
-            .collect::<EngineResult<Vec<_>>>()?;
 
         Ok(PoolSave {
                name: self.name.clone(),
                block_devs: self.block_devs.record()?,
-               flex_devs: FlexDevsSave {
-                   meta_dev: meta_dev,
-                   thin_meta_dev: thin_meta_dev,
-                   thin_data_dev: thin_data_dev,
-                   thin_meta_dev_spare: thin_meta_dev_spare,
-               },
+               flex_devs: self.thin_pool.flexdevssave(&mapper)?,
                thinpool_dev: self.thin_pool
                    .record()
                    .expect("this function never fails"),

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -67,30 +67,7 @@ impl StratPool {
 
         }
 
-        let meta_regions = block_mgr
-            .alloc_space(ThinPool::initial_metadata_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let meta_spare_regions = block_mgr
-            .alloc_space(ThinPool::initial_metadata_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let data_regions = block_mgr
-            .alloc_space(ThinPool::initial_data_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let mdv_regions = block_mgr
-            .alloc_space(ThinPool::initial_mdv_size())
-            .expect("blockmgr must not fail, already checked for space");
-
-        let thinpool = ThinPool::new(pool_uuid,
-                                     dm,
-                                     DATA_BLOCK_SIZE,
-                                     DATA_LOWATER,
-                                     meta_spare_regions,
-                                     meta_regions,
-                                     data_regions,
-                                     mdv_regions)?;
+        let thinpool = ThinPool::new(pool_uuid, dm, DATA_BLOCK_SIZE, DATA_LOWATER, &mut block_mgr)?;
 
         let devnodes = block_mgr.devnodes();
 

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -16,17 +16,17 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use uuid::Uuid;
+use serde::Serialize;
 
 use devicemapper::{Sectors, ThinDevId};
 
-use super::super::errors::EngineResult;
 use super::super::types::{DevUuid, FilesystemUuid};
 
 /// Implements saving struct data to a serializable form. The form should be
 /// sufficient, in conjunction with the environment, to reconstruct the
 /// saved struct in all its essentials.
-pub trait Recordable<T> {
-    fn record(&self) -> EngineResult<T>;
+pub trait Recordable<T: Serialize> {
+    fn record(&self) -> T;
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -341,8 +341,11 @@ impl ThinPool {
         // Last existing and first new may be contiguous. Coalesce into
         // a single BlkDevSegment if so.
         let coalesced_new_first = {
-            match (self.data_segments.last_mut(), new_segs.first()) {
-                (Some(old_last), Some(new_first)) => {
+            match new_segs.first() {
+                Some(new_first) => {
+                    let old_last = self.data_segments
+                        .last_mut()
+                        .expect("thin pool must always have some data segments");
                     if old_last.uuid == new_first.uuid &&
                        (old_last.segment.start + old_last.segment.length ==
                         new_first.segment.start) {
@@ -352,7 +355,7 @@ impl ThinPool {
                         false
                     }
                 }
-                _ => false,
+                None => false,
             }
         };
 

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -329,30 +329,6 @@ impl ThinPool {
         Ok(())
     }
 
-    /// Return the FlexDevsSave data structure for variable length metadata.
-    /// May return an error if mapper can not locate the UUID corresponding
-    /// to a device node.
-    pub fn flexdevssave(&self) -> EngineResult<FlexDevsSave> {
-        Ok(FlexDevsSave {
-               meta_dev: self.mdv_segments
-                   .iter()
-                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
-                   .collect::<Vec<_>>(),
-               thin_meta_dev: self.meta_segments
-                   .iter()
-                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
-                   .collect::<Vec<_>>(),
-               thin_data_dev: self.data_segments
-                   .iter()
-                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
-                   .collect::<Vec<_>>(),
-               thin_meta_dev_spare: self.meta_spare_segments
-                   .iter()
-                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
-                   .collect::<Vec<_>>(),
-           })
-    }
-
     /// Get the devicemapper::ThinPoolDev for this pool. Used for testing.
     pub fn thinpooldev(&self) -> &ThinPoolDev {
         &self.thin_pool
@@ -509,9 +485,20 @@ impl ThinPool {
     }
 }
 
+impl Recordable<FlexDevsSave> for ThinPool {
+    fn record(&self) -> FlexDevsSave {
+        FlexDevsSave {
+            meta_dev: self.mdv_segments.record(),
+            thin_meta_dev: self.meta_segments.record(),
+            thin_data_dev: self.data_segments.record(),
+            thin_meta_dev_spare: self.meta_spare_segments.record(),
+        }
+    }
+}
+
 impl Recordable<ThinPoolDevSave> for ThinPool {
-    fn record(&self) -> EngineResult<ThinPoolDevSave> {
-        Ok(ThinPoolDevSave { data_block_size: self.thin_pool.data_block_size() })
+    fn record(&self) -> ThinPoolDevSave {
+        ThinPoolDevSave { data_block_size: self.thin_pool.data_block_size() }
     }
 }
 

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -13,7 +13,6 @@ use devicemapper as dm;
 use devicemapper::{DM, DmDevice, DataBlocks, DmError, LinearDev, MetaBlocks, Sectors, Segment,
                    ThinDev, ThinDevId, ThinPoolDev};
 use devicemapper::ErrorEnum::CheckFailed;
-use devicemapper::consts::SECTOR_SIZE;
 
 use super::super::consts::IEC;
 use super::super::engine::{Filesystem, HasName};
@@ -21,6 +20,7 @@ use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
 use super::super::types::{PoolUuid, FilesystemUuid, RenameAction};
 
+use super::device::wipe_sectors;
 use super::dmdevice::{FlexRole, ThinDevIdPool, ThinPoolRole, ThinRole, format_flex_name,
                       format_thinpool_name, format_thin_name};
 use super::filesystem::{StratFilesystem, FilesystemStatus};
@@ -34,9 +34,9 @@ pub const META_LOWATER: MetaBlocks = MetaBlocks(512);
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
-pub const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4096);
+const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4096);
 pub const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);
-pub const INITIAL_MDV_SIZE: Sectors = Sectors(16 * IEC::Mi / SECTOR_SIZE as u64);
+const INITIAL_MDV_SIZE: Sectors = Sectors(32 * IEC::Ki); // 16 MiB
 
 
 /// A ThinPool struct contains the thinpool itself, the spare
@@ -68,10 +68,33 @@ impl ThinPool {
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
                spare_segments: Vec<Segment>,
-               meta_dev: LinearDev,
-               data_dev: LinearDev,
-               mdv: MetadataVol)
+               meta_segments: Vec<Segment>,
+               data_segments: Vec<Segment>,
+               mdv_segments: Vec<Segment>)
                -> EngineResult<ThinPool> {
+        // When constructing a thin-pool, Stratis reserves the first N
+        // sectors on a block device by creating a linear device with a
+        // starting offset. DM writes the super block in the first block.
+        // DM requires this first block to be zeros when the meta data for
+        // the thin-pool is initially created. If we don't zero the
+        // superblock DM issue error messages because it triggers code paths
+        // that are trying to re-adopt the device with the attributes that
+        // have been passed.
+        let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
+                                      dm,
+                                      meta_segments)?;
+        wipe_sectors(&meta_dev.devnode(),
+                     Sectors(0),
+                     INITIAL_META_SIZE.sectors())?;
+
+        let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
+                                      dm,
+                                      data_segments)?;
+
+        let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
+        let mdv_dev = LinearDev::new(&mdv_name, dm, mdv_segments)?;
+        let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
+
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
         let thinpool_dev = ThinPoolDev::new(name.as_ref(),
                                             dm,
@@ -100,13 +123,20 @@ impl ThinPool {
                  dm: &DM,
                  data_block_size: Sectors,
                  low_water_mark: DataBlocks,
-                 thin_ids: &[ThinDevId],
                  spare_segments: Vec<Segment>,
-                 meta_dev: LinearDev,
-                 data_dev: LinearDev,
-                 mdv: MetadataVol,
-                 fs_save: Vec<FilesystemSave>)
+                 meta_segments: Vec<Segment>,
+                 data_segments: Vec<Segment>,
+                 mdv_segments: Vec<Segment>)
                  -> EngineResult<ThinPool> {
+        let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
+                                      dm,
+                                      meta_segments)?;
+
+        let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
+                                      dm,
+                                      data_segments)?;
+
+
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
 
         let res = match ThinPoolDev::setup(name.as_ref(),
@@ -133,6 +163,12 @@ impl ThinPool {
         };
         let (thinpool_dev, spare_segments) = res?;
 
+        let mdv_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::MetadataVolume),
+                                     dm,
+                                     mdv_segments)?;
+        let mdv = MetadataVol::setup(&pool_uuid, mdv_dev)?;
+        let filesystem_metadatas = mdv.filesystems()?;
+
         // TODO: not fail completely if one filesystem setup fails?
         let filesystems = {
             // Set up a filesystem from its metadata.
@@ -146,7 +182,7 @@ impl ThinPool {
                 Ok(StratFilesystem::setup(fssave.uuid, &fssave.name, thin_dev))
             };
 
-            fs_save
+            filesystem_metadatas
                 .iter()
                 .map(get_filesystem)
                 .collect::<EngineResult<Vec<_>>>()?
@@ -161,10 +197,11 @@ impl ThinPool {
             }
         }
 
+        let thin_ids: Vec<ThinDevId> = filesystem_metadatas.iter().map(|x| x.thin_id).collect();
         Ok(ThinPool {
                thin_pool: thinpool_dev,
                meta_spare: spare_segments,
-               id_gen: ThinDevIdPool::new_from_ids(thin_ids),
+               id_gen: ThinDevIdPool::new_from_ids(&thin_ids),
                filesystems: fs_table,
                mdv: mdv,
            })
@@ -174,10 +211,24 @@ impl ThinPool {
     /// Initial size for a pool.
     pub fn initial_size() -> Sectors {
         // One extra meta for spare
-        (INITIAL_META_SIZE.sectors() * 2u64) + *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE +
-        INITIAL_MDV_SIZE
+        ThinPool::initial_metadata_size() * 2u64 + ThinPool::initial_data_size() +
+        ThinPool::initial_mdv_size()
     }
 
+    /// Initial size for a pool's meta data device.
+    pub fn initial_metadata_size() -> Sectors {
+        INITIAL_META_SIZE.sectors()
+    }
+
+    /// Initial size for a pool's data device.
+    pub fn initial_data_size() -> Sectors {
+        *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE
+    }
+
+    /// Initial size for a pool's filesystem metadata volume.
+    pub fn initial_mdv_size() -> Sectors {
+        INITIAL_MDV_SIZE
+    }
 
     /// The status of the thin pool as calculated by DM.
     pub fn check(&mut self, dm: &DM) -> EngineResult<ThinPoolStatus> {

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -146,16 +146,15 @@ impl ThinPool {
                  flex_devs: &FlexDevsSave,
                  bd_mgr: &BlockDevMgr)
                  -> EngineResult<ThinPool> {
-
+        let uuid_to_devno = bd_mgr.uuid_to_devno();
         let mapper = |triple: &(DevUuid, Sectors, Sectors)| -> EngineResult<BlkDevSegment> {
-            let bd = bd_mgr
-                .get_by_uuid(&triple.0)
+            let device = uuid_to_devno(&triple.0)
                 .ok_or_else(|| {
                                 EngineError::Engine(ErrorEnum::NotFound,
                                                     format!("missing device for UUID {:?}",
                                                             &triple.0))
                             })?;
-            Ok(BlkDevSegment::new(triple.0, Segment::new(*bd.device(), triple.1, triple.2)))
+            Ok(BlkDevSegment::new(triple.0, Segment::new(device, triple.1, triple.2)))
         };
 
         let mdv_segments = flex_devs

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -64,14 +64,10 @@ impl ThinPool {
                block_mgr: &mut BlockDevMgr)
                -> EngineResult<ThinPool> {
         if block_mgr.avail_space() < ThinPool::initial_size() {
-            let avail_size = block_mgr.avail_space().bytes();
-            return Err(EngineError::Engine(ErrorEnum::Invalid,
-                                           format!("Space on pool must be at least {} bytes, \
-                                                   available space is only {} bytes",
-                                                   ThinPool::initial_size().bytes(),
-                                                   avail_size)));
-
-
+            let err_msg = format!("Space on pool must be at least {}, available space is only {}",
+                                  ThinPool::initial_size().bytes(),
+                                  block_mgr.avail_space().bytes());
+            return Err(EngineError::Engine(ErrorEnum::Invalid, err_msg.into()));
         }
 
         let meta_segments = block_mgr

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -33,8 +33,9 @@ pub const META_LOWATER: MetaBlocks = MetaBlocks(512);
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
-/// A ThinPool struct contains the thinpool itself, but also the spare
-/// segments for its metadata device.
+/// A ThinPool struct contains the thinpool itself, the spare
+/// segments for its metadata device, and the filesystems and filesystem
+/// metadata associated with it.
 #[derive(Debug)]
 pub struct ThinPool {
     thin_pool: ThinPoolDev,

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -20,6 +20,7 @@ use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
 use super::super::types::{PoolUuid, FilesystemUuid, RenameAction};
 
+use super::blockdevmgr::BlockDevMgr;
 use super::device::wipe_sectors;
 use super::dmdevice::{FlexRole, ThinDevIdPool, ThinPoolRole, ThinRole, format_flex_name,
                       format_thinpool_name, format_thin_name};
@@ -62,16 +63,31 @@ pub struct ThinPoolStatus {
 
 impl ThinPool {
     /// Make a new thin pool.
-    #[allow(too_many_arguments)]
+    /// Precondition: block_mgr can allocate the space required.
     pub fn new(pool_uuid: PoolUuid,
                dm: &DM,
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
-               spare_segments: Vec<Segment>,
-               meta_segments: Vec<Segment>,
-               data_segments: Vec<Segment>,
-               mdv_segments: Vec<Segment>)
+               block_mgr: &mut BlockDevMgr)
                -> EngineResult<ThinPool> {
+        assert!(block_mgr.avail_space() >= ThinPool::initial_size());
+
+        let meta_segments = block_mgr
+            .alloc_space(ThinPool::initial_metadata_size())
+            .expect("blockmgr must not fail, already checked for space");
+
+        let spare_segments = block_mgr
+            .alloc_space(ThinPool::initial_metadata_size())
+            .expect("blockmgr must not fail, already checked for space");
+
+        let data_segments = block_mgr
+            .alloc_space(ThinPool::initial_data_size())
+            .expect("blockmgr must not fail, already checked for space");
+
+        let mdv_segments = block_mgr
+            .alloc_space(ThinPool::initial_mdv_size())
+            .expect("blockmgr must not fail, already checked for space");
+
         // When constructing a thin-pool, Stratis reserves the first N
         // sectors on a block device by creating a linear device with a
         // starting offset. DM writes the super block in the first block.
@@ -85,7 +101,7 @@ impl ThinPool {
                                       meta_segments)?;
         wipe_sectors(&meta_dev.devnode(),
                      Sectors(0),
-                     INITIAL_META_SIZE.sectors())?;
+                     ThinPool::initial_metadata_size())?;
 
         let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
                                       dm,
@@ -216,17 +232,17 @@ impl ThinPool {
     }
 
     /// Initial size for a pool's meta data device.
-    pub fn initial_metadata_size() -> Sectors {
+    fn initial_metadata_size() -> Sectors {
         INITIAL_META_SIZE.sectors()
     }
 
     /// Initial size for a pool's data device.
-    pub fn initial_data_size() -> Sectors {
+    fn initial_data_size() -> Sectors {
         *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE
     }
 
     /// Initial size for a pool's filesystem metadata volume.
-    pub fn initial_mdv_size() -> Sectors {
+    fn initial_mdv_size() -> Sectors {
         INITIAL_MDV_SIZE
     }
 

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -134,16 +134,39 @@ impl ThinPool {
     /// If initial setup fails due to a thin_check failure, attempt to fix
     /// the problem by running thin_repair. If failure recurs, return an
     /// error.
-    #[allow(too_many_arguments)]
-    pub fn setup(pool_uuid: PoolUuid,
-                 dm: &DM,
-                 data_block_size: Sectors,
-                 low_water_mark: DataBlocks,
-                 spare_segments: Vec<Segment>,
-                 meta_segments: Vec<Segment>,
-                 data_segments: Vec<Segment>,
-                 mdv_segments: Vec<Segment>)
-                 -> EngineResult<ThinPool> {
+    pub fn setup<F>(pool_uuid: PoolUuid,
+                    dm: &DM,
+                    data_block_size: Sectors,
+                    low_water_mark: DataBlocks,
+                    flex_devs: &FlexDevsSave,
+                    mapper: F)
+                    -> EngineResult<ThinPool>
+        where F: Fn(&(Uuid, Sectors, Sectors)) -> EngineResult<Segment>
+    {
+        let mdv_segments = flex_devs
+            .meta_dev
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
+
+        let meta_segments = flex_devs
+            .thin_meta_dev
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
+
+        let data_segments = flex_devs
+            .thin_data_dev
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
+
+        let spare_segments = flex_devs
+            .thin_meta_dev_spare
+            .iter()
+            .map(&mapper)
+            .collect::<EngineResult<Vec<_>>>()?;
+
         let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
                                       dm,
                                       meta_segments)?;

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -18,9 +18,9 @@ use super::super::consts::IEC;
 use super::super::engine::{Filesystem, HasName};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
-use super::super::types::{PoolUuid, FilesystemUuid, RenameAction};
+use super::super::types::{DevUuid, PoolUuid, FilesystemUuid, RenameAction};
 
-use super::blockdevmgr::BlockDevMgr;
+use super::blockdevmgr::{BlockDevMgr, BlkDevSegment, map_to_dm};
 use super::device::wipe_sectors;
 use super::dmdevice::{FlexRole, ThinDevIdPool, ThinPoolRole, ThinRole, format_flex_name,
                       format_thinpool_name, format_thin_name};
@@ -46,7 +46,10 @@ const INITIAL_MDV_SIZE: Sectors = Sectors(32 * IEC::Ki); // 16 MiB
 #[derive(Debug)]
 pub struct ThinPool {
     thin_pool: ThinPoolDev,
-    meta_spare: Vec<Segment>,
+    meta_segments: Vec<BlkDevSegment>,
+    meta_spare_segments: Vec<BlkDevSegment>,
+    data_segments: Vec<BlkDevSegment>,
+    mdv_segments: Vec<BlkDevSegment>,
     id_gen: ThinDevIdPool,
     filesystems: Table<StratFilesystem>,
     mdv: MetadataVol,
@@ -106,17 +109,17 @@ impl ThinPool {
         // have been passed.
         let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
                                       dm,
-                                      meta_segments)?;
+                                      map_to_dm(&meta_segments))?;
         wipe_sectors(&meta_dev.devnode(),
                      Sectors(0),
                      ThinPool::initial_metadata_size())?;
 
         let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
                                       dm,
-                                      data_segments)?;
+                                      map_to_dm(&data_segments))?;
 
         let mdv_name = format_flex_name(&pool_uuid, FlexRole::MetadataVolume);
-        let mdv_dev = LinearDev::new(&mdv_name, dm, mdv_segments)?;
+        let mdv_dev = LinearDev::new(&mdv_name, dm, map_to_dm(&mdv_segments))?;
         let mdv = MetadataVol::initialize(&pool_uuid, mdv_dev)?;
 
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
@@ -128,7 +131,10 @@ impl ThinPool {
                                             data_dev)?;
         Ok(ThinPool {
                thin_pool: thinpool_dev,
-               meta_spare: spare_segments,
+               meta_segments: meta_segments,
+               meta_spare_segments: spare_segments,
+               data_segments: data_segments,
+               mdv_segments: mdv_segments,
                id_gen: ThinDevIdPool::new_from_ids(&[]),
                filesystems: Table::default(),
                mdv: mdv,
@@ -142,15 +148,25 @@ impl ThinPool {
     /// If initial setup fails due to a thin_check failure, attempt to fix
     /// the problem by running thin_repair. If failure recurs, return an
     /// error.
-    pub fn setup<F>(pool_uuid: PoolUuid,
-                    dm: &DM,
-                    data_block_size: Sectors,
-                    low_water_mark: DataBlocks,
-                    flex_devs: &FlexDevsSave,
-                    mapper: F)
-                    -> EngineResult<ThinPool>
-        where F: Fn(&(Uuid, Sectors, Sectors)) -> EngineResult<Segment>
-    {
+    pub fn setup(pool_uuid: PoolUuid,
+                 dm: &DM,
+                 data_block_size: Sectors,
+                 low_water_mark: DataBlocks,
+                 flex_devs: &FlexDevsSave,
+                 bd_mgr: &BlockDevMgr)
+                 -> EngineResult<ThinPool> {
+
+        let mapper = |triple: &(DevUuid, Sectors, Sectors)| -> EngineResult<BlkDevSegment> {
+            let bd = bd_mgr
+                .get_by_uuid(&triple.0)
+                .ok_or_else(|| {
+                                EngineError::Engine(ErrorEnum::NotFound,
+                                                    format!("missing device for UUID {:?}",
+                                                            &triple.0))
+                            })?;
+            Ok(BlkDevSegment::new(triple.0, Segment::new(*bd.device(), triple.1, triple.2)))
+        };
+
         let mdv_segments = flex_devs
             .meta_dev
             .iter()
@@ -177,42 +193,42 @@ impl ThinPool {
 
         let meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMeta),
                                       dm,
-                                      meta_segments)?;
+                                      map_to_dm(&meta_segments))?;
 
         let data_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinData),
                                       dm,
-                                      data_segments)?;
+                                      map_to_dm(&data_segments))?;
 
 
         let name = format_thinpool_name(&pool_uuid, ThinPoolRole::Pool);
 
-        let res = match ThinPoolDev::setup(name.as_ref(),
-                                           dm,
-                                           data_block_size,
-                                           low_water_mark,
-                                           meta_dev,
-                                           data_dev) {
-            Ok(dev) => Ok((dev, spare_segments)),
-            Err(DmError::Dm(CheckFailed(meta_dev, data_dev), _)) => {
-                attempt_thin_repair(pool_uuid, dm, meta_dev, spare_segments)
-                    .and_then(|(new_meta_dev, new_spare_segments)| {
-                        ThinPoolDev::setup(name.as_ref(),
-                                           dm,
-                                           data_block_size,
-                                           low_water_mark,
-                                           new_meta_dev,
-                                           data_dev)
-                                .map(|dev| (dev, new_spare_segments))
-                                .map_err(|e| e.into())
-                    })
-            }
-            Err(e) => Err(e.into()),
-        };
-        let (thinpool_dev, spare_segments) = res?;
+        let (thinpool_dev, meta_segments, spare_segments) =
+            match ThinPoolDev::setup(&name,
+                                     dm,
+                                     data_block_size,
+                                     low_water_mark,
+                                     meta_dev,
+                                     data_dev) {
+                Ok(dev) => Ok((dev, meta_segments, spare_segments)),
+                Err(DmError::Dm(CheckFailed(meta_dev, data_dev), _)) => {
+                    attempt_thin_repair(pool_uuid, dm, meta_dev, &spare_segments)
+                        .and_then(|new_meta_dev| {
+                            ThinPoolDev::setup(&name,
+                                               dm,
+                                               data_block_size,
+                                               low_water_mark,
+                                               new_meta_dev,
+                                               data_dev)
+                                    .map(|dev| (dev, spare_segments, meta_segments))
+                                    .map_err(|e| e.into())
+                        })
+                }
+                Err(e) => Err(e.into()),
+            }?;
 
         let mdv_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::MetadataVolume),
                                      dm,
-                                     mdv_segments)?;
+                                     map_to_dm(&mdv_segments))?;
         let mdv = MetadataVol::setup(&pool_uuid, mdv_dev)?;
         let filesystem_metadatas = mdv.filesystems()?;
 
@@ -247,7 +263,10 @@ impl ThinPool {
         let thin_ids: Vec<ThinDevId> = filesystem_metadatas.iter().map(|x| x.thin_id).collect();
         Ok(ThinPool {
                thin_pool: thinpool_dev,
-               meta_spare: spare_segments,
+               meta_segments: meta_segments,
+               meta_spare_segments: spare_segments,
+               data_segments: data_segments,
+               mdv_segments: mdv_segments,
                id_gen: ThinDevIdPool::new_from_ids(&thin_ids),
                filesystems: fs_table,
                mdv: mdv,
@@ -313,31 +332,24 @@ impl ThinPool {
     /// Return the FlexDevsSave data structure for variable length metadata.
     /// May return an error if mapper can not locate the UUID corresponding
     /// to a device node.
-    pub fn flexdevssave<F>(&self, mapper: F) -> EngineResult<FlexDevsSave>
-        where F: Fn(&Segment) -> EngineResult<(Uuid, Sectors, Sectors)>
-    {
+    pub fn flexdevssave(&self) -> EngineResult<FlexDevsSave> {
         Ok(FlexDevsSave {
-               meta_dev: self.mdv
-                   .segments()
+               meta_dev: self.mdv_segments
                    .iter()
-                   .map(&mapper)
-                   .collect::<EngineResult<Vec<_>>>()?,
-               thin_meta_dev: self.thin_pool
-                   .meta_dev()
-                   .segments()
+                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
+                   .collect::<Vec<_>>(),
+               thin_meta_dev: self.meta_segments
                    .iter()
-                   .map(&mapper)
-                   .collect::<EngineResult<Vec<_>>>()?,
-               thin_data_dev: self.thin_pool
-                   .data_dev()
-                   .segments()
+                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
+                   .collect::<Vec<_>>(),
+               thin_data_dev: self.data_segments
                    .iter()
-                   .map(&mapper)
-                   .collect::<EngineResult<Vec<_>>>()?,
-               thin_meta_dev_spare: self.meta_spare
+                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
+                   .collect::<Vec<_>>(),
+               thin_meta_dev_spare: self.meta_spare_segments
                    .iter()
-                   .map(&mapper)
-                   .collect::<EngineResult<Vec<_>>>()?,
+                   .map(|bseg| (bseg.uuid, bseg.segment.start, bseg.segment.length))
+                   .collect::<Vec<_>>(),
            })
     }
 
@@ -347,8 +359,34 @@ impl ThinPool {
     }
 
     /// Extend the thinpool with new data regions.
-    pub fn extend_data(&mut self, dm: &DM, segs: Vec<Segment>) -> EngineResult<()> {
-        Ok(self.thin_pool.extend_data(dm, segs)?)
+    pub fn extend_data(&mut self, dm: &DM, new_segs: Vec<BlkDevSegment>) -> EngineResult<()> {
+        self.thin_pool.extend_data(dm, map_to_dm(&new_segs))?;
+
+        // Last existing and first new may be contiguous. Coalesce into
+        // a single BlkDevSegment if so.
+        let coalesced_new_first = {
+            match (self.data_segments.last_mut(), new_segs.first()) {
+                (Some(old_last), Some(new_first)) => {
+                    if old_last.uuid == new_first.uuid &&
+                       (old_last.segment.start + old_last.segment.length ==
+                        new_first.segment.start) {
+                        old_last.segment.length += new_first.segment.length;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            }
+        };
+
+        if coalesced_new_first {
+            self.data_segments.extend(new_segs.into_iter().skip(1));
+        } else {
+            self.data_segments.extend(new_segs);
+        }
+
+        Ok(())
     }
 
     /// The number of physical sectors in use, that is, unavailable for storage
@@ -365,7 +403,10 @@ impl ThinPool {
             }
         };
 
-        let spare_total = self.meta_spare.iter().map(|s| s.length).sum();
+        let spare_total = self.meta_spare_segments
+            .iter()
+            .map(|s| s.segment.length)
+            .sum();
         let meta_dev_total = self.thin_pool
             .meta_dev()
             .segments()
@@ -373,7 +414,10 @@ impl ThinPool {
             .map(|s| s.length)
             .sum();
 
-        let mdv_total = self.mdv.segments().iter().map(|s| s.length).sum();
+        let mdv_total = self.mdv_segments
+            .iter()
+            .map(|s| s.segment.length)
+            .sum();
 
         Ok(data_dev_used + spare_total + meta_dev_total + mdv_total)
     }
@@ -411,7 +455,7 @@ impl ThinPool {
     /// Create a filesystem within the thin pool. Given name must not
     /// already be in use.
     pub fn create_filesystem(&mut self,
-                             pool_uuid: &Uuid,
+                             pool_uuid: &PoolUuid,
                              name: &str,
                              dm: &DM,
                              size: Option<Sectors>)
@@ -477,12 +521,11 @@ impl Recordable<ThinPoolDevSave> for ThinPool {
 fn attempt_thin_repair(pool_uuid: PoolUuid,
                        dm: &DM,
                        meta_dev: LinearDev,
-                       mut spare_segments: Vec<Segment>)
-                       -> EngineResult<(LinearDev, Vec<Segment>)> {
-    let mut new_meta_dev = LinearDev::new(format_flex_name(&pool_uuid, FlexRole::ThinMetaSpare)
-                                              .as_ref(),
+                       spare_segments: &[BlkDevSegment])
+                       -> EngineResult<LinearDev> {
+    let mut new_meta_dev = LinearDev::new(&format_flex_name(&pool_uuid, FlexRole::ThinMetaSpare),
                                           dm,
-                                          spare_segments.drain(..).collect())?;
+                                          map_to_dm(spare_segments))?;
 
 
     if !Command::new("thin_repair")
@@ -497,19 +540,8 @@ fn attempt_thin_repair(pool_uuid: PoolUuid,
     }
 
     let name = meta_dev.name().to_owned();
-    let new_spare_segments = meta_dev
-        .segments()
-        .iter()
-        .map(|x| {
-                 Segment {
-                     start: x.start,
-                     length: x.length,
-                     device: x.device,
-                 }
-             })
-        .collect();
     meta_dev.teardown(dm)?;
     new_meta_dev.set_name(dm, name.as_ref())?;
 
-    Ok((new_meta_dev, new_spare_segments))
+    Ok(new_meta_dev)
 }

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -63,14 +63,22 @@ pub struct ThinPoolStatus {
 
 impl ThinPool {
     /// Make a new thin pool.
-    /// Precondition: block_mgr can allocate the space required.
     pub fn new(pool_uuid: PoolUuid,
                dm: &DM,
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
                block_mgr: &mut BlockDevMgr)
                -> EngineResult<ThinPool> {
-        assert!(block_mgr.avail_space() >= ThinPool::initial_size());
+        if block_mgr.avail_space() < ThinPool::initial_size() {
+            let avail_size = block_mgr.avail_space().bytes();
+            return Err(EngineError::Engine(ErrorEnum::Invalid,
+                                           format!("Space on pool must be at least {} bytes, \
+                                                   available space is only {} bytes",
+                                                   ThinPool::initial_size().bytes(),
+                                                   avail_size)));
+
+
+        }
 
         let meta_segments = block_mgr
             .alloc_space(ThinPool::initial_metadata_size())
@@ -248,7 +256,7 @@ impl ThinPool {
 
 
     /// Initial size for a pool.
-    pub fn initial_size() -> Sectors {
+    fn initial_size() -> Sectors {
         // One extra meta for spare
         ThinPool::initial_metadata_size() * 2u64 + ThinPool::initial_data_size() +
         ThinPool::initial_mdv_size()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate chrono;
 extern crate dbus;
 extern crate term;
 extern crate rand;
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;

--- a/tests/util/dm_tests.rs
+++ b/tests/util/dm_tests.rs
@@ -40,12 +40,15 @@ pub fn test_linear_device(paths: &[&Path]) -> () {
                                  MIN_MDA_SECTORS,
                                  false)
             .unwrap();
-    let total_blockdev_size: Sectors = initialized.iter().map(|i| i.avail_range().length).sum();
+    let total_blockdev_size: Sectors = initialized.iter().map(|i| i.avail_range().1).sum();
 
     let segments = initialized
         .iter()
-        .map(|block_dev| block_dev.avail_range())
-        .collect::<Vec<Segment>>();
+        .map(|block_dev| {
+                 let (start, length) = block_dev.avail_range();
+                 Segment::new(*block_dev.device(), start, length)
+             })
+        .collect::<Vec<_>>();
 
     let dm = DM::new().unwrap();
     let lineardev = LinearDev::new(DmName::new("stratis_testing_linear").expect("valid format"),
@@ -75,10 +78,13 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
                                               initialized.last().unwrap());
 
     let dm = DM::new().unwrap();
+
+    let (meta_start, meta_length) = metadata_blockdev.avail_range();
+    let meta_segment = Segment::new(*metadata_blockdev.device(), meta_start, meta_length);
     let metadata_dev =
         LinearDev::new(DmName::new("stratis_testing_thinpool_metadata").expect("valid format"),
                        &dm,
-                       vec![metadata_blockdev.avail_range()])
+                       vec![meta_segment])
                 .unwrap();
 
     // Clear the meta data device.  If the first block is not all zeros - the
@@ -87,11 +93,12 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
     // the same approach when constructing a thin pool.
     wipe_sectors(&metadata_dev.devnode(), Sectors(0), metadata_dev.size()).unwrap();
 
-
+    let (data_start, data_length) = data_blockdev.avail_range();
+    let data_segment = Segment::new(*data_blockdev.device(), data_start, data_length);
     let data_dev =
         LinearDev::new(DmName::new("stratis_testing_thinpool_datadev").expect("valid format"),
                        &dm,
-                       vec![data_blockdev.avail_range()])
+                       vec![data_segment])
                 .unwrap();
     let thinpool_dev =
         ThinPoolDev::new(DmName::new("stratis_testing_thinpool").expect("valid format"),

--- a/tests/util/setup_tests.rs
+++ b/tests/util/setup_tests.rs
@@ -95,19 +95,11 @@ pub fn test_basic_metadata(paths: &[&Path]) {
 
     let name1 = "name1";
     let (uuid1, _) = engine.create_pool(&name1, paths1, None, false).unwrap();
-    let metadata1 = engine
-        .get_strat_pool(&uuid1)
-        .unwrap()
-        .record()
-        .unwrap();
+    let metadata1 = engine.get_strat_pool(&uuid1).unwrap().record();
 
     let name2 = "name2";
     let (uuid2, _) = engine.create_pool(&name2, paths2, None, false).unwrap();
-    let metadata2 = engine
-        .get_strat_pool(&uuid2)
-        .unwrap()
-        .record()
-        .unwrap();
+    let metadata2 = engine.get_strat_pool(&uuid2).unwrap().record();
 
     let pools = find_all().unwrap();
     assert!(pools.len() == 2);


### PR DESCRIPTION
By moving functionality that properly belongs with the components of ThinPool into ThinPool methods the implementation can be tightened up. Significant changes are:

* Generate FlexDevsSave struct in ThinPool rather than using accessor methods in ThinPool to build the struct in StratPool.
* Transfer functionality from StratPool::setup() to ThinPool::setup(), StratPool::new() to ThinPool::new(), StratPool::check() to ThinPool::check().
* Use a new type, called BlkDevSegment to store the segments for the various devices that comprise the ThinPool. Transform them to DM Segments when necessary to invoke DM methods. Make use of the fact that BlkDevSegment contains its BlockDev UUID to change Recordable::record() to it returns a bare type and not a Result.
