### PR TITLE
Update to new version of clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 1.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.157 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -104,16 +104,16 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.155"
+version = "0.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.157 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.155"
+version = "0.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -659,8 +659,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 1.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cebcbd10d6c40aee217a182891eb16afbf37a674d0cae9a9a6b2decebc3aea08"
-"checksum clippy 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)" = "03ba983d61af163f1b3ccc31cf1eb4925e62264bdfdc4b6b7f2d8fa6b7cd30ec"
-"checksum clippy_lints 0.0.155 (registry+https://github.com/rust-lang/crates.io-index)" = "315166a7e8c0fa313d852dd9d156857ffdfd40aad7989df4b2035970a1a31f6a"
+"checksum clippy 0.0.157 (registry+https://github.com/rust-lang/crates.io-index)" = "97ed8737240be5336d4a93927b43b74ae026a0e212e8886ddacb1a634706efcf"
+"checksum clippy_lints 0.0.157 (registry+https://github.com/rust-lang/crates.io-index)" = "15a01dcefcffa4d32138d950ef6c971ef0900252f5453acc23e9724c10730a0b"
 "checksum crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc1914fae6f18ae347320f0ba5e4fc270e17c037ea621fe41ec7e8adf67d11b0"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4aee01fb76ada3e5e7ca642ea6664ebf7308a810739ca2aca44909a1191ac254"


### PR DESCRIPTION
New version is 0.0.157.

Signed-off-by: mulhern <amulhern@redhat.com>