### PR TITLE
Implement D-Bus Blockdev API

### DIFF
--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -71,13 +71,14 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                                          MessageItem::Array(vec![], "o".into())]);
             let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
-            let mut bd_object_paths = Vec::new();
-            for dev_uuid in pool.blockdevs().iter().map(|bd| bd.uuid()) {
-                bd_object_paths
-                    .push(MessageItem::ObjectPath(create_dbus_blockdev(dbus_context,
-                                                                       pool_object_path.clone(),
-                                                                       dev_uuid)));
-            }
+            let bd_object_paths = pool.blockdevs()
+                .iter()
+                .map(|bd| {
+                         MessageItem::ObjectPath(create_dbus_blockdev(dbus_context,
+                                                                      pool_object_path.clone(),
+                                                                      bd.uuid()))
+                     })
+                .collect::<Vec<_>>();
 
             let return_path = MessageItem::ObjectPath(pool_object_path);
             let return_list = MessageItem::Array(bd_object_paths, "o".into());

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -66,9 +66,9 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         Ok(pool_uuid) => {
             let pool_object_path: dbus::Path =
                 create_dbus_pool(dbus_context, object_path.clone(), pool_uuid);
-            let return_sig = "(oao)";
-            let default_return = MessageItem::Array(vec![], return_sig.into());
-
+            let default_return =
+                MessageItem::Struct(vec![MessageItem::ObjectPath(default_object_path()),
+                                         MessageItem::Array(vec![], "o".into())]);
             let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
             let mut bd_object_paths = Vec::new();
@@ -264,8 +264,9 @@ pub fn connect(engine: Rc<RefCell<Engine>>)
     let (tree, object_path) = get_base_tree(DbusContext::new(engine));
     let dbus_context = tree.get_data().clone();
 
-    // This should never panic as create_dbus_pool() and
-    // create_dbus_filesystem() do not borrow the engine.
+    // This should never panic as create_dbus_pool(),
+    // create_dbus_filesystem(), and create_dbus_blockdev() do not borrow the
+    // engine.
     for pool in local_engine.borrow().pools() {
         let pool_path = create_dbus_pool(&dbus_context, object_path.clone(), pool.uuid());
         for fs_uuid in pool.filesystems().iter().map(|f| f.uuid()) {

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -32,6 +32,7 @@ use engine::{Engine, Redundancy};
 use stratis::VERSION;
 
 use super::filesystem::create_dbus_filesystem;
+use super::blockdev::create_dbus_blockdev;
 use super::pool::create_dbus_pool;
 use super::types::{DeferredAction, DbusContext, DbusErrorEnum, TData};
 use super::util::STRATIS_BASE_PATH;
@@ -56,27 +57,30 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let object_path = m.path.get_name();
     let dbus_context = m.tree.get_data();
-    let result = dbus_context
-        .engine
-        .borrow_mut()
-        .create_pool(name, &blockdevs, tuple_to_option(redundancy), force);
+    let mut engine = dbus_context.engine.borrow_mut();
+    let result = engine.create_pool(name, &blockdevs, tuple_to_option(redundancy), force);
 
     let return_message = message.method_return();
 
     let msg = match result {
-        Ok((uuid, devnodes)) => {
+        Ok(pool_uuid) => {
             let pool_object_path: dbus::Path =
-                create_dbus_pool(dbus_context, object_path.clone(), uuid);
-            let paths = devnodes
-                .iter()
-                .map(|d| {
-                         d.to_str()
-                             .expect("'d' originated in the 'devs' D-Bus argument")
-                             .into()
-                     });
-            let paths = paths.map(MessageItem::Str).collect();
+                create_dbus_pool(dbus_context, object_path.clone(), pool_uuid);
+            let return_sig = "(oao)";
+            let default_return = MessageItem::Array(vec![], return_sig.into());
+
+            let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
+
+            let mut bd_object_paths = Vec::new();
+            for dev_uuid in pool.blockdevs().iter().map(|bd| bd.uuid()) {
+                bd_object_paths
+                    .push(MessageItem::ObjectPath(create_dbus_blockdev(&dbus_context,
+                                                                       pool_object_path.clone(),
+                                                                       dev_uuid)));
+            }
+
             let return_path = MessageItem::ObjectPath(pool_object_path);
-            let return_list = MessageItem::Array(paths, "s".into());
+            let return_list = MessageItem::Array(bd_object_paths, "o".into());
             let return_value = MessageItem::Struct(vec![return_path, return_list]);
             let (rc, rs) = ok_message_items();
             return_message.append3(return_value, rc, rs)
@@ -201,7 +205,7 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>, db
         .in_arg(("redundancy", "(bq)"))
         .in_arg(("force", "b"))
         .in_arg(("devices", "as"))
-        .out_arg(("result", "(oas)"))
+        .out_arg(("result", "(oao)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
@@ -266,6 +270,9 @@ pub fn connect(engine: Rc<RefCell<Engine>>)
         let pool_path = create_dbus_pool(&dbus_context, object_path.clone(), pool.uuid());
         for fs_uuid in pool.filesystems().iter().map(|f| f.uuid()) {
             create_dbus_filesystem(&dbus_context, pool_path.clone(), fs_uuid);
+        }
+        for dev_uuid in pool.blockdevs().iter().map(|bd| bd.uuid()) {
+            create_dbus_blockdev(&dbus_context, pool_path.clone(), dev_uuid);
         }
     }
 

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -74,7 +74,7 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             let mut bd_object_paths = Vec::new();
             for dev_uuid in pool.blockdevs().iter().map(|bd| bd.uuid()) {
                 bd_object_paths
-                    .push(MessageItem::ObjectPath(create_dbus_blockdev(&dbus_context,
+                    .push(MessageItem::ObjectPath(create_dbus_blockdev(dbus_context,
                                                                        pool_object_path.clone(),
                                                                        dev_uuid)));
             }

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -1,0 +1,283 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use dbus;
+use dbus::Message;
+use dbus::MessageItem;
+use dbus::arg::IterAppend;
+use dbus::tree::Access;
+use dbus::tree::EmitsChangedSignal;
+use dbus::tree::Factory;
+use dbus::tree::MTFn;
+use dbus::tree::MethodErr;
+use dbus::tree::MethodInfo;
+use dbus::tree::MethodResult;
+use dbus::tree::PropInfo;
+
+use uuid::Uuid;
+
+use super::super::engine::BlockDev;
+use super::super::engine::types::BlockDevState;
+
+use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
+
+use super::util::STRATIS_BASE_PATH;
+use super::util::STRATIS_BASE_SERVICE;
+use super::util::code_to_message_items;
+use super::util::get_next_arg;
+use super::util::get_parent;
+use super::util::get_uuid;
+use super::util::ok_message_items;
+
+
+pub fn create_dbus_blockdev<'a>(dbus_context: &DbusContext,
+                                parent: dbus::Path<'static>,
+                                uuid: Uuid)
+                                -> dbus::Path<'a> {
+    let f = Factory::new_fn();
+
+    let set_userid_method = f.method("SetUserId", (), set_user_id)
+        .in_arg(("id", "s"))
+        .out_arg(("changed", "b"))
+        .out_arg(("return_code", "q"))
+        .out_arg(("return_string", "s"));
+
+    let devnode_property = f.property::<&str, _>("Devnode", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::Const)
+        .on_get(get_blockdev_devnode);
+
+    let hardware_id_property = f.property::<&str, _>("HardwareId", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::Const)
+        .on_get(get_blockdev_hardware_id);
+
+    let user_id_property = f.property::<&str, _>("UserId", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::Const)
+        .on_get(get_blockdev_user_id);
+
+    let initialization_time_property = f.property::<&str, _>("InitializationTime", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::Const)
+        .on_get(get_blockdev_initialization_time);
+
+    let total_physical_size_property = f.property::<&str, _>("TotalPhysicalSize", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::False)
+        .on_get(get_blockdev_physical_size);
+
+    let state_property = f.property::<&str, _>("State", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::False)
+        .on_get(get_blockdev_state);
+
+    let pool_property = f.property::<&dbus::Path, _>("Pool", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::Const)
+        .on_get(get_parent);
+
+    let uuid_property = f.property::<&str, _>("Uuid", ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::Const)
+        .on_get(get_uuid);
+
+    let object_name = format!("{}/{}",
+                              STRATIS_BASE_PATH,
+                              dbus_context.get_next_id().to_string());
+
+    let interface_name = format!("{}.{}", STRATIS_BASE_SERVICE, "blockdev");
+
+    let object_path = f.object_path(object_name, Some(OPContext::new(parent, uuid)))
+        .introspectable()
+        .add(f.interface(interface_name, ())
+                 .add_m(set_userid_method)
+                 .add_p(devnode_property)
+                 .add_p(hardware_id_property)
+                 .add_p(initialization_time_property)
+                 .add_p(total_physical_size_property)
+                 .add_p(pool_property)
+                 .add_p(state_property)
+                 .add_p(user_id_property)
+                 .add_p(uuid_property));
+
+    let path = object_path.get_name().to_owned();
+    dbus_context.actions.borrow_mut().push_add(object_path);
+    path
+}
+
+fn set_user_id(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+    let message: &Message = m.msg;
+    let mut iter = message.iter_init();
+
+    let new_id: &str = get_next_arg(&mut iter, 0)?;
+
+    let dbus_context = m.tree.get_data();
+    let object_path = m.path.get_name();
+    let return_message = message.method_return();
+    let default_return = MessageItem::Bool(false);
+
+    let blockdev_path = m.tree
+        .get(object_path)
+        .expect("implicit argument must be in tree");
+    let blockdev_data = get_data!(blockdev_path; default_return; return_message);
+
+    let pool_path = get_parent!(m; blockdev_data; default_return; return_message);
+    let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
+
+    let mut engine = dbus_context.engine.borrow_mut();
+    let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
+
+    let blockdev_uuid = &blockdev_data.uuid;
+    let id_changed = {
+        let blockdev =
+            pool.get_mut_blockdev(blockdev_uuid)
+                .ok_or_else(|| {
+                                MethodErr::failed(&format!("no blockdev with uuid {}",
+                                                           &blockdev_uuid))
+                            })?;
+
+        let id_changed = blockdev.user_id() != &Some(new_id.to_owned());
+
+        blockdev
+            .set_user_id(Some(new_id))
+            .map_err(|err| {
+                         MethodErr::failed(&format!("set_user_id failed for object path {}: {}",
+                                                    object_path,
+                                                    err))
+                     })?;
+        id_changed
+    };
+
+    pool.save_state()
+        .map_err(|err| {
+                     MethodErr::failed(&format!("Could not save state for object path {}: {}",
+                                                object_path,
+                                                err))
+                 })?;
+
+
+    let (rc, rs) = ok_message_items();
+    let msg = return_message.append3(MessageItem::Bool(id_changed), rc, rs);
+
+    Ok(vec![msg])
+}
+
+
+/// Get a blockdev property and place it on the D-Bus. The property is
+/// found by means of the getter method which takes a reference to a
+/// blockdev and obtains the property from the blockdev.
+fn get_blockdev_property<F>(i: &mut IterAppend,
+                            p: &PropInfo<MTFn<TData>, TData>,
+                            getter: F)
+                            -> Result<(), MethodErr>
+    where F: Fn(&BlockDev) -> Result<MessageItem, MethodErr>
+{
+    let dbus_context = p.tree.get_data();
+    let object_path = p.path.get_name();
+
+    let blockdev_path = p.tree
+        .get(object_path)
+        .expect("tree must contain implicit argument");
+
+    let blockdev_data =
+        blockdev_path
+            .get_data()
+            .as_ref()
+            .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
+
+    let pool_path = p.tree
+        .get(&blockdev_data.parent)
+        .ok_or_else(|| {
+                        MethodErr::failed(&format!("no path for parent object path {}",
+                                                   &blockdev_data.parent))
+                    })?;
+
+    let pool_uuid = pool_path
+        .get_data()
+        .as_ref()
+        .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?
+        .uuid;
+
+    let engine = dbus_context.engine.borrow();
+    let pool =
+        engine
+            .get_pool(pool_uuid)
+            .ok_or_else(|| {
+                            MethodErr::failed(&format!("no pool corresponding to uuid {}",
+                                                       &pool_uuid))
+                        })?;
+    let blockdev_uuid = &blockdev_data.uuid;
+    let blockdev =
+        pool.get_blockdev(blockdev_uuid)
+            .ok_or_else(|| MethodErr::failed(&format!("noblockdev with uuid {}", &blockdev_uuid)))?;
+    i.append(getter(blockdev)?);
+    Ok(())
+}
+
+/// Get the devnode for an object path.
+fn get_blockdev_devnode(i: &mut IterAppend,
+                        p: &PropInfo<MTFn<TData>, TData>)
+                        -> Result<(), MethodErr> {
+    get_blockdev_property(i,
+                          p,
+                          |p| Ok(MessageItem::Str(format!("{}", p.devnode().display()))))
+}
+
+fn get_blockdev_hardware_id(i: &mut IterAppend,
+                            p: &PropInfo<MTFn<TData>, TData>)
+                            -> Result<(), MethodErr> {
+    fn get_hardware_id(blockdev: &BlockDev) -> Result<MessageItem, MethodErr> {
+        match *blockdev.hardware_id() {
+            Some(ref id) => Ok(MessageItem::Str(id.to_owned())),
+            None => Ok(MessageItem::Str("".to_owned())),
+        }
+    }
+
+    get_blockdev_property(i, p, get_hardware_id)
+}
+
+fn get_blockdev_user_id(i: &mut IterAppend,
+                        p: &PropInfo<MTFn<TData>, TData>)
+                        -> Result<(), MethodErr> {
+    fn get_user_id(blockdev: &BlockDev) -> Result<MessageItem, MethodErr> {
+        match *blockdev.user_id() {
+            Some(ref id) => Ok(MessageItem::Str(id.to_owned())),
+            None => Ok(MessageItem::Str("".to_owned())),
+        }
+    }
+
+    get_blockdev_property(i, p, get_user_id)
+}
+
+fn get_blockdev_initialization_time(i: &mut IterAppend,
+                                    p: &PropInfo<MTFn<TData>, TData>)
+                                    -> Result<(), MethodErr> {
+    get_blockdev_property(i, p, |p| Ok(MessageItem::Str(p.initialization_time())))
+}
+
+fn get_blockdev_physical_size(i: &mut IterAppend,
+                              p: &PropInfo<MTFn<TData>, TData>)
+                              -> Result<(), MethodErr> {
+    get_blockdev_property(i,
+                          p,
+                          |p| Ok(MessageItem::Str(format!("{}", *p.total_size()))))
+}
+
+fn get_blockdev_state(i: &mut IterAppend,
+                      p: &PropInfo<MTFn<TData>, TData>)
+                      -> Result<(), MethodErr> {
+    fn get_state(blockdev: &BlockDev) -> Result<MessageItem, MethodErr> {
+        let state = match blockdev.state() {
+            BlockDevState::Missing => "Missing".into(),
+            BlockDevState::Bad => "Bad".into(),
+            BlockDevState::Spare => "Spare".into(),
+            BlockDevState::NotInUse => "Not-in-use".into(),
+            BlockDevState::InUse => "In-use".into(),
+        };
+        Ok(MessageItem::Str(state))
+    }
+
+    get_blockdev_property(i, p, get_state)
+}

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -132,14 +132,12 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
-    let blockdev_uuid = &blockdev_data.uuid;
     let id_changed = {
-        let blockdev =
-            pool.get_mut_blockdev(blockdev_uuid)
-                .ok_or_else(|| {
-                                MethodErr::failed(&format!("no blockdev with uuid {}",
-                                                           &blockdev_uuid))
-                            })?;
+        let blockdev = pool.get_mut_blockdev(blockdev_data.uuid)
+            .ok_or_else(|| {
+                            MethodErr::failed(&format!("no blockdev with uuid {}",
+                                                       blockdev_data.uuid))
+                        })?;
 
         let id_changed = blockdev.user_info() != new_id;
         blockdev.set_user_info(new_id);
@@ -207,10 +205,12 @@ fn get_blockdev_property<F>(i: &mut IterAppend,
                             MethodErr::failed(&format!("no pool corresponding to uuid {}",
                                                        &pool_uuid))
                         })?;
-    let blockdev_uuid = &blockdev_data.uuid;
     let blockdev =
-        pool.get_blockdev(blockdev_uuid)
-            .ok_or_else(|| MethodErr::failed(&format!("noblockdev with uuid {}", &blockdev_uuid)))?;
+        pool.get_blockdev(blockdev_data.uuid)
+            .ok_or_else(|| {
+                            MethodErr::failed(&format!("noblockdev with uuid {}",
+                                                       blockdev_data.uuid))
+                        })?;
     i.append(getter(blockdev)?);
     Ok(())
 }

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -254,7 +254,9 @@ fn get_blockdev_user_id(i: &mut IterAppend,
 fn get_blockdev_initialization_time(i: &mut IterAppend,
                                     p: &PropInfo<MTFn<TData>, TData>)
                                     -> Result<(), MethodErr> {
-    get_blockdev_property(i, p, |p| Ok(MessageItem::Str(p.initialization_time())))
+    get_blockdev_property(i,
+                          p,
+                          |p| Ok(MessageItem::Str(p.initialization_time().to_rfc3339())))
 }
 
 fn get_blockdev_physical_size(i: &mut IterAppend,

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -139,10 +139,7 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                                                        blockdev_data.uuid))
                         })?;
 
-        let id_changed = blockdev.user_info() != new_id;
-        blockdev.set_user_info(new_id);
-
-        id_changed
+        blockdev.set_user_info(new_id)
     };
 
     // FIXME: engine should decide to save state, not this function
@@ -208,7 +205,7 @@ fn get_blockdev_property<F>(i: &mut IterAppend,
     let blockdev =
         pool.get_blockdev(blockdev_data.uuid)
             .ok_or_else(|| {
-                            MethodErr::failed(&format!("noblockdev with uuid {}",
+                            MethodErr::failed(&format!("no blockdev with uuid {}",
                                                        blockdev_data.uuid))
                         })?;
     i.append(getter(blockdev)?);

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -48,12 +48,12 @@ pub fn create_dbus_blockdev<'a>(dbus_context: &DbusContext,
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_blockdev_devnode);
 
-    let hardware_info_property = f.property::<&str, _>("HardwareId", ())
+    let hardware_info_property = f.property::<&str, _>("HardwareInfo", ())
         .access(Access::Read)
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_blockdev_hardware_info);
 
-    let user_info_property = f.property::<&str, _>("UserId", ())
+    let user_info_property = f.property::<&str, _>("UserInfo", ())
         .access(Access::Read)
         .emits_changed(EmitsChangedSignal::False)
         .on_get(get_blockdev_user_info);
@@ -150,6 +150,7 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         id_changed
     };
 
+    // FIXME: engine should decide to save state, not this function
     pool.save_state()
         .map_err(|err| {
                      MethodErr::failed(&format!("Could not save state for object path {}: {}",

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -7,6 +7,7 @@ mod macros;
 
 mod api;
 mod filesystem;
+mod blockdev;
 mod pool;
 mod types;
 mod util;

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -174,18 +174,16 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let result = pool.add_blockdevs(&blockdevs, force);
     let msg = match result {
-        Ok(ref infos) => {
-            let mut return_value = Vec::new();
-            for uuid in infos {
-                let bd_object_path: dbus::Path =
-                    create_dbus_blockdev(dbus_context, object_path.clone(), *uuid);
-                return_value.push(bd_object_path);
-            }
-
-            let return_value = return_value
+        Ok(uuids) => {
+            let return_value = uuids
                 .iter()
-                .map(|p| MessageItem::ObjectPath(p.clone()))
+                .map(|uuid| {
+                         MessageItem::ObjectPath(create_dbus_blockdev(dbus_context,
+                                                                      object_path.clone(),
+                                                                      *uuid))
+                     })
                 .collect();
+
             let return_value = MessageItem::Array(return_value, return_sig.into());
             let (rc, rs) = ok_message_items();
             return_message.append3(return_value, rc, rs)

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -26,6 +26,7 @@ use devicemapper::Sectors;
 
 use engine::{Pool, RenameAction};
 
+use super::blockdev::create_dbus_blockdev;
 use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
@@ -158,7 +159,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let return_sig = "s";
+    let return_sig = "o";
     let default_return = MessageItem::Array(vec![], return_sig.into());
 
     let pool_path = m.tree
@@ -171,25 +172,31 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
-    let msg = match pool.add_blockdevs(&blockdevs, force) {
-        Ok(devnodes) => {
-            let paths = devnodes
+    let result = pool.add_blockdevs(&blockdevs, force);
+    let msg = match result {
+        Ok(ref infos) => {
+            let mut return_value = Vec::new();
+            for uuid in infos {
+                let bd_object_path: dbus::Path =
+                    create_dbus_blockdev(dbus_context, object_path.clone(), *uuid);
+                return_value.push(bd_object_path);
+            }
+
+            let return_value = return_value
                 .iter()
-                .map(|d| {
-                         d.to_str()
-                             .expect("'d' originated in the 'devs' D-Bus argument")
-                             .into()
-                     });
-            let paths = paths.map(MessageItem::Str).collect();
+                .map(|p| MessageItem::ObjectPath(p.clone()))
+                .collect();
+            let return_value = MessageItem::Array(return_value, return_sig.into());
             let (rc, rs) = ok_message_items();
-            return_message.append3(MessageItem::Array(paths, return_sig.into()), rc, rs)
+            return_message.append3(return_value, rc, rs)
         }
-        Err(x) => {
-            let (rc, rs) = engine_to_dbus_err(&x);
+        Err(err) => {
+            let (rc, rs) = engine_to_dbus_err(&err);
             let (rc, rs) = code_to_message_items(rc, rs);
             return_message.append3(default_return, rc, rs)
         }
     };
+
     Ok(vec![msg])
 }
 
@@ -320,7 +327,7 @@ pub fn create_dbus_pool<'a>(dbus_context: &DbusContext,
     let add_devs_method = f.method("AddDevs", (), add_devs)
         .in_arg(("force", "b"))
         .in_arg(("devices", "as"))
-        .out_arg(("results", "as"))
+        .out_arg(("results", "ao"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -34,7 +34,7 @@ pub trait BlockDev: HasUuid {
     fn user_info(&self) -> Option<&str>;
 
     /// Set the user-settable string associated with this blockdev.
-    fn set_user_info(&mut self, user_info: Option<&str>) -> ();
+    fn set_user_info(&mut self, user_info: Option<&str>) -> bool;
 
     /// Get the hardware ID for this blockdev.
     fn hardware_info(&self) -> Option<&str>;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -39,7 +39,8 @@ pub trait BlockDev: HasUuid {
     /// Get the hardware ID for this blockdev.
     fn hardware_info(&self) -> Option<&str>;
 
-    /// The time that this blockdev was initialized by Stratis.
+    /// The time that this blockdev was initialized by Stratis, rounded down
+    /// to the nearest second.
     fn initialization_time(&self) -> DateTime<Utc>;
 
     /// The usable size of the device, not counting Stratis overhead.
@@ -117,12 +118,12 @@ pub trait Pool: HasName + HasUuid {
     fn blockdevs(&self) -> Vec<&BlockDev>;
 
     /// Get the blockdev in this pool with this UUID.
-    fn get_blockdev(&self, uuid: &DevUuid) -> Option<&BlockDev>;
+    fn get_blockdev(&self, uuid: DevUuid) -> Option<&BlockDev>;
 
     /// Get the mutable filesystem in this pool with this UUID.
-    fn get_mut_blockdev(&mut self, uuid: &DevUuid) -> Option<&mut BlockDev>;
+    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<&mut BlockDev>;
 
-    /// Save the state of the pool.
+    /// Save the state of the pool. FIXME, see #614.
     fn save_state(&mut self) -> EngineResult<()>;
 }
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -5,6 +5,7 @@
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use devicemapper::Sectors;
@@ -26,14 +27,25 @@ pub trait Filesystem: HasName + HasUuid {
 }
 
 pub trait BlockDev: HasUuid {
-    /// path of the device node
+    /// Get the path of the device node for this device.
     fn devnode(&self) -> PathBuf;
 
+    /// Get the user-settable string associated with this blockdev.
     fn user_id(&self) -> &Option<String>;
-    fn set_user_id(&mut self, location: Option<&str>) -> EngineResult<()>;
+
+    /// Set the user-settable string associated with this blockdev.
+    fn set_user_id(&mut self, user_id: Option<&str>) -> EngineResult<()>;
+
+    /// Get the hardware ID for this blockdev.
     fn hardware_id(&self) -> &Option<String>;
-    fn initialization_time(&self) -> String;
+
+    /// The time that this blockdev was initialized by Stratis.
+    fn initialization_time(&self) -> DateTime<Utc>;
+
+    /// The usable size of the device, not counting Stratis overhead.
     fn total_size(&self) -> Sectors;
+
+    /// The current state of the blockdev.
     fn state(&self) -> BlockDevState;
 }
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -31,13 +31,13 @@ pub trait BlockDev: HasUuid {
     fn devnode(&self) -> PathBuf;
 
     /// Get the user-settable string associated with this blockdev.
-    fn user_id(&self) -> &Option<String>;
+    fn user_info(&self) -> Option<&str>;
 
     /// Set the user-settable string associated with this blockdev.
-    fn set_user_id(&mut self, user_id: Option<&str>) -> EngineResult<()>;
+    fn set_user_info(&mut self, user_info: Option<&str>) -> EngineResult<()>;
 
     /// Get the hardware ID for this blockdev.
-    fn hardware_id(&self) -> &Option<String>;
+    fn hardware_info(&self) -> Option<&str>;
 
     /// The time that this blockdev was initialized by Stratis.
     fn initialization_time(&self) -> DateTime<Utc>;
@@ -128,8 +128,7 @@ pub trait Pool: HasName + HasUuid {
 
 pub trait Engine: Debug {
     /// Create a Stratis pool.
-    /// Returns the UUID of the newly created pool and the blockdevs the
-    /// pool contains.
+    /// Returns the UUID of the newly created pool.
     /// Returns an error if the redundancy code does not correspond to a
     /// supported redundancy.
     fn create_pool(&mut self,

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -34,7 +34,7 @@ pub trait BlockDev: HasUuid {
     fn user_info(&self) -> Option<&str>;
 
     /// Set the user-settable string associated with this blockdev.
-    fn set_user_info(&mut self, user_info: Option<&str>) -> EngineResult<()>;
+    fn set_user_info(&mut self, user_info: Option<&str>) -> ();
 
     /// Get the hardware ID for this blockdev.
     fn hardware_info(&self) -> Option<&str>;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -60,7 +60,7 @@ pub trait Pool: HasName + HasUuid {
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>>;
 
     /// Adds blockdevs specified by paths to pool.
-    /// Returns a list of device nodes corresponding to devices actually added.
+    /// Returns a list of uuids corresponding to devices actually added.
     /// Returns an error if a blockdev can not be added because it is owned
     /// or there was an error while reading or writing a blockdev.
     fn add_blockdevs(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<DevUuid>>;

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -96,3 +96,14 @@ macro_rules! check_engine {
         }
     }
 }
+
+macro_rules! set_blockdev_user_info {
+    ( $s:ident; $info:ident ) => {
+        if $s.user_info.as_ref().map(|x| &**x) != $info {
+            $s.user_info = $info.map(|x| x.to_owned());
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -37,8 +37,13 @@ impl BlockDev for SimDev {
         self.user_info.as_ref().map(|x| &**x)
     }
 
-    fn set_user_info(&mut self, user_info: Option<&str>) -> () {
-        self.user_info = user_info.map(|x| x.to_owned());
+    fn set_user_info(&mut self, user_info: Option<&str>) -> bool {
+        if self.user_info.as_ref().map(|x| &**x) != user_info {
+            self.user_info = user_info.map(|x| x.to_owned());
+            true
+        } else {
+            false
+        }
     }
 
     fn hardware_info(&self) -> Option<&str> {

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -38,12 +38,7 @@ impl BlockDev for SimDev {
     }
 
     fn set_user_info(&mut self, user_info: Option<&str>) -> bool {
-        if self.user_info.as_ref().map(|x| &**x) != user_info {
-            self.user_info = user_info.map(|x| x.to_owned());
-            true
-        } else {
-            false
-        }
+        set_blockdev_user_info!(self; user_info)
     }
 
     fn hardware_info(&self) -> Option<&str> {

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -24,8 +24,8 @@ pub struct SimDev {
     pub devnode: PathBuf,
     rdm: Rc<RefCell<Randomizer>>,
     pub uuid: Uuid,
-    location: Option<String>,
-    disk_id: Option<String>,
+    user_info: Option<String>,
+    hardware_info: Option<String>,
     initialization_time: u64,
 }
 
@@ -34,17 +34,17 @@ impl BlockDev for SimDev {
         self.devnode.clone()
     }
 
-    fn user_id(&self) -> &Option<String> {
-        &self.location
+    fn user_info(&self) -> Option<&str> {
+        self.user_info.as_ref().map(|x| &**x)
     }
 
-    fn set_user_id(&mut self, location: Option<&str>) -> EngineResult<()> {
-        self.location = location.map(|x| x.to_owned());
+    fn set_user_info(&mut self, user_info: Option<&str>) -> EngineResult<()> {
+        self.user_info = user_info.map(|x| x.to_owned());
         Ok(())
     }
 
-    fn hardware_id(&self) -> &Option<String> {
-        &self.disk_id
+    fn hardware_info(&self) -> Option<&str> {
+        self.hardware_info.as_ref().map(|x| &**x)
     }
 
     fn initialization_time(&self) -> DateTime<Utc> {
@@ -73,8 +73,8 @@ impl SimDev {
             devnode: devnode.to_owned(),
             rdm: rdm,
             uuid: Uuid::new_v4(),
-            location: None,
-            disk_id: None,
+            user_info: None,
+            hardware_info: None,
             initialization_time: Utc::now().timestamp() as u64,
         }
     }

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -20,9 +20,9 @@ use super::randomization::Randomizer;
 #[derive(Debug)]
 /// A simulated device.
 pub struct SimDev {
-    pub devnode: PathBuf,
+    devnode: PathBuf,
     rdm: Rc<RefCell<Randomizer>>,
-    pub uuid: Uuid,
+    uuid: Uuid,
     user_info: Option<String>,
     hardware_info: Option<String>,
     initialization_time: u64,

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -7,8 +7,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use chrono::{TimeZone, Utc};
-
+use chrono::{DateTime, TimeZone, Utc};
 use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC};
@@ -48,9 +47,8 @@ impl BlockDev for SimDev {
         &self.disk_id
     }
 
-    fn initialization_time(&self) -> String {
+    fn initialization_time(&self) -> DateTime<Utc> {
         Utc.timestamp(self.initialization_time as i64, 0)
-            .to_rfc3339()
     }
 
     fn total_size(&self) -> Sectors {

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -12,7 +12,6 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC};
 
-use super::super::errors::EngineResult;
 use super::super::engine::{BlockDev, HasUuid};
 use super::super::types::{BlockDevState, DevUuid};
 
@@ -38,9 +37,8 @@ impl BlockDev for SimDev {
         self.user_info.as_ref().map(|x| &**x)
     }
 
-    fn set_user_info(&mut self, user_info: Option<&str>) -> EngineResult<()> {
+    fn set_user_info(&mut self, user_info: Option<&str>) -> () {
         self.user_info = user_info.map(|x| x.to_owned());
-        Ok(())
     }
 
     fn hardware_info(&self) -> Option<&str> {

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -181,7 +181,7 @@ mod tests {
         let mut engine = SimEngine::default();
         engine.create_pool(name, &[], None, false).unwrap();
         assert!(match engine.create_pool(name, &[], None, false) {
-                    Ok(uuid) => engine.get_pool(&uuid).unwrap().blockdevs().is_empty(),
+                    Ok(uuid) => engine.get_pool(uuid).unwrap().blockdevs().is_empty(),
                     Err(_) => false,
                 });
     }
@@ -207,7 +207,7 @@ mod tests {
         let mut engine = SimEngine::default();
         let devices = vec![Path::new(path), Path::new(path)];
         assert!(match engine.create_pool("name", &devices, None, false) {
-                    Ok(uuid) => engine.get_pool(&uuid).unwrap().blockdevs().len() == 1,
+                    Ok(uuid) => engine.get_pool(uuid).unwrap().blockdevs().len() == 1,
                     _ => false,
                 });
     }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -44,7 +44,7 @@ impl SimPool {
         let device_pairs = devices
             .iter()
             .map(|p| {
-                     let bd = SimDev::new(rdm.clone(), p);
+                     let bd = SimDev::new(Rc::clone(&rdm), p);
                      (bd.uuid(), bd)
                  });
         SimPool {
@@ -68,12 +68,11 @@ impl SimPool {
 
 impl Pool for SimPool {
     fn add_blockdevs(&mut self, paths: &[&Path], _force: bool) -> EngineResult<Vec<DevUuid>> {
-        let rdm = Rc::clone(&self.rdm);
         let devices: HashSet<_, RandomState> = HashSet::from_iter(paths);
         let device_pairs: Vec<_> = devices
             .iter()
             .map(|p| {
-                     let bd = SimDev::new(rdm.clone(), p);
+                     let bd = SimDev::new(Rc::clone(&self.rdm), p);
                      (bd.uuid(), bd)
                  })
             .collect();

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -175,13 +175,13 @@ impl Pool for SimPool {
             .collect()
     }
 
-    fn get_blockdev(&self, uuid: &DevUuid) -> Option<&BlockDev> {
-        self.block_devs.get(uuid).map(|p| p as &BlockDev)
+    fn get_blockdev(&self, uuid: DevUuid) -> Option<&BlockDev> {
+        self.block_devs.get(&uuid).map(|p| p as &BlockDev)
     }
 
-    fn get_mut_blockdev(&mut self, uuid: &DevUuid) -> Option<&mut BlockDev> {
+    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<&mut BlockDev> {
         self.block_devs
-            .get_mut(uuid)
+            .get_mut(&uuid)
             .map(|p| p as &mut BlockDev)
     }
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -7,7 +7,6 @@ use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::RandomState;
 use std::iter::FromIterator;
 use std::path::Path;
-use std::path::PathBuf;
 use std::rc::Rc;
 use std::vec::Vec;
 
@@ -18,7 +17,7 @@ use devicemapper::{IEC, Sectors};
 use super::super::engine::{Filesystem, BlockDev, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
-use super::super::types::{FilesystemUuid, PoolUuid, RenameAction, Redundancy};
+use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, RenameAction, Redundancy};
 
 use super::blockdev::SimDev;
 use super::filesystem::SimFilesystem;
@@ -28,7 +27,7 @@ use super::randomization::Randomizer;
 pub struct SimPool {
     name: String,
     pool_uuid: PoolUuid,
-    pub block_devs: HashMap<PathBuf, SimDev>,
+    pub block_devs: HashMap<DevUuid, SimDev>,
     pub filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
@@ -44,7 +43,10 @@ impl SimPool {
         let devices: HashSet<_, RandomState> = HashSet::from_iter(paths);
         let device_pairs = devices
             .iter()
-            .map(|p| (p.to_path_buf(), SimDev::new(Rc::clone(&rdm), p)));
+            .map(|p| {
+                     let bd = SimDev::new(rdm.clone(), p);
+                     (bd.uuid(), bd)
+                 });
         SimPool {
             name: name.to_owned(),
             pool_uuid: Uuid::new_v4(),
@@ -65,14 +67,19 @@ impl SimPool {
 }
 
 impl Pool for SimPool {
-    fn add_blockdevs(&mut self, paths: &[&Path], _force: bool) -> EngineResult<Vec<PathBuf>> {
+    fn add_blockdevs(&mut self, paths: &[&Path], _force: bool) -> EngineResult<Vec<DevUuid>> {
         let rdm = Rc::clone(&self.rdm);
         let devices: HashSet<_, RandomState> = HashSet::from_iter(paths);
-        let device_pairs = devices
+        let device_pairs: Vec<_> = devices
             .iter()
-            .map(|p| (p.to_path_buf(), SimDev::new(Rc::clone(&rdm), p)));
+            .map(|p| {
+                     let bd = SimDev::new(rdm.clone(), p);
+                     (bd.uuid(), bd)
+                 })
+            .collect();
+        let ret_uuids = device_pairs.iter().map(|&(uuid, _)| uuid).collect();
         self.block_devs.extend(device_pairs);
-        Ok(devices.iter().map(|d| d.to_path_buf()).collect())
+        Ok(ret_uuids)
     }
 
     fn destroy_filesystems<'a>(&'a mut self,
@@ -133,18 +140,6 @@ impl Pool for SimPool {
         self.name = name.to_owned();
     }
 
-    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem> {
-        self.filesystems
-            .get_by_uuid(uuid)
-            .map(|p| p as &Filesystem)
-    }
-
-    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<&mut Filesystem> {
-        self.filesystems
-            .get_mut_by_uuid(uuid)
-            .map(|p| p as &mut Filesystem)
-    }
-
     fn total_physical_size(&self) -> Sectors {
         // We choose to make our pools very big, and we can change that
         // if it is inconvenient.
@@ -162,11 +157,37 @@ impl Pool for SimPool {
             .collect()
     }
 
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem> {
+        self.filesystems
+            .get_by_uuid(uuid)
+            .map(|p| p as &Filesystem)
+    }
+
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<&mut Filesystem> {
+        self.filesystems
+            .get_mut_by_uuid(uuid)
+            .map(|p| p as &mut Filesystem)
+    }
+
     fn blockdevs(&self) -> Vec<&BlockDev> {
         self.block_devs
-            .iter()
-            .map(|(_, bd)| bd as &BlockDev)
+            .values()
+            .map(|bd| bd as &BlockDev)
             .collect()
+    }
+
+    fn get_blockdev(&self, uuid: &DevUuid) -> Option<&BlockDev> {
+        self.block_devs.get(uuid).map(|p| p as &BlockDev)
+    }
+
+    fn get_mut_blockdev(&mut self, uuid: &DevUuid) -> Option<&mut BlockDev> {
+        self.block_devs
+            .get_mut(uuid)
+            .map(|p| p as &mut BlockDev)
+    }
+
+    fn save_state(&mut self) -> EngineResult<()> {
+        Ok(())
     }
 }
 
@@ -201,7 +222,7 @@ mod tests {
     /// Renaming a filesystem on an empty pool always works
     fn rename_empty() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
+        let uuid = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
         assert!(match pool.rename_filesystem(Uuid::new_v4(), "new_name") {
                     Ok(RenameAction::NoSource) => true,
@@ -213,7 +234,7 @@ mod tests {
     /// Renaming a filesystem to another filesystem should work if new name not taken
     fn rename_happens() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
+        let uuid = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
         let infos = pool.create_filesystems(&[("old_name", None)]).unwrap();
         assert!(match pool.rename_filesystem(infos[0].1, "new_name") {
@@ -228,7 +249,7 @@ mod tests {
         let old_name = "old_name";
         let new_name = "new_name";
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
+        let uuid = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
         let results = pool.create_filesystems(&[(old_name, None), (new_name, None)])
             .unwrap();
@@ -244,7 +265,7 @@ mod tests {
     fn rename_no_op() {
         let new_name = "new_name";
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
+        let uuid = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
         assert!(match pool.rename_filesystem(Uuid::new_v4(), new_name) {
                     Ok(RenameAction::NoSource) => true,
@@ -256,7 +277,7 @@ mod tests {
     /// Removing an empty list of filesystems should always succeed
     fn destroy_fs_empty() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
+        let uuid = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
         assert!(match pool.destroy_filesystems(&[]) {
                     Ok(names) => names.is_empty(),
@@ -268,7 +289,7 @@ mod tests {
     /// Removing a non-empty list of filesystems should succeed on empty pool
     fn destroy_fs_some() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
+        let uuid = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
         assert!(pool.destroy_filesystems(&[Uuid::new_v4()]).is_ok());
     }
@@ -277,7 +298,7 @@ mod tests {
     /// Removing a non-empty list of filesystems should succeed on any pool
     fn destroy_fs_any() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine.create_pool("name", &[], None, false).unwrap();
+        let uuid = engine.create_pool("name", &[], None, false).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
         let fs_results = pool.create_filesystems(&[("fs_name", None)]).unwrap();
         let fs_uuid = fs_results[0].1;
@@ -291,7 +312,7 @@ mod tests {
     /// Creating an empty list of filesystems should succeed, always
     fn create_fs_none() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine
+        let uuid = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
@@ -305,7 +326,7 @@ mod tests {
     /// Creating a non-empty list of filesystems always succeeds.
     fn create_fs_some() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine
+        let uuid = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
@@ -320,7 +341,7 @@ mod tests {
     fn create_fs_conflict() {
         let fs_name = "fs_name";
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine
+        let uuid = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
@@ -336,7 +357,7 @@ mod tests {
     fn create_fs_dups() {
         let fs_name = "fs_name";
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine
+        let uuid = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();
@@ -350,7 +371,7 @@ mod tests {
     /// Adding a list of devices to an empty pool should yield list.
     fn add_device_empty() {
         let mut engine = SimEngine::default();
-        let (uuid, _) = engine
+        let uuid = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap();

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -26,8 +26,8 @@ pub struct StratBlockDev {
     pub devnode: PathBuf,
     bda: BDA,
     used: RangeAllocator,
-    location: Option<String>,
-    disk_id: Option<String>,
+    user_info: Option<String>,
+    hardware_info: Option<String>,
 }
 
 impl StratBlockDev {
@@ -35,16 +35,16 @@ impl StratBlockDev {
                devnode: PathBuf,
                bda: BDA,
                allocator: RangeAllocator,
-               location: Option<String>,
-               disk_id: Option<String>)
+               user_info: Option<String>,
+               hardware_info: Option<String>)
                -> StratBlockDev {
         StratBlockDev {
             dev: dev,
             devnode: devnode,
             bda: bda,
             used: allocator,
-            location: location,
-            disk_id: disk_id,
+            user_info: user_info,
+            hardware_info: hardware_info,
         }
     }
 
@@ -136,17 +136,17 @@ impl BlockDev for StratBlockDev {
         self.devnode.clone()
     }
 
-    fn user_id(&self) -> &Option<String> {
-        &self.location
+    fn user_info(&self) -> Option<&str> {
+        self.user_info.as_ref().map(|x| &**x)
     }
 
-    fn set_user_id(&mut self, location: Option<&str>) -> EngineResult<()> {
-        self.location = location.map(|x| x.to_owned());
+    fn set_user_info(&mut self, user_info: Option<&str>) -> EngineResult<()> {
+        self.user_info = user_info.map(|x| x.to_owned());
         Ok(())
     }
 
-    fn hardware_id(&self) -> &Option<String> {
-        &self.disk_id
+    fn hardware_info(&self) -> Option<&str> {
+        self.hardware_info.as_ref().map(|x| &**x)
     }
 
     fn initialization_time(&self) -> DateTime<Utc> {
@@ -167,8 +167,8 @@ impl Recordable<BlockDevSave> for StratBlockDev {
     fn record(&self) -> BlockDevSave {
         BlockDevSave {
             dev: Some(self.devnode.clone()),
-            location: self.location.clone(),
-            disk_id: self.disk_id.clone(),
+            user_info: self.user_info.clone(),
+            hardware_info: self.hardware_info.clone(),
         }
     }
 }

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -140,8 +140,13 @@ impl BlockDev for StratBlockDev {
         self.user_info.as_ref().map(|x| &**x)
     }
 
-    fn set_user_info(&mut self, user_info: Option<&str>) -> () {
-        self.user_info = user_info.map(|x| x.to_owned());
+    fn set_user_info(&mut self, user_info: Option<&str>) -> bool {
+        if self.user_info.as_ref().map(|x| &**x) != user_info {
+            self.user_info = user_info.map(|x| x.to_owned());
+            true
+        } else {
+            false
+        }
     }
 
     fn hardware_info(&self) -> Option<&str> {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -140,9 +140,8 @@ impl BlockDev for StratBlockDev {
         self.user_info.as_ref().map(|x| &**x)
     }
 
-    fn set_user_info(&mut self, user_info: Option<&str>) -> EngineResult<()> {
+    fn set_user_info(&mut self, user_info: Option<&str>) -> () {
         self.user_info = user_info.map(|x| x.to_owned());
-        Ok(())
     }
 
     fn hardware_info(&self) -> Option<&str> {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -167,7 +167,7 @@ impl BlockDev for StratBlockDev {
 impl Recordable<BlockDevSave> for StratBlockDev {
     fn record(&self) -> BlockDevSave {
         BlockDevSave {
-            dev: Some(self.devnode.clone()),
+            devnode: Some(self.devnode.clone()),
             user_info: self.user_info.clone(),
             hardware_info: self.hardware_info.clone(),
         }

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -154,7 +154,7 @@ impl BlockDev for StratBlockDev {
     }
 
     fn total_size(&self) -> Sectors {
-        self.current_capacity()
+        self.avail_range().1
     }
 
     fn state(&self) -> BlockDevState {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -141,12 +141,7 @@ impl BlockDev for StratBlockDev {
     }
 
     fn set_user_info(&mut self, user_info: Option<&str>) -> bool {
-        if self.user_info.as_ref().map(|x| &**x) != user_info {
-            self.user_info = user_info.map(|x| x.to_owned());
-            true
-        } else {
-            false
-        }
+        set_blockdev_user_info!(self; user_info)
     }
 
     fn hardware_info(&self) -> Option<&str> {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -149,6 +149,8 @@ impl BlockDev for StratBlockDev {
     }
 
     fn initialization_time(&self) -> DateTime<Utc> {
+        // This cast will result in an incorrect, negative value starting in
+        // the year 292,277,026,596. :-)
         Utc.timestamp(self.bda.initialization_time() as i64, 0)
     }
 

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -26,8 +26,8 @@ pub struct StratBlockDev {
     pub devnode: PathBuf,
     bda: BDA,
     used: RangeAllocator,
-    pub location: Option<String>,
-    pub disk_id: Option<String>,
+    location: Option<String>,
+    disk_id: Option<String>,
 }
 
 impl StratBlockDev {
@@ -123,11 +123,6 @@ impl StratBlockDev {
     pub fn max_metadata_size(&self) -> Sectors {
         self.bda.max_data_size()
     }
-
-    /// Timestamp when the device was initialized.
-    pub fn initialization_time(&self) -> u64 {
-        self.bda.initialization_time()
-    }
 }
 
 impl HasUuid for StratBlockDev {
@@ -154,16 +149,16 @@ impl BlockDev for StratBlockDev {
         &self.disk_id
     }
 
-    fn initialization_time(&self) -> String {
-        Utc.timestamp(self.initialization_time() as i64, 0)
-            .to_rfc3339()
+    fn initialization_time(&self) -> DateTime<Utc> {
+        Utc.timestamp(self.bda.initialization_time() as i64, 0)
     }
 
     fn total_size(&self) -> Sectors {
-        self.bda.dev_size()
+        self.current_capacity()
     }
 
     fn state(&self) -> BlockDevState {
+        // TODO: Implement states for blockdevs
         BlockDevState::InUse
     }
 }

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -76,7 +76,7 @@ impl BlockDevMgr {
             pool_uuid: pool_uuid,
             block_devs: block_devs
                 .into_iter()
-                .map(|bd| (bd.uuid().clone(), bd))
+                .map(|bd| (bd.uuid(), bd))
                 .collect(),
             last_update_time: None,
         }

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -217,13 +217,13 @@ impl BlockDevMgr {
             .collect()
     }
 
-    pub fn get_blockdev_by_uuid(&self, uuid: &DevUuid) -> Option<&BlockDev> {
-        self.block_devs.get(uuid).map(|bd| bd as &BlockDev)
+    pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<&BlockDev> {
+        self.block_devs.get(&uuid).map(|bd| bd as &BlockDev)
     }
 
-    pub fn get_mut_blockdev_by_uuid(&mut self, uuid: &DevUuid) -> Option<&mut BlockDev> {
+    pub fn get_mut_blockdev_by_uuid(&mut self, uuid: DevUuid) -> Option<&mut BlockDev> {
         self.block_devs
-            .get_mut(uuid)
+            .get_mut(&uuid)
             .map(|bd| bd as &mut BlockDev)
     }
 

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -66,7 +66,7 @@ pub fn map_to_dm(bsegs: &[BlkDevSegment]) -> Vec<Segment> {
 #[derive(Debug)]
 pub struct BlockDevMgr {
     pool_uuid: PoolUuid,
-    block_devs: Vec<StratBlockDev>,
+    block_devs: HashMap<DevUuid, StratBlockDev>,
     last_update_time: Option<DateTime<Utc>>,
 }
 
@@ -74,7 +74,10 @@ impl BlockDevMgr {
     pub fn new(pool_uuid: PoolUuid, block_devs: Vec<StratBlockDev>) -> BlockDevMgr {
         BlockDevMgr {
             pool_uuid: pool_uuid,
-            block_devs: block_devs,
+            block_devs: block_devs
+                .into_iter()
+                .map(|bd| (bd.uuid().clone(), bd))
+                .collect(),
             last_update_time: None,
         }
     }
@@ -93,22 +96,27 @@ impl BlockDevMgr {
     pub fn uuid_to_devno(&self) -> Box<Fn(DevUuid) -> Option<Device>> {
         let uuid_map: HashMap<DevUuid, Device> = self.block_devs
             .iter()
-            .map(|bd| (bd.uuid(), *bd.device()))
+            .map(|(_, bd)| (bd.uuid(), *bd.device()))
             .collect();
 
         Box::new(move |uuid: DevUuid| -> Option<Device> { uuid_map.get(&uuid).cloned() })
     }
 
-    pub fn add(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<PathBuf>> {
+    pub fn add(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<DevUuid>> {
         let devices = resolve_devices(paths)?;
         let bds = initialize(self.pool_uuid, devices, MIN_MDA_SECTORS, force)?;
-        let bdev_paths = bds.iter().map(|p| p.devnode.clone()).collect();
-        self.block_devs.extend(bds);
-        Ok(bdev_paths)
+        let bdev_uuids = bds.iter().map(|bd| bd.uuid()).collect();
+        self.block_devs
+            .extend(bds.into_iter().map(|bd| (bd.uuid(), bd)));
+        Ok(bdev_uuids)
     }
 
-    pub fn destroy_all(self) -> EngineResult<()> {
-        wipe_blockdevs(&self.block_devs)
+    pub fn destroy_all(mut self) -> EngineResult<()> {
+        let bds = self.block_devs
+            .drain()
+            .map(|(_, bd)| bd)
+            .collect::<Vec<_>>();
+        wipe_blockdevs(&bds)
     }
 
     /// Allocate space according to sizes vector request.
@@ -133,7 +141,7 @@ impl BlockDevMgr {
             // In the context of this major inefficiency that ensues over time
             // the obvious but more minor inefficiency of this inner loop is
             // not worth worrying about.
-            for bd in &mut self.block_devs {
+            for bd in self.block_devs.values_mut() {
                 if alloc == needed {
                     break;
                 }
@@ -157,7 +165,7 @@ impl BlockDevMgr {
 
     pub fn devnodes(&self) -> Vec<PathBuf> {
         self.block_devs
-            .iter()
+            .values()
             .map(|d| d.devnode.clone())
             .collect()
     }
@@ -182,7 +190,7 @@ impl BlockDevMgr {
 
         let data_size = Bytes(metadata.len() as u64).sectors();
         let candidates = self.block_devs
-            .iter_mut()
+            .values_mut()
             .filter(|b| b.max_metadata_size() >= data_size);
 
         // TODO: consider making selection not entirely random, i.e, ensuring
@@ -204,16 +212,26 @@ impl BlockDevMgr {
     /// Get references to managed blockdevs.
     pub fn blockdevs(&self) -> Vec<&BlockDev> {
         self.block_devs
-            .iter()
+            .values()
             .map(|bd| bd as &BlockDev)
             .collect()
+    }
+
+    pub fn get_blockdev_by_uuid(&self, uuid: &DevUuid) -> Option<&BlockDev> {
+        self.block_devs.get(uuid).map(|bd| bd as &BlockDev)
+    }
+
+    pub fn get_mut_blockdev_by_uuid(&mut self, uuid: &DevUuid) -> Option<&mut BlockDev> {
+        self.block_devs
+            .get_mut(uuid)
+            .map(|bd| bd as &mut BlockDev)
     }
 
     // SIZE methods
 
     /// The number of sectors not allocated for any purpose.
     pub fn avail_space(&self) -> Sectors {
-        self.block_devs.iter().map(|bd| bd.available()).sum()
+        self.block_devs.values().map(|bd| bd.available()).sum()
     }
 
     /// The current capacity of all the blockdevs.
@@ -221,7 +239,7 @@ impl BlockDevMgr {
     /// are certainly allocated for Stratis metadata
     pub fn current_capacity(&self) -> Sectors {
         self.block_devs
-            .iter()
+            .values()
             .map(|b| b.current_capacity())
             .sum()
     }
@@ -230,7 +248,7 @@ impl BlockDevMgr {
     /// self.current_capacity() - self.metadata_size() >= self.avail_space()
     pub fn metadata_size(&self) -> Sectors {
         self.block_devs
-            .iter()
+            .values()
             .map(|bd| bd.metadata_size())
             .sum()
     }
@@ -240,7 +258,7 @@ impl Recordable<HashMap<DevUuid, BlockDevSave>> for BlockDevMgr {
     fn record(&self) -> HashMap<Uuid, BlockDevSave> {
         self.block_devs
             .iter()
-            .map(|bd| (bd.uuid(), bd.record()))
+            .map(|(uuid, bd)| (*uuid, bd.record()))
             .collect()
     }
 }
@@ -336,7 +354,7 @@ pub fn initialize(pool_uuid: PoolUuid,
             let allocator = RangeAllocator::new(bda.dev_size(), &[(Sectors(0), bda.size())])
                 .expect("bda.size() < bda.dev_size() and single range");
 
-            bds.push(StratBlockDev::new(dev, devnode.to_owned(), bda, allocator));
+            bds.push(StratBlockDev::new(dev, devnode.to_owned(), bda, allocator, None, None));
         } else {
             // TODO: check the return values and update state machine on failure
             let _ = BDA::wipe(&mut f);

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -354,6 +354,7 @@ pub fn initialize(pool_uuid: PoolUuid,
             let allocator = RangeAllocator::new(bda.dev_size(), &[(Sectors(0), bda.size())])
                 .expect("bda.size() < bda.dev_size() and single range");
 
+            // TODO: support getting hw info and passing in here. See #615
             bds.push(StratBlockDev::new(dev, devnode.to_owned(), bda, allocator, None, None));
         } else {
             // TODO: check the return values and update state machine on failure

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -96,7 +96,7 @@ impl BlockDevMgr {
     pub fn uuid_to_devno(&self) -> Box<Fn(DevUuid) -> Option<Device>> {
         let uuid_map: HashMap<DevUuid, Device> = self.block_devs
             .iter()
-            .map(|(_, bd)| (bd.uuid(), *bd.device()))
+            .map(|(uuid, bd)| (*uuid, *bd.device()))
             .collect();
 
         Box::new(move |uuid: DevUuid| -> Option<Device> { uuid_map.get(&uuid).cloned() })

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::path::Path;
-use std::path::PathBuf;
 
 use uuid::Uuid;
 
@@ -77,7 +76,7 @@ impl Engine for StratEngine {
                    blockdev_paths: &[&Path],
                    redundancy: Option<u16>,
                    force: bool)
-                   -> EngineResult<(PoolUuid, Vec<PathBuf>)> {
+                   -> EngineResult<PoolUuid> {
 
         let redundancy = calculate_redundancy!(redundancy);
 
@@ -86,11 +85,11 @@ impl Engine for StratEngine {
         }
 
         let dm = DM::new()?;
-        let (pool, devnodes) = StratPool::initialize(name, &dm, blockdev_paths, redundancy, force)?;
+        let pool = StratPool::initialize(name, &dm, blockdev_paths, redundancy, force)?;
 
         let uuid = pool.uuid();
         self.pools.insert(pool);
-        Ok((uuid, devnodes))
+        Ok(uuid)
     }
 
     fn destroy_pool(&mut self, uuid: PoolUuid) -> EngineResult<bool> {

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -152,6 +152,11 @@ impl BDA {
     pub fn max_data_size(&self) -> Sectors {
         self.regions.max_data_size()
     }
+
+    /// Timestamp when the device was initialized.
+    pub fn initialization_time(&self) -> u64 {
+        self.header.initialization_time
+    }
 }
 
 #[derive(Debug)]

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -228,11 +228,11 @@ impl Pool for StratPool {
         self.block_devs.blockdevs()
     }
 
-    fn get_blockdev(&self, uuid: &DevUuid) -> Option<&BlockDev> {
+    fn get_blockdev(&self, uuid: DevUuid) -> Option<&BlockDev> {
         self.block_devs.get_blockdev_by_uuid(uuid)
     }
 
-    fn get_mut_blockdev(&mut self, uuid: &DevUuid) -> Option<&mut BlockDev> {
+    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<&mut BlockDev> {
         self.block_devs.get_mut_blockdev_by_uuid(uuid)
     }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -15,7 +15,7 @@ use devicemapper::{Device, DM, Sectors, ThinPoolDev};
 
 use super::super::engine::{Filesystem, BlockDev, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::types::{FilesystemUuid, PoolUuid, RenameAction, Redundancy};
+use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, RenameAction, Redundancy};
 
 use super::blockdevmgr::BlockDevMgr;
 use super::filesystem::StratFilesystem;
@@ -44,7 +44,7 @@ impl StratPool {
                       paths: &[&Path],
                       redundancy: Redundancy,
                       force: bool)
-                      -> EngineResult<(StratPool, Vec<PathBuf>)> {
+                      -> EngineResult<StratPool> {
         let pool_uuid = Uuid::new_v4();
 
         let mut block_mgr = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, force)?;
@@ -58,8 +58,6 @@ impl StratPool {
             }
         };
 
-        let devnodes = block_mgr.devnodes();
-
         let mut pool = StratPool {
             name: name.to_owned(),
             pool_uuid: pool_uuid,
@@ -70,7 +68,7 @@ impl StratPool {
 
         pool.write_metadata()?;
 
-        Ok((pool, devnodes))
+        Ok(pool)
     }
 
     /// Setup a StratPool using its UUID and the list of devnodes it has.
@@ -163,10 +161,10 @@ impl Pool for StratPool {
         Ok(result)
     }
 
-    fn add_blockdevs(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<PathBuf>> {
-        let bdev_paths = self.block_devs.add(paths, force)?;
+    fn add_blockdevs(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<DevUuid>> {
+        let bdev_info = self.block_devs.add(paths, force)?;
         self.write_metadata()?;
-        Ok(bdev_paths)
+        Ok(bdev_info)
     }
 
     fn destroy(self) -> EngineResult<()> {
@@ -200,18 +198,6 @@ impl Pool for StratPool {
         self.name = name.to_owned();
     }
 
-    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem> {
-        self.thin_pool
-            .get_filesystem_by_uuid(uuid)
-            .map(|fs| fs as &Filesystem)
-    }
-
-    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<&mut Filesystem> {
-        self.thin_pool
-            .get_mut_filesystem_by_uuid(uuid)
-            .map(|fs| fs as &mut Filesystem)
-    }
-
     fn total_physical_size(&self) -> Sectors {
         self.block_devs.current_capacity()
     }
@@ -226,8 +212,32 @@ impl Pool for StratPool {
         self.thin_pool.filesystems()
     }
 
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem> {
+        self.thin_pool
+            .get_filesystem_by_uuid(uuid)
+            .map(|fs| fs as &Filesystem)
+    }
+
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<&mut Filesystem> {
+        self.thin_pool
+            .get_mut_filesystem_by_uuid(uuid)
+            .map(|fs| fs as &mut Filesystem)
+    }
+
     fn blockdevs(&self) -> Vec<&BlockDev> {
         self.block_devs.blockdevs()
+    }
+
+    fn get_blockdev(&self, uuid: &DevUuid) -> Option<&BlockDev> {
+        self.block_devs.get_blockdev_by_uuid(uuid)
+    }
+
+    fn get_mut_blockdev(&mut self, uuid: &DevUuid) -> Option<&mut BlockDev> {
+        self.block_devs.get_mut_blockdev_by_uuid(uuid)
+    }
+
+    fn save_state(&mut self) -> EngineResult<()> {
+        self.write_metadata()
     }
 }
 

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -40,7 +40,7 @@ pub struct PoolSave {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockDevSave {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dev: Option<PathBuf>,
+    pub devnode: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_info: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -42,9 +42,9 @@ pub struct BlockDevSave {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub location: Option<String>,
+    pub user_info: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub disk_id: Option<String>,
+    pub hardware_info: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -39,7 +39,12 @@ pub struct PoolSave {
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockDevSave {
-    pub devnode: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dev: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_id: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -200,7 +200,18 @@ pub fn get_blockdevs(pool_uuid: PoolUuid,
                     RangeAllocator::new(actual_size,
                                         segment_table.get(&bda.dev_uuid()).unwrap_or(&vec![]))?;
 
-                blockdevs.push(StratBlockDev::new(*device, devnode.to_owned(), bda, allocator));
+                let (location, disk_id) = pool_save
+                    .block_devs
+                    .get(&bda.dev_uuid())
+                    .map(|bd_save| (bd_save.location.clone(), bd_save.disk_id.clone()))
+                    .unwrap_or((None, None));
+
+                blockdevs.push(StratBlockDev::new(*device,
+                                                  devnode.to_owned(),
+                                                  bda,
+                                                  allocator,
+                                                  location,
+                                                  disk_id));
             }
         }
     }

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -206,7 +206,7 @@ pub fn get_blockdevs(pool_uuid: PoolUuid,
                     .ok_or_else(|| {
                                     let err_msg = format!("Blockdev {} not found in metadata",
                                                           bda.dev_uuid());
-                                    EngineError::Engine(ErrorEnum::NotFound, err_msg.into())
+                                    EngineError::Engine(ErrorEnum::NotFound, err_msg)
                                 })?;
 
                 blockdevs.push(StratBlockDev::new(*device,

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -203,7 +203,7 @@ pub fn get_blockdevs(pool_uuid: PoolUuid,
                 let (location, disk_id) = pool_save
                     .block_devs
                     .get(&bda.dev_uuid())
-                    .map(|bd_save| (bd_save.location.clone(), bd_save.disk_id.clone()))
+                    .map(|bd_save| (bd_save.user_info.clone(), bd_save.hardware_info.clone()))
                     .unwrap_or((None, None));
 
                 blockdevs.push(StratBlockDev::new(*device,

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -15,6 +15,7 @@ pub enum RenameAction {
     Renamed,
 }
 
+/// See Design Doc section 10.2.1 for more details.
 #[derive(Debug, PartialEq, Eq)]
 pub enum BlockDevState {
     Missing,

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -15,6 +15,15 @@ pub enum RenameAction {
     Renamed,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum BlockDevState {
+    Missing,
+    Bad,
+    Spare,
+    NotInUse,
+    InUse,
+}
+
 /// Redundancy classifications which the engine allows for pools.
 custom_derive! {
     #[derive(Debug, Eq, PartialEq, EnumDisplay,

--- a/tests/util/filesystem_tests.rs
+++ b/tests/util/filesystem_tests.rs
@@ -36,8 +36,8 @@ pub fn test_xfs_expand(paths: &[&Path]) -> () {
     // the low water mark.
     let fs_size = FILESYSTEM_LOWATER + Bytes(IEC::Mi).sectors();
 
-    let (mut pool, _) =
-        StratPool::initialize("stratis_test_pool", &dm, paths, Redundancy::NONE, true).unwrap();
+    let mut pool = StratPool::initialize("stratis_test_pool", &dm, paths, Redundancy::NONE, true)
+        .unwrap();
     let &(_, fs_uuid) = pool.create_filesystems(&[("stratis_test_filesystem", Some(fs_size))])
         .unwrap()
         .first()

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -32,11 +32,11 @@ use libstratis::engine::types::{Redundancy, RenameAction};
 /// INITIAL_DATA_SIZE.  If we are able to write more sectors to the filesystem
 /// than are initially allocated to the pool, the pool must have been expanded.
 pub fn test_thinpool_expand(paths: &[&Path]) -> () {
-    let (mut pool, _) = StratPool::initialize("stratis_test_pool",
-                                              &DM::new().unwrap(),
-                                              paths,
-                                              Redundancy::NONE,
-                                              true)
+    let mut pool = StratPool::initialize("stratis_test_pool",
+                                         &DM::new().unwrap(),
+                                         paths,
+                                         Redundancy::NONE,
+                                         true)
             .unwrap();
 
     let &(_, fs_uuid) = pool.create_filesystems(&[("stratis_test_filesystem", None)])
@@ -147,7 +147,7 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
 
     let name1 = "name1";
     let name2 = "name2";
-    let (uuid1, _) = engine.create_pool(&name1, paths, None, false).unwrap();
+    let uuid1 = engine.create_pool(&name1, paths, None, false).unwrap();
     let fs_uuid = {
         let pool = engine.get_mut_pool(uuid1).unwrap();
         let &(fs_name, fs_uuid) = pool.create_filesystems(&[(name1, None)])
@@ -180,11 +180,11 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
 /// from the thinpool, by attempting to reinstantiate it using the
 /// same thin id and verifying that it fails.
 pub fn test_thinpool_thindev_destroy(paths: &[&Path]) -> () {
-    let (mut pool, _) = StratPool::initialize("stratis_test_pool",
-                                              &DM::new().unwrap(),
-                                              paths,
-                                              Redundancy::NONE,
-                                              true)
+    let mut pool = StratPool::initialize("stratis_test_pool",
+                                         &DM::new().unwrap(),
+                                         paths,
+                                         Redundancy::NONE,
+                                         true)
             .unwrap();
     let &(_, fs_uuid) = pool.create_filesystems(&[("stratis_test_filesystem", None)])
         .unwrap()

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -69,8 +69,8 @@ pub fn test_thinpool_expand(paths: &[&Path]) -> () {
 /// Verify a snapshot has the same files and same contents as the origin.
 pub fn test_filesystem_snapshot(paths: &[&Path]) {
     let dm = DM::new().unwrap();
-    let (mut pool, _) =
-        StratPool::initialize("stratis_test_pool", &dm, paths, Redundancy::NONE, true).unwrap();
+    let mut pool = StratPool::initialize("stratis_test_pool", &dm, paths, Redundancy::NONE, true)
+        .unwrap();
     let &(_, fs_uuid) = pool.create_filesystems(&[("stratis_test_filesystem", None)])
         .unwrap()
         .first()

--- a/tests/util/setup_tests.rs
+++ b/tests/util/setup_tests.rs
@@ -94,11 +94,11 @@ pub fn test_basic_metadata(paths: &[&Path]) {
     let mut engine = StratEngine::initialize().unwrap();
 
     let name1 = "name1";
-    let (uuid1, _) = engine.create_pool(&name1, paths1, None, false).unwrap();
+    let uuid1 = engine.create_pool(&name1, paths1, None, false).unwrap();
     let metadata1 = engine.get_strat_pool(uuid1).unwrap().record();
 
     let name2 = "name2";
-    let (uuid2, _) = engine.create_pool(&name2, paths2, None, false).unwrap();
+    let uuid2 = engine.create_pool(&name2, paths2, None, false).unwrap();
     let metadata2 = engine.get_strat_pool(uuid2).unwrap().record();
 
     let pools = find_all().unwrap();
@@ -144,10 +144,10 @@ pub fn test_setup(paths: &[&Path]) {
     let mut engine = StratEngine::initialize().unwrap();
 
     let name1 = "name1";
-    let (uuid1, _) = engine.create_pool(&name1, paths1, None, false).unwrap();
+    let uuid1 = engine.create_pool(&name1, paths1, None, false).unwrap();
 
     let name2 = "name2";
-    let (uuid2, _) = engine.create_pool(&name2, paths2, None, false).unwrap();
+    let uuid2 = engine.create_pool(&name2, paths2, None, false).unwrap();
 
     assert!(engine.get_pool(uuid1).is_some());
     assert!(engine.get_pool(uuid2).is_some());
@@ -167,7 +167,7 @@ pub fn test_pool_rename(paths: &[&Path]) {
     let mut engine = StratEngine::initialize().unwrap();
 
     let name1 = "name1";
-    let (uuid1, _) = engine.create_pool(&name1, paths, None, false).unwrap();
+    let uuid1 = engine.create_pool(&name1, paths, None, false).unwrap();
 
     let name2 = "name2";
     let action = engine.rename_pool(uuid1, name2).unwrap();
@@ -187,7 +187,7 @@ pub fn test_pool_rename(paths: &[&Path]) {
 pub fn test_pool_setup(paths: &[&Path]) {
     let dm = DM::new().unwrap();
 
-    let (mut pool, _) = StratPool::initialize("name", &dm, paths, Redundancy::NONE, false).unwrap();
+    let mut pool = StratPool::initialize("name", &dm, paths, Redundancy::NONE, false).unwrap();
 
     let (_, fs_uuid) = pool.create_filesystems(&[("fsname", None)]).unwrap()[0];
 


### PR DESCRIPTION
Big one here. Hard to test since I think API changes will break cli?

Trait changes:
* Blockdev: Implement needed accessor methods
* Pool: Add methods to get a blockdev based on uuid to Pool trait
* Pool: Add save_state() since BlockDev::set_user_id() can't do this
        itself, DBus code has to.
* Pool: Change add_blockdevs() to return dev UUID instead of paths, since
        paths can be obtained by getting the blockdev from the pool and
        then calling devnode().
* Engine: Change create_pool() to just return pool UUID, same reason.

sim/strat blockdev implementation:
* Change blockdev collections from Vec to HashMap to make lookups by
  uuid more natural.
* sim: Add fields as needed to SimDev
* strat: Add fields as needed to StratBlockDev and BlockDevSave
* strat: Get location and disk_id for each blockdev from saved state, if
         available, in get_blockdevs().

D-Bus:
* Make return signature changes to CreatePool and AddDevs: object paths
  instead of devnodes.
* Create blockdev dbus objects.

general:
* Add BlockDevState enum
* Update tests for changes