### PR TITLE
Run tests inside a docker Fedora container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,20 @@
-os: linux
-group: edge
-
-addons:
-    apt:
-        packages:
-            libdbus-1-dev
-
+sudo: required
 language: rust
+env:
+    matrix:
+        - OS_TYPE=fedora
 
-matrix:
-    include:
-        - rust: stable
-          env: TASK=fmt
-        - rust: stable
-          env: TASK=build
-        - rust: stable
-          env: TASK=docs
-        - rust: stable
-          env: TASK=test
-        - rust: stable
-          sudo: required
-          env: TASK=test-loop
-        - rust: nightly
-          env: TASK=clippy
+services:
+    - docker
+
+before_install:
+    - docker pull $OS_TYPE
 
 branches:
     only: master
 
-script: make -f Makefile $TASK
+script:
+     - travis_wait 30
+         docker run --privileged --rm=true --tty=true
+         -v /dev:/dev:rw -v `pwd`:/stratisd-code:rw $OS_TYPE
+         /bin/bash -c /stratisd-code/tests/docker_travis_test.sh 

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -37,16 +37,21 @@ pub fn find_all() -> EngineResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> {
         let dir_e = dir_e?;
         let devnode = dir_e.path();
 
-        let devno = match devnode_to_devno(&devnode)? {
-            None => continue,
-            Some(devno) => {
-                // If this device has already been processed, continue.
-                if devno_set.insert(devno) {
-                    devno
-                } else {
-                    continue;
+        let devno = match devnode_to_devno(&devnode) {
+            Ok(result) => {
+                match result {
+                    None => continue,
+                    Some(devno) => {
+                        // If this device has already been processed, continue.
+                        if devno_set.insert(devno) {
+                            devno
+                        } else {
+                            continue;
+                        }
+                    }
                 }
             }
+            Err(_) => continue,
         };
 
         let f = OpenOptions::new().read(true).open(&devnode);

--- a/tests/docker_travis_test.sh
+++ b/tests/docker_travis_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-toolchain=stable -y || exit 1
+curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-toolchain=nightly -y || exit 1
+
+dnf -y install gcc dbus-devel make xfsprogs sudo || exit 1
+
+source ~/.cargo/env || exit 1
+rustup default stable || exit 1
+
+cd /stratisd-code || exit 1
+
+make fmt || exit 1
+make build || exit 1
+make docs || exit 1
+make test || exit 1
+make test-loop || exit 1
+# run clippy with nightly
+rustup default nightly
+make clippy || exit 1


### PR DESCRIPTION
Updated the .travis.yml to mount the Stratis code inside the container
then invoke the tests/docker_travis_test.sh script.

The script installs the required dependencies and invokes the tests via
the Makefile.

Signed-off-by: Todd Gill <tgill@redhat.com>