### PR TITLE
Give blockdevmgr the responsibility for allocating necessary data

### DIFF
--- a/tests/util/blockdev_tests.rs
+++ b/tests/util/blockdev_tests.rs
@@ -137,7 +137,7 @@ pub fn test_blockdevmgr_used(paths: &[&Path]) -> () {
                mgr.current_capacity());
 
     let allocated = Sectors(2);
-    mgr.alloc_space(allocated).unwrap();
+    mgr.alloc_space(&[allocated]).unwrap();
     assert_eq!(mgr.avail_space() + allocated + mgr.metadata_size(),
                mgr.current_capacity());
 }

--- a/tests/util/dm_tests.rs
+++ b/tests/util/dm_tests.rs
@@ -76,9 +76,12 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
 
     let dm = DM::new().unwrap();
 
-    let meta_segs = bd_mgr
-        .alloc_space(Bytes(16 * IEC::Mi).sectors())
+    let mut seg_list = bd_mgr
+        .alloc_space(&[Bytes(16 * IEC::Mi).sectors(), Bytes(IEC::Gi).sectors()])
         .unwrap();
+    let data_segs = seg_list.pop().expect("len(seg_list) == 2");
+    let meta_segs = seg_list.pop().expect("len(seg_list) == 1");
+
     let metadata_dev =
         LinearDev::setup(&dm,
                          DmName::new("stratis_testing_thinpool_metadata").expect("valid format"),
@@ -92,7 +95,6 @@ pub fn test_thinpool_device(paths: &[&Path]) -> () {
     // the same approach when constructing a thin pool.
     wipe_sectors(&metadata_dev.devnode(), Sectors(0), metadata_dev.size()).unwrap();
 
-    let data_segs = bd_mgr.alloc_space(Bytes(IEC::Gi).sectors()).unwrap();
     let data_dev =
         LinearDev::setup(&dm,
                          DmName::new("stratis_testing_thinpool_datadev").expect("valid format"),


### PR DESCRIPTION
In a complex situation, blockdevmgr may require more available space than
the sum of the space requested. It is better to have blockdevmgr do
all the checking of whether it can satisfy the request.

This also makes ThinPool::new() a bit simpler.

Signed-off-by: mulhern <amulhern@redhat.com>