### PR TITLE
 Update devnode_to_devno() to return None for NotFound errors

### DIFF
--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufWriter, Seek, Write, SeekFrom};
+use std::io::{BufWriter, ErrorKind, Seek, SeekFrom, Write};
 use std::fs::OpenOptions;
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::prelude::AsRawFd;
@@ -64,7 +64,12 @@ pub fn devnode_to_devno(path: &Path) -> EngineResult<Option<u64>> {
                    None
                })
         }
-        Err(err) => Err(err)?,
+        Err(err) => {
+            if err.kind() == ErrorKind::NotFound {
+                return Ok(None);
+            }
+            Err(err)?
+        }
     }
 }
 


### PR DESCRIPTION
 Update devnode_to_devno() to return None for NotFound errors

This error can happen if /dev/ has a sybolic link to a file that doesn't
exist or a file has gone away between reading the contents of /dev/ and
when we check the meta data.
