### PR TITLE
Have pool.check() return a Result

### DIFF
--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -91,7 +91,8 @@ macro_rules! rename_pool_pre {
 macro_rules! check_engine {
     ( $s:ident ) => {
         for pool in &mut $s.pools {
-            pool.check();
+            // FIXME: It is not really correct to ignore result of pool.check().
+            let _ = pool.check();
         }
     }
 }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -55,7 +55,9 @@ impl SimPool {
         }
     }
 
-    pub fn check(&mut self) -> () {}
+    pub fn check(&mut self) -> EngineResult<()> {
+        Ok(())
+    }
 
     pub fn has_filesystems(&self) -> bool {
         !self.filesystems.is_empty()

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -103,11 +103,10 @@ impl StratPool {
         self.block_devs.save_state(data.as_bytes())
     }
 
-    pub fn check(&mut self) -> () {
+    pub fn check(&mut self) -> EngineResult<()> {
         self.thin_pool
             // FIXME: It's wrong to invite a crash with an unwrap() here.
             .check(&DM::new().unwrap(), &mut self.block_devs)
-            .unwrap_or(error!("Thin pool check did not succeed"))
     }
 
     /// Teardown a pool.

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -52,7 +52,7 @@ pub fn test_thinpool_expand(paths: &[&Path]) -> () {
             // TODO: Actually handle DM events and possibly call extend() directly,
             // depending on the specificity of the events.
             if i == *(*(INITIAL_DATA_SIZE - DATA_LOWATER) * DATA_BLOCK_SIZE) {
-                pool.check();
+                pool.check().unwrap();
             }
         }
     }


### PR DESCRIPTION
Fixes a bug introduced in #537.