### PR TITLE
suspend running loopback tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
           env: TASK=docs
         - rust: stable
           env: TASK=test
-        - rust: stable
-          sudo: required
-          env: TASK=test-loop
         - rust: nightly
           env: TASK=clippy
 


### PR DESCRIPTION
Suspend the loopback tests until we either get access to newer xfsprogs
on the Travis VM or are able to run inside a container.

Stratis requires xfsprogs 4.2.0 or greater.  The -U <uuid> feature is
used to keep the Stratis UUID for the filesystem in sync with the UUID
used by XFS.

Signed-off-by: Todd Gill <tgill@redhat.com>