### PR TITLE
Remove use of UUID references where possible.

### DIFF
--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -113,10 +113,7 @@ fn destroy_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         }
     };
 
-    let msg = match dbus_context
-              .engine
-              .borrow_mut()
-              .destroy_pool(&pool_uuid) {
+    let msg = match dbus_context.engine.borrow_mut().destroy_pool(pool_uuid) {
         Ok(action) => {
             dbus_context
                 .actions
@@ -266,8 +263,8 @@ pub fn connect(engine: Rc<RefCell<Engine>>)
     // This should never panic as create_dbus_pool() and
     // create_dbus_filesystem() do not borrow the engine.
     for pool in local_engine.borrow().pools() {
-        let pool_path = create_dbus_pool(&dbus_context, object_path.clone(), *pool.uuid());
-        for fs_uuid in pool.filesystems().iter().map(|f| *f.uuid()) {
+        let pool_path = create_dbus_pool(&dbus_context, object_path.clone(), pool.uuid());
+        for fs_uuid in pool.filesystems().iter().map(|f| f.uuid()) {
             create_dbus_filesystem(&dbus_context, pool_path.clone(), fs_uuid);
         }
     }

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -102,12 +102,12 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let filesystem_data = get_data!(filesystem_path; default_return; return_message);
 
     let pool_path = get_parent!(m; filesystem_data; default_return; return_message);
-    let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
+    let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
 
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
-    let msg = match pool.rename_filesystem(&filesystem_data.uuid, new_name) {
+    let msg = match pool.rename_filesystem(filesystem_data.uuid, new_name) {
         Ok(RenameAction::NoSource) => {
             let error_message = format!("pool {} doesn't know about filesystem {}",
                                         pool_uuid,
@@ -171,12 +171,12 @@ fn get_filesystem_property<F>(i: &mut IterAppend,
     let engine = dbus_context.engine.borrow();
     let pool =
         engine
-            .get_pool(&pool_uuid)
+            .get_pool(pool_uuid)
             .ok_or_else(|| {
                             MethodErr::failed(&format!("no pool corresponding to uuid {}",
                                                        &pool_uuid))
                         })?;
-    let filesystem_uuid = &filesystem_data.uuid;
+    let filesystem_uuid = filesystem_data.uuid;
     let filesystem = pool.get_filesystem(filesystem_uuid)
         .ok_or_else(|| {
                         MethodErr::failed(&format!("no name for filesystem with uuid {}",

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -53,7 +53,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let pool_path = m.tree
         .get(object_path)
         .expect("implicit argument must be in tree");
-    let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
+    let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
 
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
@@ -108,7 +108,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let pool_path = m.tree
         .get(object_path)
         .expect("implicit argument must be in tree");
-    let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
+    let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
 
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
@@ -121,7 +121,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         }
     }
 
-    let result = pool.destroy_filesystems(&filesystem_map.keys().collect::<Vec<&Uuid>>());
+    let result = pool.destroy_filesystems(&filesystem_map.keys().cloned().collect::<Vec<Uuid>>());
     let msg = match result {
         Ok(ref uuids) => {
             for uuid in uuids {
@@ -164,7 +164,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let pool_path = m.tree
         .get(object_path)
         .expect("implicit argument must be in tree");
-    let pool_uuid = &get_data!(pool_path; default_return; return_message).uuid;
+    let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
 
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
@@ -212,7 +212,7 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let msg = match dbus_context
               .engine
               .borrow_mut()
-              .rename_pool(&pool_uuid, new_name) {
+              .rename_pool(pool_uuid, new_name) {
         Ok(RenameAction::NoSource) => {
             let error_message = format!("engine doesn't know about pool {}", &pool_uuid);
             let (rc, rs) = code_to_message_items(DbusErrorEnum::INTERNAL_ERROR, error_message);
@@ -259,7 +259,7 @@ fn get_pool_property<F>(i: &mut IterAppend,
     let engine = dbus_context.engine.borrow();
     let pool =
         engine
-            .get_pool(&pool_uuid)
+            .get_pool(pool_uuid)
             .ok_or_else(|| {
                             MethodErr::failed(&format!("no pool corresponding to uuid {}",
                                                        &pool_uuid))

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -13,7 +13,7 @@ use super::errors::EngineResult;
 use super::types::{FilesystemUuid, PoolUuid, RenameAction};
 
 pub trait HasUuid: Debug {
-    fn uuid(&self) -> &Uuid;
+    fn uuid(&self) -> Uuid;
 }
 
 pub trait HasName: Debug {
@@ -55,9 +55,9 @@ pub trait Pool: HasName + HasUuid {
     /// Returns a list of the filesystems found, and actually destroyed.
     /// This list will be a subset of the uuids passed in fs_uuids.
     /// Precondition: All filesystems given must be unmounted.
-    fn destroy_filesystems<'a, 'b>(&'a mut self,
-                                   fs_uuids: &[&'b FilesystemUuid])
-                                   -> EngineResult<Vec<&'b FilesystemUuid>>;
+    fn destroy_filesystems<'a>(&'a mut self,
+                               fs_uuids: &[FilesystemUuid])
+                               -> EngineResult<Vec<FilesystemUuid>>;
 
     /// Rename filesystem
     /// Rename pool with uuid to new_name.
@@ -65,7 +65,7 @@ pub trait Pool: HasName + HasUuid {
     /// new_name is already in use.
     /// The result indicate whether an action was performed, and if not, why.
     fn rename_filesystem(&mut self,
-                         uuid: &FilesystemUuid,
+                         uuid: FilesystemUuid,
                          new_name: &str)
                          -> EngineResult<RenameAction>;
 
@@ -73,10 +73,10 @@ pub trait Pool: HasName + HasUuid {
     fn rename(&mut self, name: &str) -> ();
 
     /// Get the filesystem in this pool with this UUID.
-    fn get_filesystem(&self, uuid: &FilesystemUuid) -> Option<&Filesystem>;
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem>;
 
     /// Get the mutable filesystem in this pool with this UUID.
-    fn get_mut_filesystem(&mut self, uuid: &FilesystemUuid) -> Option<&mut Filesystem>;
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<&mut Filesystem>;
 
     /// The total number of Sectors belonging to this pool.
     /// There are no exclusions, so this number includes overhead sectors
@@ -114,19 +114,19 @@ pub trait Engine: Debug {
     /// Destroy a pool.
     /// Ensures that the pool of the given UUID is absent on completion.
     /// Returns true if some action was necessary, otherwise false.
-    fn destroy_pool(&mut self, uuid: &PoolUuid) -> EngineResult<bool>;
+    fn destroy_pool(&mut self, uuid: PoolUuid) -> EngineResult<bool>;
 
     /// Rename pool with uuid to new_name.
     /// Raises an error if the mapping can't be applied because
     /// new_name is already in use.
     /// Returns true if it was necessary to perform an action, false if not.
-    fn rename_pool(&mut self, uuid: &PoolUuid, new_name: &str) -> EngineResult<RenameAction>;
+    fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> EngineResult<RenameAction>;
 
     /// Find the pool designated by uuid.
-    fn get_pool(&self, uuid: &PoolUuid) -> Option<&Pool>;
+    fn get_pool(&self, uuid: PoolUuid) -> Option<&Pool>;
 
     /// Get a mutable referent to the pool designated by uuid.
-    fn get_mut_pool(&mut self, uuid: &PoolUuid) -> Option<&mut Pool>;
+    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<&mut Pool>;
 
     /// Configure the simulator, for the real engine, this is a null op.
     /// denominator: the probably of failure is 1/denominator.

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -29,8 +29,8 @@ impl BlockDev for SimDev {
 }
 
 impl HasUuid for SimDev {
-    fn uuid(&self) -> &DevUuid {
-        &self.uuid
+    fn uuid(&self) -> DevUuid {
+        self.uuid
     }
 }
 

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -40,7 +40,7 @@ impl HasName for SimFilesystem {
 }
 
 impl HasUuid for SimFilesystem {
-    fn uuid(&self) -> &FilesystemUuid {
-        &self.fs_id
+    fn uuid(&self) -> FilesystemUuid {
+        self.fs_id
     }
 }

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -69,12 +69,12 @@ impl StratBlockDev {
     }
 
     /// The device's UUID.
-    pub fn uuid(&self) -> &DevUuid {
+    pub fn uuid(&self) -> DevUuid {
         self.bda.dev_uuid()
     }
 
     /// The device's pool's UUID.
-    pub fn pool_uuid(&self) -> &PoolUuid {
+    pub fn pool_uuid(&self) -> PoolUuid {
         self.bda.pool_uuid()
     }
 
@@ -120,7 +120,7 @@ impl StratBlockDev {
 }
 
 impl HasUuid for StratBlockDev {
-    fn uuid(&self) -> &DevUuid {
+    fn uuid(&self) -> DevUuid {
         self.bda.dev_uuid()
     }
 }

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -35,7 +35,7 @@ pub fn wipe_blockdevs(blockdevs: &[StratBlockDev]) -> EngineResult<()> {
 pub fn teardown_pools(pools: Vec<StratPool>) -> EngineResult<()> {
     let mut untorndown_pools = Vec::new();
     for pool in pools {
-        let pool_uuid = *pool.uuid();
+        let pool_uuid = pool.uuid();
         pool.teardown()
             .unwrap_or_else(|_| untorndown_pools.push(pool_uuid));
     }

--- a/src/engine/strat_engine/dmdevice.rs
+++ b/src/engine/strat_engine/dmdevice.rs
@@ -73,7 +73,7 @@ pub fn format_flex_name(pool_uuid: &PoolUuid, role: FlexRole) -> DmNameBuf {
 
 /// Format a name for the thin layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 50
-pub fn format_thin_name(pool_uuid: &PoolUuid, role: ThinRole) -> DmNameBuf {
+pub fn format_thin_name(pool_uuid: PoolUuid, role: ThinRole) -> DmNameBuf {
     DmNameBuf::new(format!("stratis-{}-{}-thin-{}",
                            FORMAT_VERSION,
                            pool_uuid.simple().to_string(),
@@ -83,7 +83,7 @@ pub fn format_thin_name(pool_uuid: &PoolUuid, role: ThinRole) -> DmNameBuf {
 
 /// Format a name for the thin pool layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 81
-pub fn format_thinpool_name(pool_uuid: &PoolUuid, role: ThinPoolRole) -> DmNameBuf {
+pub fn format_thinpool_name(pool_uuid: PoolUuid, role: ThinPoolRole) -> DmNameBuf {
     DmNameBuf::new(format!("stratis-{}-{}-thinpool-{}",
                            FORMAT_VERSION,
                            pool_uuid.simple().to_string(),

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -62,7 +62,7 @@ impl StratEngine {
     }
 
     /// Get pool as StratPool
-    pub fn get_strat_pool(&self, uuid: &PoolUuid) -> Option<&StratPool> {
+    pub fn get_strat_pool(&self, uuid: PoolUuid) -> Option<&StratPool> {
         self.pools.get_by_uuid(uuid)
     }
 }
@@ -88,16 +88,16 @@ impl Engine for StratEngine {
         let dm = DM::new()?;
         let (pool, devnodes) = StratPool::initialize(name, &dm, blockdev_paths, redundancy, force)?;
 
-        let uuid = *pool.uuid();
+        let uuid = pool.uuid();
         self.pools.insert(pool);
         Ok((uuid, devnodes))
     }
 
-    fn destroy_pool(&mut self, uuid: &PoolUuid) -> EngineResult<bool> {
+    fn destroy_pool(&mut self, uuid: PoolUuid) -> EngineResult<bool> {
         destroy_pool!{self; uuid}
     }
 
-    fn rename_pool(&mut self, uuid: &PoolUuid, new_name: &str) -> EngineResult<RenameAction> {
+    fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> EngineResult<RenameAction> {
         let old_name = rename_pool_pre!(self; uuid; new_name);
 
         let mut pool = self.pools
@@ -115,11 +115,11 @@ impl Engine for StratEngine {
         }
     }
 
-    fn get_pool(&self, uuid: &PoolUuid) -> Option<&Pool> {
+    fn get_pool(&self, uuid: PoolUuid) -> Option<&Pool> {
         get_pool!(self; uuid)
     }
 
-    fn get_mut_pool(&mut self, uuid: &PoolUuid) -> Option<&mut Pool> {
+    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<&mut Pool> {
         get_mut_pool!(self; uuid)
     }
 

--- a/src/engine/strat_engine/filesystem.rs
+++ b/src/engine/strat_engine/filesystem.rs
@@ -182,8 +182,8 @@ impl HasName for StratFilesystem {
 }
 
 impl HasUuid for StratFilesystem {
-    fn uuid(&self) -> &FilesystemUuid {
-        &self.fs_id
+    fn uuid(&self) -> FilesystemUuid {
+        self.fs_id
     }
 }
 

--- a/src/engine/strat_engine/mdv.rs
+++ b/src/engine/strat_engine/mdv.rs
@@ -155,7 +155,7 @@ impl MetadataVol {
     }
 
     /// Remove info on a filesystem from persistent storage.
-    pub fn rm_fs(&self, fs_uuid: &FilesystemUuid) -> EngineResult<()> {
+    pub fn rm_fs(&self, fs_uuid: FilesystemUuid) -> EngineResult<()> {
         let fs_path = self.mount_pt
             .join(FILESYSTEM_DIR)
             .join(fs_uuid.simple().to_string())

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -37,8 +37,8 @@ pub struct BDA {
 impl BDA {
     /// Initialize a blockdev with a Stratis BDA.
     pub fn initialize<F>(mut f: &mut F,
-                         pool_uuid: &Uuid,
-                         dev_uuid: &Uuid,
+                         pool_uuid: Uuid,
+                         dev_uuid: Uuid,
                          mda_size: Sectors,
                          blkdev_size: Sectors,
                          initialization_time: u64)
@@ -129,13 +129,13 @@ impl BDA {
     }
 
     /// The UUID of the device.
-    pub fn dev_uuid(&self) -> &DevUuid {
-        &self.header.dev_uuid
+    pub fn dev_uuid(&self) -> DevUuid {
+        self.header.dev_uuid
     }
 
     /// The UUID of the device's pool.
-    pub fn pool_uuid(&self) -> &PoolUuid {
-        &self.header.pool_uuid
+    pub fn pool_uuid(&self) -> PoolUuid {
+        self.header.pool_uuid
     }
 
     /// The size of the device.
@@ -167,16 +167,16 @@ pub struct StaticHeader {
 }
 
 impl StaticHeader {
-    fn new(pool_uuid: &PoolUuid,
-           dev_uuid: &DevUuid,
+    fn new(pool_uuid: PoolUuid,
+           dev_uuid: DevUuid,
            mda_size: Sectors,
            blkdev_size: Sectors,
            initialization_time: u64)
            -> StaticHeader {
         StaticHeader {
             blkdev_size: blkdev_size,
-            pool_uuid: *pool_uuid,
-            dev_uuid: *dev_uuid,
+            pool_uuid: pool_uuid,
+            dev_uuid: dev_uuid,
             mda_size: mda_size,
             reserved_size: MDA_RESERVED_SECTORS,
             flags: 0,
@@ -769,8 +769,8 @@ mod tests {
         let dev_uuid = Uuid::new_v4();
         let mda_size = MIN_MDA_SECTORS + Sectors((mda_size_factor * 4) as u64);
         let blkdev_size = (Bytes(IEC::Mi) + Sectors(blkdev_size).bytes()).sectors();
-        StaticHeader::new(&pool_uuid,
-                          &dev_uuid,
+        StaticHeader::new(pool_uuid,
+                          dev_uuid,
                           mda_size,
                           blkdev_size,
                           Utc::now().timestamp() as u64)
@@ -824,8 +824,8 @@ mod tests {
             }
 
             BDA::initialize(&mut buf,
-                            &sh.pool_uuid,
-                            &sh.dev_uuid,
+                            sh.pool_uuid,
+                            sh.dev_uuid,
                             sh.mda_size,
                             sh.blkdev_size,
                             Utc::now().timestamp() as u64)
@@ -863,8 +863,8 @@ mod tests {
             let sh = random_static_header(blkdev_size, mda_size_factor);
             let mut buf = Cursor::new(vec![0; *sh.blkdev_size.bytes() as usize]);
             let bda = BDA::initialize(&mut buf,
-                                      &sh.pool_uuid,
-                                      &sh.dev_uuid,
+                                      sh.pool_uuid,
+                                      sh.dev_uuid,
                                       sh.mda_size,
                                       sh.blkdev_size,
                                       Utc::now().timestamp() as u64)
@@ -887,8 +887,8 @@ mod tests {
         let sh = random_static_header(0, 0);
         let mut buf = Cursor::new(vec![0; *sh.blkdev_size.bytes() as usize]);
         let mut bda = BDA::initialize(&mut buf,
-                                      &sh.pool_uuid,
-                                      &sh.dev_uuid,
+                                      sh.pool_uuid,
+                                      sh.dev_uuid,
                                       sh.mda_size,
                                       sh.blkdev_size,
                                       Utc::now().timestamp() as u64)
@@ -931,8 +931,8 @@ mod tests {
             let sh = random_static_header(blkdev_size, mda_size_factor);
             let mut buf = Cursor::new(vec![0; *sh.blkdev_size.bytes() as usize]);
             let mut bda = BDA::initialize(&mut buf,
-                                          &sh.pool_uuid,
-                                          &sh.dev_uuid,
+                                          sh.pool_uuid,
+                                          sh.dev_uuid,
                                           sh.mda_size,
                                           sh.blkdev_size,
                                           Utc::now().timestamp() as u64)

--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -115,7 +115,7 @@ pub fn get_metadata(pool_uuid: PoolUuid,
     for devnode in devnodes.values() {
         let bda = BDA::load(&mut OpenOptions::new().read(true).open(devnode)?)?;
         if let Some(bda) = bda {
-            if *bda.pool_uuid() == pool_uuid {
+            if bda.pool_uuid() == pool_uuid {
                 bdas.push((devnode, bda));
             }
         }
@@ -186,7 +186,7 @@ pub fn get_blockdevs(pool_uuid: PoolUuid,
     for (device, devnode) in devnodes {
         let bda = BDA::load(&mut OpenOptions::new().read(true).open(devnode)?)?;
         if let Some(bda) = bda {
-            if *bda.pool_uuid() == pool_uuid {
+            if bda.pool_uuid() == pool_uuid {
                 let actual_size = blkdev_size(&OpenOptions::new().read(true).open(devnode)?)?
                     .sectors();
 
@@ -196,7 +196,7 @@ pub fn get_blockdevs(pool_uuid: PoolUuid,
                 // RangeAllocator::new() will return an error.
                 let allocator =
                     RangeAllocator::new(actual_size,
-                                        segment_table.get(bda.dev_uuid()).unwrap_or(&vec![]))?;
+                                        segment_table.get(&bda.dev_uuid()).unwrap_or(&vec![]))?;
 
                 blockdevs.push(StratBlockDev::new(*device, devnode.to_owned(), bda, allocator));
             }
@@ -204,7 +204,7 @@ pub fn get_blockdevs(pool_uuid: PoolUuid,
     }
 
     // Verify that blockdevs found match blockdevs recorded.
-    let current_uuids: HashSet<_> = blockdevs.iter().map(|b| *b.uuid()).collect();
+    let current_uuids: HashSet<_> = blockdevs.iter().map(|b| b.uuid()).collect();
     let recorded_uuids: HashSet<_> = pool_save.block_devs.keys().cloned().collect();
 
     if current_uuids != recorded_uuids {

--- a/tests/util/blockdev_tests.rs
+++ b/tests/util/blockdev_tests.rs
@@ -48,7 +48,7 @@ pub fn test_force_flag_dirty(paths: &[&Path]) -> () {
     let unique_devices = resolve_devices(&paths).unwrap();
 
     let uuid = Uuid::new_v4();
-    assert!(initialize(&uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).is_err());
+    assert!(initialize(uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).is_err());
     assert!(paths
                 .iter()
                 .enumerate()
@@ -62,7 +62,7 @@ pub fn test_force_flag_dirty(paths: &[&Path]) -> () {
         }
     }));
 
-    assert!(initialize(&uuid, unique_devices.clone(), MIN_MDA_SECTORS, true).is_ok());
+    assert!(initialize(uuid, unique_devices.clone(), MIN_MDA_SECTORS, true).is_ok());
     assert!(paths
                 .iter()
                 .all(|path| {
@@ -88,14 +88,14 @@ pub fn test_force_flag_stratis(paths: &[&Path]) -> () {
     let uuid = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    initialize(&uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).unwrap();
-    assert!(initialize(&uuid2, unique_devices.clone(), MIN_MDA_SECTORS, false).is_err());
+    initialize(uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).unwrap();
+    assert!(initialize(uuid2, unique_devices.clone(), MIN_MDA_SECTORS, false).is_err());
 
-    assert!(initialize(&uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).is_ok());
+    assert!(initialize(uuid, unique_devices.clone(), MIN_MDA_SECTORS, false).is_ok());
 
     // FIXME: this should succeed, but currently it fails, to be extra safe.
     // See: https://github.com/stratis-storage/stratisd/pull/292
-    assert!(initialize(&uuid2, unique_devices.clone(), MIN_MDA_SECTORS, true).is_err());
+    assert!(initialize(uuid2, unique_devices.clone(), MIN_MDA_SECTORS, true).is_err());
 }
 
 
@@ -115,7 +115,7 @@ pub fn test_pool_blockdevs(paths: &[&Path]) -> () {
                                                                     .unwrap())
                                  .unwrap() == DevOwnership::Ours(uuid)
                      }));
-    engine.destroy_pool(&uuid).unwrap();
+    engine.destroy_pool(uuid).unwrap();
     assert!(blockdevs
                 .iter()
                 .all(|path| {
@@ -132,7 +132,7 @@ pub fn test_pool_blockdevs(paths: &[&Path]) -> () {
 /// balance.
 pub fn test_blockdevmgr_used(paths: &[&Path]) -> () {
     let uuid = Uuid::new_v4();
-    let mut mgr = BlockDevMgr::initialize(&uuid, paths, MIN_MDA_SECTORS, false).unwrap();
+    let mut mgr = BlockDevMgr::initialize(uuid, paths, MIN_MDA_SECTORS, false).unwrap();
     assert_eq!(mgr.avail_space() + mgr.metadata_size(),
                mgr.current_capacity());
 

--- a/tests/util/dm_tests.rs
+++ b/tests/util/dm_tests.rs
@@ -31,7 +31,7 @@ use libstratis::engine::strat_engine::util::create_fs;
 /// blockdevs in the linear device equals the size of the linear device.
 pub fn test_linear_device(paths: &[&Path]) -> () {
     let unique_devices = resolve_devices(&paths).unwrap();
-    let initialized = initialize(&Uuid::new_v4(),
+    let initialized = initialize(Uuid::new_v4(),
                                  unique_devices.clone(),
                                  MIN_MDA_SECTORS,
                                  false)
@@ -65,7 +65,7 @@ pub fn test_linear_device(paths: &[&Path]) -> () {
 /// Verify no errors when writing files to a mounted filesystem on a thin
 /// device.
 pub fn test_thinpool_device(paths: &[&Path]) -> () {
-    let initialized = initialize(&Uuid::new_v4(),
+    let initialized = initialize(Uuid::new_v4(),
                                  resolve_devices(&paths).unwrap(),
                                  MIN_MDA_SECTORS,
                                  false)

--- a/tests/util/filesystem_tests.rs
+++ b/tests/util/filesystem_tests.rs
@@ -44,7 +44,7 @@ pub fn test_xfs_expand(paths: &[&Path]) -> () {
         .unwrap();
     // Braces to ensure f is closed before destroy and the borrow of pool is complete
     {
-        let filesystem = pool.get_mut_strat_filesystem(&fs_uuid).unwrap();
+        let filesystem = pool.get_mut_strat_filesystem(fs_uuid).unwrap();
         // Write 2 MiB of data. The filesystem's free space is now 1 MiB below
         // FILESYSTEM_LOWATER.
         let write_size = Bytes(IEC::Mi * 2).sectors();
@@ -74,6 +74,6 @@ pub fn test_xfs_expand(paths: &[&Path]) -> () {
         assert!(fs_total_bytes > orig_fs_total_bytes);
         umount(tmp_dir.path()).unwrap();
     }
-    pool.destroy_filesystems(&[&fs_uuid]).unwrap();
+    pool.destroy_filesystems(&[fs_uuid]).unwrap();
     pool.teardown().unwrap();
 }

--- a/tests/util/pool_tests.rs
+++ b/tests/util/pool_tests.rs
@@ -44,7 +44,7 @@ pub fn test_thinpool_expand(paths: &[&Path]) -> () {
         .first()
         .unwrap();
 
-    let devnode = pool.get_filesystem(&fs_uuid).unwrap().devnode();
+    let devnode = pool.get_filesystem(fs_uuid).unwrap().devnode();
     // Braces to ensure f is closed before destroy
     {
         let mut f = OpenOptions::new().write(true).open(devnode).unwrap();
@@ -62,7 +62,7 @@ pub fn test_thinpool_expand(paths: &[&Path]) -> () {
             }
         }
     }
-    pool.destroy_filesystems(&[&fs_uuid]).unwrap();
+    pool.destroy_filesystems(&[fs_uuid]).unwrap();
     pool.teardown().unwrap();
 }
 
@@ -80,7 +80,7 @@ pub fn test_filesystem_snapshot(paths: &[&Path]) {
     let source_tmp_dir = TempDir::new("stratis_testing").unwrap();
     {
         // to allow mutable borrow of pool
-        let filesystem = pool.get_filesystem(&fs_uuid).unwrap();
+        let filesystem = pool.get_filesystem(fs_uuid).unwrap();
         mount(Some(&filesystem.devnode()),
               source_tmp_dir.path(),
               Some("xfs"),
@@ -117,7 +117,7 @@ pub fn test_filesystem_snapshot(paths: &[&Path]) {
     let mut read_buf = [0u8; SECTOR_SIZE];
     let snapshot_tmp_dir = TempDir::new("stratis_testing").unwrap();
     {
-        let snapshot_filesystem = pool.get_filesystem(&snapshot_uuid).unwrap();
+        let snapshot_filesystem = pool.get_filesystem(snapshot_uuid).unwrap();
         mount(Some(&snapshot_filesystem.devnode()),
               snapshot_tmp_dir.path(),
               Some("xfs"),
@@ -135,7 +135,7 @@ pub fn test_filesystem_snapshot(paths: &[&Path]) {
     }
     umount(source_tmp_dir.path()).unwrap();
     umount(snapshot_tmp_dir.path()).unwrap();
-    pool.destroy_filesystems(&[&fs_uuid, &snapshot_uuid])
+    pool.destroy_filesystems(&[fs_uuid, snapshot_uuid])
         .unwrap();
     pool.teardown().unwrap();
 }
@@ -149,7 +149,7 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
     let name2 = "name2";
     let (uuid1, _) = engine.create_pool(&name1, paths, None, false).unwrap();
     let fs_uuid = {
-        let pool = engine.get_mut_pool(&uuid1).unwrap();
+        let pool = engine.get_mut_pool(uuid1).unwrap();
         let &(fs_name, fs_uuid) = pool.create_filesystems(&[(name1, None)])
             .unwrap()
             .first()
@@ -157,7 +157,7 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
 
         assert_eq!(name1, fs_name);
 
-        let action = pool.rename_filesystem(&fs_uuid, name2).unwrap();
+        let action = pool.rename_filesystem(fs_uuid, name2).unwrap();
         assert_eq!(action, RenameAction::Renamed);
         fs_uuid
     };
@@ -165,9 +165,9 @@ pub fn test_filesystem_rename(paths: &[&Path]) {
 
     let engine = StratEngine::initialize().unwrap();
     let filesystem_name: String = engine
-        .get_pool(&uuid1)
+        .get_pool(uuid1)
         .unwrap()
-        .get_filesystem(&fs_uuid)
+        .get_filesystem(fs_uuid)
         .unwrap()
         .name()
         .into();
@@ -191,13 +191,13 @@ pub fn test_thinpool_thindev_destroy(paths: &[&Path]) -> () {
         .first()
         .unwrap();
 
-    let fs_id = pool.get_mut_strat_filesystem(&fs_uuid)
+    let fs_id = pool.get_mut_strat_filesystem(fs_uuid)
         .unwrap()
         .thin_id();
 
-    pool.destroy_filesystems(&[&fs_uuid]).unwrap();
+    pool.destroy_filesystems(&[fs_uuid]).unwrap();
 
-    let pool_uuid = *pool.uuid();
+    let pool_uuid = pool.uuid();
 
     // Try to setup a thindev that has been destroyed
     let dm = DM::new().unwrap();
@@ -222,6 +222,6 @@ pub fn test_thinpool_thindev_destroy(paths: &[&Path]) -> () {
 
     // This also should never happen, given the previous two parts of
     // this test.
-    assert!(pool.get_filesystem(&fs_uuid).is_none());
+    assert!(pool.get_filesystem(fs_uuid).is_none());
     pool.teardown().unwrap();
 }

--- a/tests/util/setup_tests.rs
+++ b/tests/util/setup_tests.rs
@@ -51,7 +51,7 @@ pub fn test_initialize(paths: &[&Path]) -> () {
 
     let unique_devices = resolve_devices(paths1).unwrap();
     let uuid1 = Uuid::new_v4();
-    initialize(&uuid1, unique_devices, MIN_MDA_SECTORS, false).unwrap();
+    initialize(uuid1, unique_devices, MIN_MDA_SECTORS, false).unwrap();
 
     let pools = find_all().unwrap();
     assert!(pools.len() == 1);
@@ -61,7 +61,7 @@ pub fn test_initialize(paths: &[&Path]) -> () {
 
     let unique_devices = resolve_devices(paths2).unwrap();
     let uuid2 = Uuid::new_v4();
-    initialize(&uuid2, unique_devices, MIN_MDA_SECTORS, false).unwrap();
+    initialize(uuid2, unique_devices, MIN_MDA_SECTORS, false).unwrap();
 
     let pools = find_all().unwrap();
     assert!(pools.len() == 2);
@@ -95,11 +95,11 @@ pub fn test_basic_metadata(paths: &[&Path]) {
 
     let name1 = "name1";
     let (uuid1, _) = engine.create_pool(&name1, paths1, None, false).unwrap();
-    let metadata1 = engine.get_strat_pool(&uuid1).unwrap().record();
+    let metadata1 = engine.get_strat_pool(uuid1).unwrap().record();
 
     let name2 = "name2";
     let (uuid2, _) = engine.create_pool(&name2, paths2, None, false).unwrap();
-    let metadata2 = engine.get_strat_pool(&uuid2).unwrap().record();
+    let metadata2 = engine.get_strat_pool(uuid2).unwrap().record();
 
     let pools = find_all().unwrap();
     assert!(pools.len() == 2);
@@ -149,15 +149,15 @@ pub fn test_setup(paths: &[&Path]) {
     let name2 = "name2";
     let (uuid2, _) = engine.create_pool(&name2, paths2, None, false).unwrap();
 
-    assert!(engine.get_pool(&uuid1).is_some());
-    assert!(engine.get_pool(&uuid2).is_some());
+    assert!(engine.get_pool(uuid1).is_some());
+    assert!(engine.get_pool(uuid2).is_some());
 
     engine.teardown().unwrap();
 
     let engine = StratEngine::initialize().unwrap();
 
-    assert!(engine.get_pool(&uuid1).is_some());
-    assert!(engine.get_pool(&uuid2).is_some());
+    assert!(engine.get_pool(uuid1).is_some());
+    assert!(engine.get_pool(uuid2).is_some());
 
     engine.teardown().unwrap();
 }
@@ -170,13 +170,13 @@ pub fn test_pool_rename(paths: &[&Path]) {
     let (uuid1, _) = engine.create_pool(&name1, paths, None, false).unwrap();
 
     let name2 = "name2";
-    let action = engine.rename_pool(&uuid1, name2).unwrap();
+    let action = engine.rename_pool(uuid1, name2).unwrap();
 
     assert_eq!(action, RenameAction::Renamed);
     engine.teardown().unwrap();
 
     let engine = StratEngine::initialize().unwrap();
-    let pool_name: String = engine.get_pool(&uuid1).unwrap().name().into();
+    let pool_name: String = engine.get_pool(uuid1).unwrap().name().into();
     assert_eq!(pool_name, name2);
     engine.teardown().unwrap();
 }
@@ -194,7 +194,7 @@ pub fn test_pool_setup(paths: &[&Path]) {
     let tmp_dir = TempDir::new("stratis_testing").unwrap();
     let new_file = tmp_dir.path().join("stratis_test.txt");
     {
-        let fs = pool.get_filesystem(&fs_uuid).unwrap();
+        let fs = pool.get_filesystem(fs_uuid).unwrap();
         mount(Some(&fs.devnode()),
               tmp_dir.path(),
               Some("xfs"),
@@ -215,9 +215,9 @@ pub fn test_pool_setup(paths: &[&Path]) {
         .into_iter()
         .map(|(d, p)| (d, p.to_owned()))
         .collect();
-    let new_pool = StratPool::setup(*pool.uuid(), &paths2).unwrap();
+    let new_pool = StratPool::setup(pool.uuid(), &paths2).unwrap();
 
-    assert!(new_pool.get_filesystem(&fs_uuid).is_some());
+    assert!(new_pool.get_filesystem(fs_uuid).is_some());
 
     umount2(tmp_dir.path(), MNT_DETACH).unwrap();
     pool.teardown().unwrap();


### PR DESCRIPTION
Uuid implements Copy.  We shouldn't be passing it around as a reference.  

Resolves #569

Signed-off-by: Todd Gill <tgill@redhat.com>