### PR TITLE
Add snapshot support for dbus

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -89,6 +89,13 @@ pub trait Pool: HasName + HasUuid {
                          new_name: &str)
                          -> EngineResult<RenameAction>;
 
+    /// Snapshot filesystem
+    /// Create a CoW snapshot of the origin
+    fn snapshot_filesystem(&mut self,
+                           origin_uuid: FilesystemUuid,
+                           snapshot_name: &str)
+                           -> EngineResult<FilesystemUuid>;
+
     /// Rename this pool.
     fn rename(&mut self, name: &str) -> ();
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -119,6 +119,21 @@ impl Pool for SimPool {
         Ok(result)
     }
 
+    fn snapshot_filesystem(&mut self,
+                           origin_uuid: FilesystemUuid,
+                           snapshot_name: &str)
+                           -> EngineResult<FilesystemUuid> {
+        let uuid = Uuid::new_v4();
+        let snapshot = match self.get_filesystem(origin_uuid) {
+            Some(_filesystem) => SimFilesystem::new(uuid, snapshot_name),
+            None => {
+                return Err(EngineError::Engine(ErrorEnum::NotFound, origin_uuid.to_string()));
+            }
+        };
+        self.filesystems.insert(snapshot);
+        Ok(uuid)
+    }
+
     fn rename_filesystem(&mut self,
                          uuid: FilesystemUuid,
                          new_name: &str)

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -117,12 +117,6 @@ impl StratPool {
     pub fn has_filesystems(&self) -> bool {
         self.thin_pool.has_filesystems()
     }
-
-    #[allow(dead_code)]
-    pub fn snapshot_filesystem(&mut self, filesystem_uuid: Uuid) -> EngineResult<FilesystemUuid> {
-        let dm = DM::new()?;
-        self.thin_pool.snapshot_filesystem(&dm, filesystem_uuid)
-    }
 }
 
 impl Pool for StratPool {
@@ -198,6 +192,14 @@ impl Pool for StratPool {
 
     fn filesystems(&self) -> Vec<&Filesystem> {
         self.thin_pool.filesystems()
+    }
+
+    fn snapshot_filesystem(&mut self,
+                           origin_uuid: FilesystemUuid,
+                           snapshot_name: &str)
+                           -> EngineResult<FilesystemUuid> {
+        self.thin_pool
+            .snapshot_filesystem(&DM::new()?, origin_uuid, snapshot_name)
     }
 
     fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem> {


### PR DESCRIPTION
Add  SnapshotFilesystem method to the the dbus Pool object

Allows dbus user to create an independent filesystem snapshot in the pool.

Tested via "busctl" command:

busctl call org.storage.stratis1 /org/storage/stratis1/1 org.storage.stratis1.pool SnapshotFilesystem os /org/storage/stratis1/5 snapshot
