### PR TITLE
Fix pool destroy for blockdevs

### DIFF
--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -81,8 +81,8 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                              let path =
                                  create_dbus_blockdev(dbus_context,
                                                       pool_object_path.get_name().to_owned(),
-                                                      bd.uuid());
-                             pool_data.children.borrow_mut().insert(path.clone());
+                                                      bd.uuid(),
+                                                      pool_data);
                              MessageItem::ObjectPath(path)
                          })
                     .collect::<Vec<_>>()
@@ -299,18 +299,17 @@ pub fn connect(engine: Rc<RefCell<Engine>>)
         }
 
         {
-            let pool_data = pool_path.get_data();
+            let op_data = pool_path.get_data();
             for dev_uuid in pool.blockdevs().iter().map(|bd| bd.uuid()) {
-                let path =
-                    create_dbus_blockdev(&dbus_context, pool_path.get_name().to_owned(), dev_uuid);
-                pool_data
+                let pool_data = op_data
                     .as_ref()
                     .expect("pools must have valid context")
                     .pool()
-                    .expect("pools must contain pool enum variant")
-                    .children
-                    .borrow_mut()
-                    .insert(path);
+                    .expect("pools must contain pool enum variant");
+                create_dbus_blockdev(&dbus_context,
+                                     pool_path.get_name().to_owned(),
+                                     dev_uuid,
+                                     pool_data);
             }
         }
         dbus_context.actions.borrow_mut().push_add(pool_path);

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use super::super::engine::BlockDev;
 use super::super::engine::types::BlockDevState;
 
-use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
+use super::types::{DbusContext, DbusErrorEnum, OPContext, OPType, TData};
 
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
@@ -89,7 +89,8 @@ pub fn create_dbus_blockdev<'a>(dbus_context: &DbusContext,
 
     let interface_name = format!("{}.{}", STRATIS_BASE_SERVICE, "blockdev");
 
-    let object_path = f.object_path(object_name, Some(OPContext::new(parent, uuid)))
+    let object_path = f.object_path(object_name,
+                                    Some(OPContext::new(parent, uuid, OPType::Blockdev)))
         .introspectable()
         .add(f.interface(interface_name, ())
                  .add_m(set_userid_method)

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use super::super::engine::BlockDev;
 use super::super::engine::types::BlockDevState;
 
-use super::types::{DbusContext, DbusErrorEnum, OPContext, OPType, TData};
+use super::types::{DbusContext, DbusErrorEnum, OPContext, OPType, OPTypePool, TData};
 
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
@@ -33,7 +33,8 @@ use super::util::ok_message_items;
 
 pub fn create_dbus_blockdev<'a>(dbus_context: &DbusContext,
                                 parent: dbus::Path<'static>,
-                                uuid: Uuid)
+                                uuid: Uuid,
+                                pool_data: &OPTypePool)
                                 -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
@@ -105,6 +106,7 @@ pub fn create_dbus_blockdev<'a>(dbus_context: &DbusContext,
 
     let path = object_path.get_name().to_owned();
     dbus_context.actions.borrow_mut().push_add(object_path);
+    pool_data.children.borrow_mut().insert(path.clone());
     path
 }
 

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -21,7 +21,7 @@ use engine::RenameAction;
 
 use super::super::engine::Filesystem;
 
-use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
+use super::types::{DbusContext, DbusErrorEnum, OPContext, OPType, TData};
 
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
@@ -71,7 +71,8 @@ pub fn create_dbus_filesystem<'a>(dbus_context: &DbusContext,
 
     let interface_name = format!("{}.{}", STRATIS_BASE_SERVICE, "filesystem");
 
-    let object_path = f.object_path(object_name, Some(OPContext::new(parent, uuid)))
+    let object_path = f.object_path(object_name,
+                                    Some(OPContext::new(parent, uuid, OPType::Filesystem)))
         .introspectable()
         .add(f.interface(interface_name, ())
                  .add_m(rename_method)

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -180,12 +180,13 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             let return_value = uuids
                 .into_iter()
                 .map(|uuid| {
-                    let path =
-                        create_dbus_blockdev(dbus_context, pool_path.get_name().to_owned(), uuid);
                     let pool_data = op_data
                         .pool()
                         .expect("pools must contain pool enum variant");
-                    pool_data.children.borrow_mut().insert(path.clone());
+                    let path = create_dbus_blockdev(dbus_context,
+                                                    pool_path.get_name().to_owned(),
+                                                    uuid,
+                                                    pool_data);
                     MessageItem::ObjectPath(path)
                 })
                 .collect();

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::cell::{Cell, RefCell};
+use std::collections::HashSet;
 use std::collections::vec_deque::{Drain, VecDeque};
 use std::convert::From;
 use std::rc::Rc;
@@ -67,6 +68,7 @@ pub enum DeferredAction {
 pub struct OPContext {
     pub parent: Path<'static>,
     pub uuid: Uuid,
+    pub children: RefCell<HashSet<Path<'static>>>,
 }
 
 impl OPContext {
@@ -74,6 +76,7 @@ impl OPContext {
         OPContext {
             parent: parent,
             uuid: uuid,
+            children: RefCell::new(HashSet::new()),
         }
     }
 }

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -61,6 +61,19 @@ pub enum DeferredAction {
     Remove(Path<'static>),
 }
 
+/// Pool-specific data stored in the OPContext.
+#[derive(Debug, Default)]
+pub struct OPTypePool {
+    pub children: RefCell<HashSet<Path<'static>>>,
+}
+
+#[derive(Debug)]
+pub enum OPType {
+    Pool(OPTypePool),
+    Blockdev,
+    Filesystem,
+}
+
 /// Context for an object path.
 /// Contains the object path of the parent as a Path and the UUID of the
 /// object itself.
@@ -68,15 +81,22 @@ pub enum DeferredAction {
 pub struct OPContext {
     pub parent: Path<'static>,
     pub uuid: Uuid,
-    pub children: RefCell<HashSet<Path<'static>>>,
+    pub op_type: OPType,
 }
 
 impl OPContext {
-    pub fn new(parent: Path<'static>, uuid: Uuid) -> OPContext {
+    pub fn new(parent: Path<'static>, uuid: Uuid, op_type: OPType) -> OPContext {
         OPContext {
             parent: parent,
             uuid: uuid,
-            children: RefCell::new(HashSet::new()),
+            op_type: op_type,
+        }
+    }
+
+    pub fn pool(&self) -> Option<&OPTypePool> {
+        match self.op_type {
+            OPType::Pool(ref optp) => Some(optp),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
We need to remove blockdev objectpaths from DBus when the pool is destroyed. Unfortunately, this is hard for the reasons stated in #626.