### PR TITLE
Do more clean up in unit tests by leveraging the drop trait more

### DIFF
--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -14,6 +14,7 @@ use self::loopdev::{LoopControl, LoopDevice};
 
 use super::logger::init_logger;
 use super::tempdir::TempDir;
+use super::util::clean_up;
 
 use super::super::device::wipe_sectors;
 
@@ -34,6 +35,7 @@ impl LoopTestDev {
     /// Create a new loopbacked device.
     /// Create its backing store of 1 GiB wiping the first 1 MiB.
     pub fn new(lc: &LoopControl, path: &Path) -> LoopTestDev {
+        clean_up();
         let mut f = OpenOptions::new()
             .read(true)
             .write(true)
@@ -71,6 +73,7 @@ impl LoopTestDev {
 
 impl Drop for LoopTestDev {
     fn drop(&mut self) {
+        clean_up();
         self.detach()
     }
 }

--- a/src/engine/strat_engine/tests/mod.rs
+++ b/src/engine/strat_engine/tests/mod.rs
@@ -7,5 +7,6 @@ extern crate log;
 pub extern crate tempdir;
 
 mod logger;
+mod util;
 pub mod loopbacked;
 pub mod real;

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -13,6 +13,7 @@ use serde_json::{Value, from_reader};
 use devicemapper::{Bytes, IEC, Sectors};
 
 use super::logger::init_logger;
+use super::util::clean_up;
 
 use super::super::device::wipe_sectors;
 
@@ -24,6 +25,7 @@ impl RealTestDev {
     /// Construct a new test device for the given path.
     /// Wipe initial MiB to clear metadata.
     pub fn new(path: &Path) -> RealTestDev {
+        clean_up();
         wipe_sectors(path, Sectors(0), Bytes(IEC::Mi).sectors()).unwrap();
         RealTestDev { path: PathBuf::from(path) }
     }
@@ -36,6 +38,7 @@ impl RealTestDev {
 
 impl Drop for RealTestDev {
     fn drop(&mut self) {
+        clean_up();
         wipe_sectors(&self.path, Sectors(0), Bytes(IEC::Mi).sectors()).unwrap();
     }
 }

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::path::PathBuf;
+
+use devicemapper::{DM, DmFlags, DevId};
+
+use nix::mount::umount;
+use mnt::get_submounts;
+
+/// Attempt to remove all device mapper devices which match the stratis naming convention.
+/// FIXME: Current implementation complicated by https://bugzilla.redhat.com/show_bug.cgi?id=1506287
+fn dm_stratis_devices_remove() {
+
+    let dm = DM::new().unwrap();
+
+    loop {
+        let mut progress_made = false;
+        for d in dm.list_devices()
+                .unwrap()
+                .iter()
+                .filter(|d| format!("{}", d.0.as_ref()).starts_with("stratis-1")) {
+            progress_made |= dm.device_remove(&DevId::Name(&d.0), DmFlags::empty())
+                .is_ok();
+        }
+
+        if !progress_made {
+            break;
+        }
+    }
+}
+
+/// Try and un-mount any filesystems that have the name stratis in the mount point.
+fn stratis_filesystems_unmount() {
+    for m in get_submounts(&PathBuf::from("/"))
+            .unwrap()
+            .iter()
+            .filter(|m| m.file.to_str().map_or(false, |s| s.contains("stratis"))) {
+        umount(&m.file).unwrap();
+    }
+}
+
+/// When a unit test panics we can leave the system in an inconsistent state.  This function
+/// tries to clean up by un-mounting any mounted file systems which contain the string
+/// "stratis_testing" and then it tries to remove any device mapper tables which are also stratis
+/// created.
+pub fn clean_up() -> () {
+    stratis_filesystems_unmount();
+    dm_stratis_devices_remove();
+}


### PR DESCRIPTION
Add code in the drop trait so that when it runs we:

* Remove all mounted file systems that were created from the unit test
* ~Remove all the dm tables using `dmsetup remove_all --force`~
* Remove only those dm devices which following the stratis naming convention

~Tested with numerous unit tests that panic and we do appear to clean up the system.  However, we may end up causing a kernel oops in the process, ref: https://bugzilla.redhat.com/show_bug.cgi?id=1506287~

When we tear down the dm devices in the correct order we don't oops the kernel.

~Note: This change build up on PR https://github.com/stratis-storage/stratisd/pull/625 as it uses the mnt crate too.~
Note: Using standard released mount crate  and I've removed the changes for https://github.com/stratis-storage/stratisd/pull/625