### PR TITLE
Fixes and alterations to some tests

### DIFF
--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -538,24 +538,24 @@ mod tests {
         BlockDevMgr::initialize(uuid1, paths1, MIN_MDA_SECTORS, false).unwrap();
 
         let pools = find_all().unwrap();
-        assert!(pools.len() == 1);
+        assert_eq!(pools.len(), 1);
         assert!(pools.contains_key(&uuid1));
         let devices = pools.get(&uuid1).expect("pools.contains_key() was true");
-        assert!(devices.len() == paths1.len());
+        assert_eq!(devices.len(), paths1.len());
 
         let uuid2 = Uuid::new_v4();
         BlockDevMgr::initialize(uuid2, paths2, MIN_MDA_SECTORS, false).unwrap();
 
         let pools = find_all().unwrap();
-        assert!(pools.len() == 2);
+        assert_eq!(pools.len(), 2);
 
         assert!(pools.contains_key(&uuid1));
         let devices1 = pools.get(&uuid1).expect("pools.contains_key() was true");
-        assert!(devices1.len() == paths1.len());
+        assert_eq!(devices1.len(), paths1.len());
 
         assert!(pools.contains_key(&uuid2));
         let devices2 = pools.get(&uuid2).expect("pools.contains_key() was true");
-        assert!(devices2.len() == paths2.len());
+        assert_eq!(devices2.len(), paths2.len());
 
         assert!(pools
                     .iter()

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -147,7 +147,6 @@ mod test {
         let engine = StratEngine::initialize().unwrap();
         let pool_name: String = engine.get_pool(uuid1).unwrap().name().into();
         assert_eq!(pool_name, name2);
-        engine.teardown().unwrap();
     }
 
     #[test]
@@ -189,8 +188,6 @@ mod test {
 
         assert!(engine.get_pool(uuid1).is_some());
         assert!(engine.get_pool(uuid2).is_some());
-
-        engine.teardown().unwrap();
     }
 
     #[test]

--- a/src/engine/strat_engine/metadata.rs
+++ b/src/engine/strat_engine/metadata.rs
@@ -900,7 +900,7 @@ mod tests {
 
         let timestamp0 = Utc::now();
         let timestamp1 = Utc::now();
-        assert!(timestamp0 != timestamp1);
+        assert_ne!(timestamp0, timestamp1);
 
         let mut buf = Cursor::new(vec![0; *sh.blkdev_size.bytes() as usize]);
         bda.save_state(&timestamp1, &data, &mut buf).unwrap();
@@ -910,7 +910,7 @@ mod tests {
 
         let timestamp2 = Utc::now();
         let timestamp3 = Utc::now();
-        assert!(timestamp2 != timestamp3);
+        assert_ne!(timestamp2, timestamp3);
 
         bda.save_state(&timestamp3, &data, &mut buf).unwrap();
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -287,32 +287,32 @@ mod tests {
         let metadata2 = pool2.record();
 
         let pools = find_all().unwrap();
-        assert!(pools.len() == 2);
+        assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
         let devnodes2 = pools.get(&uuid2).unwrap();
         let pool_save1 = get_metadata(uuid1, devnodes1).unwrap().unwrap();
         let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
-        assert!(pool_save1 == metadata1);
-        assert!(pool_save2 == metadata2);
+        assert_eq!(pool_save1, metadata1);
+        assert_eq!(pool_save2, metadata2);
         let blockdevs1 = get_blockdevs(uuid1, &pool_save1, devnodes1).unwrap();
         let blockdevs2 = get_blockdevs(uuid2, &pool_save2, devnodes2).unwrap();
-        assert!(blockdevs1.len() == pool_save1.block_devs.len());
-        assert!(blockdevs2.len() == pool_save2.block_devs.len());
+        assert_eq!(blockdevs1.len(), pool_save1.block_devs.len());
+        assert_eq!(blockdevs2.len(), pool_save2.block_devs.len());
 
         pool1.teardown().unwrap();
         pool2.teardown().unwrap();
         let pools = find_all().unwrap();
-        assert!(pools.len() == 2);
+        assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
         let devnodes2 = pools.get(&uuid2).unwrap();
         let pool_save1 = get_metadata(uuid1, devnodes1).unwrap().unwrap();
         let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
-        assert!(pool_save1 == metadata1);
-        assert!(pool_save2 == metadata2);
+        assert_eq!(pool_save1, metadata1);
+        assert_eq!(pool_save2, metadata2);
         let blockdevs1 = get_blockdevs(uuid1, &pool_save1, devnodes1).unwrap();
         let blockdevs2 = get_blockdevs(uuid2, &pool_save2, devnodes2).unwrap();
-        assert!(blockdevs1.len() == pool_save1.block_devs.len());
-        assert!(blockdevs2.len() == pool_save2.block_devs.len());
+        assert_eq!(blockdevs1.len(), pool_save1.block_devs.len());
+        assert_eq!(blockdevs2.len(), pool_save2.block_devs.len());
     }
 
     #[test]
@@ -327,7 +327,7 @@ mod tests {
     /// Verify that a pool with no devices does not have the minimum amount of
     /// space required.
     fn test_empty_pool(paths: &[&Path]) -> () {
-        assert!(paths.len() == 0);
+        assert_eq!(paths.len(), 0);
         let dm = DM::new().unwrap();
         assert!(match StratPool::initialize("stratis_test_pool",
                                             &dm,

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use devicemapper::{DM, DmFlags, DevId};
 
-use nix::mount::umount;
+use nix::mount::{MNT_DETACH, umount2};
 use mnt::get_submounts;
 
 /// Attempt to remove all device mapper devices which match the stratis naming convention.
@@ -37,7 +37,7 @@ fn stratis_filesystems_unmount() {
             .unwrap()
             .iter()
             .filter(|m| m.file.to_str().map_or(false, |s| s.contains("stratis"))) {
-        umount(&m.file).unwrap();
+        umount2(&m.file, MNT_DETACH).unwrap();
     }
 }
 

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -635,7 +635,7 @@ mod tests {
     use std::io::{Read, Write};
     use std::path::Path;
 
-    use nix::mount::{MNT_DETACH, MsFlags, mount, umount, umount2};
+    use nix::mount::{MsFlags, mount, umount};
     use uuid::Uuid;
 
     use devicemapper::{Bytes, SECTOR_SIZE};
@@ -714,11 +714,6 @@ mod tests {
                 assert_eq!(read_buf[0..SECTOR_SIZE], write_buf[0..SECTOR_SIZE]);
             }
         }
-        umount(source_tmp_dir.path()).unwrap();
-        umount(snapshot_tmp_dir.path()).unwrap();
-        pool.destroy_filesystem(&dm, fs_uuid).unwrap();
-        pool.destroy_filesystem(&dm, snapshot_uuid).unwrap();
-        pool.teardown(&dm).unwrap();
     }
 
     #[test]
@@ -760,7 +755,6 @@ mod tests {
                 .unwrap();
 
         assert_eq!(pool.get_filesystem_by_uuid(fs_uuid).unwrap().name(), name2);
-        pool.teardown(&dm).unwrap();
     }
 
     #[test]
@@ -814,10 +808,6 @@ mod tests {
                 .unwrap();
 
         assert!(new_pool.get_filesystem_by_uuid(fs_uuid).is_some());
-
-        umount2(tmp_dir.path(), MNT_DETACH).unwrap();
-        pool.destroy_filesystem(&dm, fs_uuid).unwrap();
-        pool.teardown(&dm).unwrap();
     }
 
     #[test]
@@ -873,7 +863,6 @@ mod tests {
                 .unwrap();
 
         assert!(pool.get_filesystem_by_uuid(fs_uuid).is_none());
-        pool.teardown(&dm).unwrap();
     }
 
     #[test]
@@ -919,8 +908,6 @@ mod tests {
                 }
             }
         }
-        pool.destroy_filesystem(&dm, fs_uuid).unwrap();
-        pool.teardown(&dm).unwrap();
     }
 
     #[test]
@@ -987,8 +974,6 @@ mod tests {
             assert!(fs_total_bytes > orig_fs_total_bytes);
             umount(tmp_dir.path()).unwrap();
         }
-        pool.destroy_filesystem(&dm, fs_uuid).unwrap();
-        pool.teardown(&dm).unwrap();
     }
 
     #[test]

--- a/src/engine/strat_engine/thinpool.rs
+++ b/src/engine/strat_engine/thinpool.rs
@@ -711,7 +711,7 @@ mod tests {
                     .join(format!("stratis_test{}.txt", i));
                 let mut f = OpenOptions::new().read(true).open(file_path).unwrap();
                 f.read(&mut read_buf).unwrap();
-                assert!(read_buf[0..SECTOR_SIZE] == write_buf[0..SECTOR_SIZE]);
+                assert_eq!(read_buf[0..SECTOR_SIZE], write_buf[0..SECTOR_SIZE]);
             }
         }
         umount(source_tmp_dir.path()).unwrap();

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -209,18 +209,18 @@ mod tests {
         for i in 0..items.len() {
             let name = items[i].name();
             let uuid = items[i].uuid();
-            assert!(name_map.get(name).unwrap() == &i);
-            assert!(uuid_map.get(&uuid).unwrap() == &i);
+            assert_eq!(name_map.get(name).unwrap(), &i);
+            assert_eq!(uuid_map.get(&uuid).unwrap(), &i);
         }
 
         for name in name_map.keys() {
             let index = name_map.get(name).unwrap();
-            assert!(items[*index].name() == name);
+            assert_eq!(items[*index].name(), name);
         }
 
         for &uuid in uuid_map.keys() {
             let index = uuid_map.get(&uuid).unwrap();
-            assert!(items[*index].uuid() == uuid);
+            assert_eq!(items[*index].uuid(), uuid);
         }
 
     }
@@ -299,7 +299,7 @@ mod tests {
         // t now contains the inserted thing.
         assert!(t.contains_name(&name));
         assert!(t.contains_uuid(uuid));
-        assert!(t.get_by_uuid(uuid).unwrap().stuff == thing_key);
+        assert_eq!(t.get_by_uuid(uuid).unwrap().stuff, thing_key);
 
         // Add another thing with the same keys.
         let thing2 = TestThing::new(&name, uuid);
@@ -308,16 +308,16 @@ mod tests {
         table_invariant(&t);
 
         // It has displaced the old thing.
-        assert!(displaced.len() == 1);
+        assert_eq!(displaced.len(), 1);
         let ref displaced_item = displaced[0];
-        assert!(displaced_item.name() == name);
-        assert!(displaced_item.uuid() == uuid);
+        assert_eq!(displaced_item.name(), name);
+        assert_eq!(displaced_item.uuid(), uuid);
 
         // But it contains a thing with the same keys.
         assert!(t.contains_name(&name));
         assert!(t.contains_uuid(uuid));
-        assert!(t.get_by_uuid(uuid).unwrap().stuff == thing_key2);
-        assert!(t.len() == 1);
+        assert_eq!(t.get_by_uuid(uuid).unwrap().stuff, thing_key2);
+        assert_eq!(t.len(), 1);
     }
 
     #[test]
@@ -349,18 +349,18 @@ mod tests {
         table_invariant(&t);
 
         // The items displaced consist exactly of the first item.
-        assert!(displaced.len() == 1);
+        assert_eq!(displaced.len(), 1);
         let ref displaced_item = displaced[0];
-        assert!(displaced_item.name() == name);
-        assert!(displaced_item.uuid() == uuid);
-        assert!(displaced_item.stuff == thing_key);
+        assert_eq!(displaced_item.name(), name);
+        assert_eq!(displaced_item.uuid(), uuid);
+        assert_eq!(displaced_item.stuff, thing_key);
 
         // The table contains the new item and has no memory of the old.
         assert!(t.contains_name(&name));
         assert!(t.contains_uuid(uuid2));
         assert!(!t.contains_uuid(uuid));
-        assert!(t.get_by_uuid(uuid2).unwrap().stuff == thing_key2);
-        assert!(t.get_by_name(&name).unwrap().stuff == thing_key2);
-        assert!(t.len() == 1);
+        assert_eq!(t.get_by_uuid(uuid2).unwrap().stuff, thing_key2);
+        assert_eq!(t.get_by_name(&name).unwrap().stuff, thing_key2);
+        assert_eq!(t.len(), 1);
     }
 }


### PR DESCRIPTION
Somewhat miscellaneous fixes to tests:

* Use assert_eq, assert_neq macros where possible in tests.
* Use umount2 and MNT_DETACH in test infrastructure to support loopbacked tests slightly better.
* Omit the code that is there just for cleanup in tests. We expect that the cleanup code in the test infrastructure should do all the cleaning up that is necessary.