### PR TITLE
Do not use unwrap in clean_up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "devicemapper 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "loopdev 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ env_logger="0.3.5"
 libc = "0.2"
 clippy = {version = "*", optional = true}
 mnt = "0.3.1"
+error-chain = "0.11.0"
 
 [dependencies.uuid]
 version = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,10 @@ extern crate serde_json;
 extern crate log;
 
 #[cfg(test)]
+#[macro_use]
+extern crate error_chain;
+
+#[cfg(test)]
 extern crate quickcheck;
 
 pub mod engine;


### PR DESCRIPTION
~When we are trying to clean up the test environment after a panic if
we panic again we no long get anything of use from the unit test.  The
process aborts and we get no back trace or anything which we can
leverage to figure out what happened.~

Updated:

    Before we execute the unit test we will do a sanity check on the
    test environment which will panic and end that unit test if bad.  If
    the environment is good we will run the test capturing the result
    and then clean up capturing its result.  We will then ensure that
    the test and the post clean ups were successful as well.  This
    approach removes the potential of a panic during a panic and allowing
    us to know when we encounter an issue.
