### PR TITLE
Update dbus version 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "clippy 0.0.171 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbus 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devicemapper 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,11 +180,11 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdbus-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -310,6 +310,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -751,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc1914fae6f18ae347320f0ba5e4fc270e17c037ea621fe41ec7e8adf67d11b0"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
-"checksum dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4aee01fb76ada3e5e7ca642ea6664ebf7308a810739ca2aca44909a1191ac254"
+"checksum dbus 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "796755704353dc297bf81c1461b17244d3d1c6fb018e0fb3f43f3223555118f5"
 "checksum devicemapper 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30c22c89a127f41c200830bb295cbf7bbe9055f9807a8ce0b7ad72d302433f67"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
@@ -769,6 +777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
+"checksum libdbus-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e764c95d2e469b780a35e0a7684857369912d99aa35eeb927f204eb63e6e5b6a"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum loopdev 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e46bc95111b97652ff1c74b96f4353785826ba9ff31737b1af94aec020e81a6"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.2"
 authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.com>"]
 
 [dependencies]
-dbus = "0.5.3"
+dbus = "0.6"
 clap = "1"
 nix = "0.9"
 devicemapper = "0.13"

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -34,7 +34,6 @@ use super::pool::create_dbus_pool;
 use super::types::{ActionQueue, DeferredAction, DbusContext, DbusErrorEnum, TData};
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
-use super::util::code_to_message_items;
 use super::util::engine_to_dbus_err_tuple;
 use super::util::get_next_arg;
 use super::util::ok_message_items;

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -36,7 +36,8 @@ use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
 use super::util::engine_to_dbus_err_tuple;
 use super::util::get_next_arg;
-use super::util::ok_message_items;
+use super::util::msg_code_ok;
+use super::util::msg_string_ok;
 use super::util::tuple_to_option;
 
 fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -71,8 +72,9 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                 .map(|bd| create_dbus_blockdev(dbus_context, pool_object_path.clone(), bd.uuid()))
                 .collect::<Vec<_>>();
 
-            let (rc, rs) = ok_message_items();
-            return_message.append3((pool_object_path, bd_object_paths), rc, rs)
+            return_message.append3((pool_object_path, bd_object_paths),
+                                   msg_code_ok(),
+                                   msg_string_ok())
         }
         Err(x) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&x);
@@ -97,8 +99,7 @@ fn destroy_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let pool_uuid = match m.tree.get(&object_path) {
         Some(pool_path) => get_data!(pool_path; default_return; return_message).uuid,
         None => {
-            let (rc, rs) = ok_message_items();
-            return Ok(vec![return_message.append3(default_return, rc, rs)]);
+            return Ok(vec![return_message.append3(default_return, msg_code_ok(), msg_string_ok())]);
         }
     };
 
@@ -108,8 +109,7 @@ fn destroy_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                 .actions
                 .borrow_mut()
                 .push_remove(object_path);
-            let (rc, rs) = ok_message_items();
-            return_message.append3(action, rc, rs)
+            return_message.append3(action, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -139,10 +139,7 @@ fn configure_simulator(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let return_message = message.method_return();
 
     let msg = match result {
-        Ok(_) => {
-            let (rc, rs) = ok_message_items();
-            return_message.append2(rc, rs)
-        }
+        Ok(_) => return_message.append2(msg_code_ok(), msg_string_ok()),
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append2(rc, rs)

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -35,7 +35,7 @@ use super::types::{ActionQueue, DeferredAction, DbusContext, DbusErrorEnum, TDat
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
 use super::util::code_to_message_items;
-use super::util::engine_to_dbus_err;
+use super::util::engine_to_dbus_err_tuple;
 use super::util::get_next_arg;
 use super::util::ok_message_items;
 use super::util::tuple_to_option;
@@ -76,8 +76,7 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3((pool_object_path, bd_object_paths), rc, rs)
         }
         Err(x) => {
-            let (rc, rs) = engine_to_dbus_err(&x);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&x);
             return_message.append3(default_return, rc, rs)
         }
     };
@@ -114,8 +113,7 @@ fn destroy_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(action, rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
         }
     };
@@ -147,8 +145,7 @@ fn configure_simulator(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append2(rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append2(rc, rs)
         }
     };

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -4,7 +4,6 @@
 
 use dbus;
 use dbus::Message;
-use dbus::MessageItem;
 use dbus::arg::IterAppend;
 use dbus::tree::Access;
 use dbus::tree::EmitsChangedSignal;
@@ -119,7 +118,7 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return = MessageItem::Bool(false);
+    let default_return = false;
 
     let blockdev_path = m.tree
         .get(object_path)
@@ -153,7 +152,7 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     }
 
     let (rc, rs) = ok_message_items();
-    let msg = return_message.append3(MessageItem::Bool(id_changed), rc, rs);
+    let msg = return_message.append3(id_changed, rc, rs);
 
     Ok(vec![msg])
 }
@@ -162,11 +161,12 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 /// Get a blockdev property and place it on the D-Bus. The property is
 /// found by means of the getter method which takes a reference to a
 /// blockdev and obtains the property from the blockdev.
-fn get_blockdev_property<F>(i: &mut IterAppend,
-                            p: &PropInfo<MTFn<TData>, TData>,
-                            getter: F)
-                            -> Result<(), MethodErr>
-    where F: Fn(&BlockDev) -> Result<MessageItem, MethodErr>
+fn get_blockdev_property<F, R>(i: &mut IterAppend,
+                               p: &PropInfo<MTFn<TData>, TData>,
+                               getter: F)
+                               -> Result<(), MethodErr>
+    where F: Fn(&BlockDev) -> Result<R, MethodErr>,
+          R: dbus::arg::Append
 {
     let dbus_context = p.tree.get_data();
     let object_path = p.path.get_name();
@@ -216,55 +216,45 @@ fn get_blockdev_property<F>(i: &mut IterAppend,
 fn get_blockdev_devnode(i: &mut IterAppend,
                         p: &PropInfo<MTFn<TData>, TData>)
                         -> Result<(), MethodErr> {
-    get_blockdev_property(i,
-                          p,
-                          |p| Ok(MessageItem::Str(format!("{}", p.devnode().display()))))
+    get_blockdev_property(i, p, |p| Ok(format!("{}", p.devnode().display())))
 }
 
 fn get_blockdev_hardware_info(i: &mut IterAppend,
                               p: &PropInfo<MTFn<TData>, TData>)
                               -> Result<(), MethodErr> {
-    get_blockdev_property(i,
-                          p,
-                          |p| Ok(MessageItem::Str(p.hardware_info().unwrap_or("").to_owned())))
+    get_blockdev_property(i, p, |p| Ok(p.hardware_info().unwrap_or("").to_owned()))
 }
 
 fn get_blockdev_user_info(i: &mut IterAppend,
                           p: &PropInfo<MTFn<TData>, TData>)
                           -> Result<(), MethodErr> {
-    get_blockdev_property(i,
-                          p,
-                          |p| Ok(MessageItem::Str(p.user_info().unwrap_or("").to_owned())))
+    get_blockdev_property(i, p, |p| Ok(p.user_info().unwrap_or("").to_owned()))
 }
 
 fn get_blockdev_initialization_time(i: &mut IterAppend,
                                     p: &PropInfo<MTFn<TData>, TData>)
                                     -> Result<(), MethodErr> {
-    get_blockdev_property(i,
-                          p,
-                          |p| Ok(MessageItem::UInt64(p.initialization_time().timestamp() as u64)))
+    get_blockdev_property(i, p, |p| Ok(p.initialization_time().timestamp() as u64))
 }
 
 fn get_blockdev_physical_size(i: &mut IterAppend,
                               p: &PropInfo<MTFn<TData>, TData>)
                               -> Result<(), MethodErr> {
-    get_blockdev_property(i,
-                          p,
-                          |p| Ok(MessageItem::Str(format!("{}", *p.total_size()))))
+    get_blockdev_property(i, p, |p| Ok(format!("{}", *p.total_size())))
 }
 
 fn get_blockdev_state(i: &mut IterAppend,
                       p: &PropInfo<MTFn<TData>, TData>)
                       -> Result<(), MethodErr> {
-    fn get_state(blockdev: &BlockDev) -> Result<MessageItem, MethodErr> {
-        let state = match blockdev.state() {
+    fn get_state(blockdev: &BlockDev) -> Result<u16, MethodErr> {
+        let state: u16 = match blockdev.state() {
             BlockDevState::Missing => 0,
             BlockDevState::Bad => 1,
             BlockDevState::Spare => 2,
             BlockDevState::NotInUse => 3,
             BlockDevState::InUse => 4,
         };
-        Ok(MessageItem::UInt16(state))
+        Ok(state)
     }
 
     get_blockdev_property(i, p, get_state)

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -23,7 +23,6 @@ use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
-use super::util::code_to_message_items;
 use super::util::get_next_arg;
 use super::util::get_parent;
 use super::util::get_uuid;

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -26,7 +26,8 @@ use super::util::STRATIS_BASE_SERVICE;
 use super::util::get_next_arg;
 use super::util::get_parent;
 use super::util::get_uuid;
-use super::util::ok_message_items;
+use super::util::msg_code_ok;
+use super::util::msg_string_ok;
 
 
 pub fn create_dbus_blockdev<'a>(dbus_context: &DbusContext,
@@ -150,8 +151,7 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                      })?;
     }
 
-    let (rc, rs) = ok_message_items();
-    let msg = return_message.append3(id_changed, rc, rs);
+    let msg = return_message.append3(id_changed, msg_code_ok(), msg_string_ok());
 
     Ok(vec![msg])
 }

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -25,7 +25,7 @@ use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
 use super::util::code_to_message_items;
-use super::util::engine_to_dbus_err;
+use super::util::engine_to_dbus_err_tuple;
 use super::util::get_next_arg;
 use super::util::get_parent;
 use super::util::get_uuid;
@@ -123,8 +123,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(true, rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
         }
     };

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -28,7 +28,8 @@ use super::util::engine_to_dbus_err_tuple;
 use super::util::get_next_arg;
 use super::util::get_parent;
 use super::util::get_uuid;
-use super::util::ok_message_items;
+use super::util::msg_code_ok;
+use super::util::msg_string_ok;
 
 
 pub fn create_dbus_filesystem<'a>(dbus_context: &DbusContext,
@@ -114,13 +115,9 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(default_return, rc, rs)
         }
         Ok(RenameAction::Identity) => {
-            let (rc, rs) = ok_message_items();
-            return_message.append3(default_return, rc, rs)
+            return_message.append3(default_return, msg_code_ok(), msg_string_ok())
         }
-        Ok(RenameAction::Renamed) => {
-            let (rc, rs) = ok_message_items();
-            return_message.append3(true, rc, rs)
-        }
+        Ok(RenameAction::Renamed) => return_message.append3(true, msg_code_ok(), msg_string_ok()),
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -24,7 +24,6 @@ use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
-use super::util::code_to_message_items;
 use super::util::engine_to_dbus_err_tuple;
 use super::util::get_next_arg;
 use super::util::get_parent;
@@ -111,7 +110,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             let error_message = format!("pool {} doesn't know about filesystem {}",
                                         pool_uuid,
                                         filesystem_data.uuid);
-            let (rc, rs) = code_to_message_items(DbusErrorEnum::INTERNAL_ERROR, error_message);
+            let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), error_message);
             return_message.append3(default_return, rc, rs)
         }
         Ok(RenameAction::Identity) => {

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -4,7 +4,6 @@
 
 use dbus;
 use dbus::Message;
-use dbus::MessageItem;
 use dbus::arg::IterAppend;
 use dbus::tree::Access;
 use dbus::tree::EmitsChangedSignal;
@@ -94,7 +93,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return = MessageItem::Bool(false);
+    let default_return = false;
 
     let filesystem_path = m.tree
         .get(object_path)
@@ -121,7 +120,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         }
         Ok(RenameAction::Renamed) => {
             let (rc, rs) = ok_message_items();
-            return_message.append3(MessageItem::Bool(true), rc, rs)
+            return_message.append3(true, rc, rs)
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err(&err);
@@ -136,11 +135,12 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 /// Get a filesystem property and place it on the D-Bus. The property is
 /// found by means of the getter method which takes a reference to a
 /// Filesystem and obtains the property from the filesystem.
-fn get_filesystem_property<F>(i: &mut IterAppend,
-                              p: &PropInfo<MTFn<TData>, TData>,
-                              getter: F)
-                              -> Result<(), MethodErr>
-    where F: Fn(&Filesystem) -> Result<MessageItem, MethodErr>
+fn get_filesystem_property<F, R>(i: &mut IterAppend,
+                                 p: &PropInfo<MTFn<TData>, TData>,
+                                 getter: F)
+                                 -> Result<(), MethodErr>
+    where F: Fn(&Filesystem) -> Result<R, MethodErr>,
+          R: dbus::arg::Append
 {
     let dbus_context = p.tree.get_data();
     let object_path = p.path.get_name();
@@ -190,16 +190,11 @@ fn get_filesystem_property<F>(i: &mut IterAppend,
 fn get_filesystem_devnode(i: &mut IterAppend,
                           p: &PropInfo<MTFn<TData>, TData>)
                           -> Result<(), MethodErr> {
-
-    fn get_devnode(filesystem: &Filesystem) -> Result<MessageItem, MethodErr> {
-        Ok(MessageItem::Str(format!("{}", filesystem.devnode().display())))
-    }
-
-    get_filesystem_property(i, p, get_devnode)
+    get_filesystem_property(i, p, |fs| Ok(format!("{}", fs.devnode().display())))
 }
 
 fn get_filesystem_name(i: &mut IterAppend,
                        p: &PropInfo<MTFn<TData>, TData>)
                        -> Result<(), MethodErr> {
-    get_filesystem_property(i, p, |f| Ok(MessageItem::Str(f.name().to_owned())))
+    get_filesystem_property(i, p, |f| Ok(f.name().to_owned()))
 }

--- a/src/dbus_api/macros.rs
+++ b/src/dbus_api/macros.rs
@@ -11,7 +11,7 @@ macro_rules! get_data {
             data
         } else {
             let message = format!("no data for object path {}", $path.get_name());
-            let (rc, rs) = code_to_message_items(DbusErrorEnum::INTERNAL_ERROR, message);
+            let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), message);
             return Ok(vec![$message.append3($default, rc, rs)]);
         }
     }
@@ -26,7 +26,7 @@ macro_rules! get_parent {
             parent
         } else {
             let message = format!("no path for object path {}", $data.parent);
-            let (rc, rs) = code_to_message_items(DbusErrorEnum::INTERNAL_ERROR, message);
+            let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), message);
             return Ok(vec![$message.append3($default, rc, rs)]);
         }
     }
@@ -41,7 +41,7 @@ macro_rules! get_mut_pool {
         } else {
             let message = format!("engine does not know about pool with uuid {}",
                                   $uuid);
-            let (rc, rs) = code_to_message_items(DbusErrorEnum::INTERNAL_ERROR, message);
+            let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), message);
             return Ok(vec![$message.append3($default, rc, rs)]);
         }
     }

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -29,7 +29,7 @@ use super::blockdev::create_dbus_blockdev;
 use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
-use super::util::{code_to_message_items, engine_to_dbus_err, get_next_arg, get_uuid,
+use super::util::{code_to_message_items, engine_to_dbus_err_tuple, get_next_arg, get_uuid,
                   ok_message_items, STRATIS_BASE_PATH, STRATIS_BASE_SERVICE};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -70,8 +70,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(return_value, rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
         }
     };
@@ -125,8 +124,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(return_value, rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
         }
     };
@@ -170,8 +168,7 @@ fn snapshot_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(fs_object_path, rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
         }
     };
@@ -213,8 +210,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(return_value, rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
         }
     };
@@ -256,8 +252,7 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             return_message.append3(true, rc, rs)
         }
         Err(err) => {
-            let (rc, rs) = engine_to_dbus_err(&err);
-            let (rc, rs) = code_to_message_items(rc, rs);
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
         }
     };

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -29,7 +29,7 @@ use super::blockdev::create_dbus_blockdev;
 use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
-use super::util::{engine_to_dbus_err_tuple, get_next_arg, get_uuid, ok_message_items,
+use super::util::{engine_to_dbus_err_tuple, get_next_arg, get_uuid, msg_code_ok, msg_string_ok,
                   STRATIS_BASE_PATH, STRATIS_BASE_SERVICE};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -66,8 +66,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                 return_value.push((fs_object_path, name));
             }
 
-            let (rc, rs) = ok_message_items();
-            return_message.append3(return_value, rc, rs)
+            return_message.append3(return_value, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -120,8 +119,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                 .iter()
                 .map(|n| format!("{}", n.simple()))
                 .collect();
-            let (rc, rs) = ok_message_items();
-            return_message.append3(return_value, rc, rs)
+            return_message.append3(return_value, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -164,8 +162,7 @@ fn snapshot_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         Ok(uuid) => {
             let fs_object_path: dbus::Path =
                 create_dbus_filesystem(dbus_context, object_path.clone(), uuid);
-            let (rc, rs) = ok_message_items();
-            return_message.append3(fs_object_path, rc, rs)
+            return_message.append3(fs_object_path, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -206,8 +203,7 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                 .map(|uuid| create_dbus_blockdev(dbus_context, object_path.clone(), *uuid))
                 .collect::<Vec<_>>();
 
-            let (rc, rs) = ok_message_items();
-            return_message.append3(return_value, rc, rs)
+            return_message.append3(return_value, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -243,14 +239,8 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), error_message);
             return_message.append3(default_return, rc, rs)
         }
-        Ok(RenameAction::Identity) => {
-            let (rc, rs) = ok_message_items();
-            return_message.append3(false, rc, rs)
-        }
-        Ok(RenameAction::Renamed) => {
-            let (rc, rs) = ok_message_items();
-            return_message.append3(true, rc, rs)
-        }
+        Ok(RenameAction::Identity) => return_message.append3(false, msg_code_ok(), msg_string_ok()),
+        Ok(RenameAction::Renamed) => return_message.append3(true, msg_code_ok(), msg_string_ok()),
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -29,8 +29,8 @@ use super::blockdev::create_dbus_blockdev;
 use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
-use super::util::{code_to_message_items, engine_to_dbus_err_tuple, get_next_arg, get_uuid,
-                  ok_message_items, STRATIS_BASE_PATH, STRATIS_BASE_SERVICE};
+use super::util::{engine_to_dbus_err_tuple, get_next_arg, get_uuid, ok_message_items,
+                  STRATIS_BASE_PATH, STRATIS_BASE_SERVICE};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
@@ -152,7 +152,7 @@ fn snapshot_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         Some(op) => get_data!(op; default_return; return_message).uuid,
         None => {
             let message = format!("no data for object path {}", filesystem);
-            let (rc, rs) = code_to_message_items(DbusErrorEnum::NOTFOUND, message);
+            let (rc, rs) = (u16::from(DbusErrorEnum::NOTFOUND), message);
             return Ok(vec![return_message.append3(default_return, rc, rs)]);
         }
     };
@@ -240,7 +240,7 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
               .rename_pool(pool_uuid, new_name) {
         Ok(RenameAction::NoSource) => {
             let error_message = format!("engine doesn't know about pool {}", &pool_uuid);
-            let (rc, rs) = code_to_message_items(DbusErrorEnum::INTERNAL_ERROR, error_message);
+            let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), error_message);
             return_message.append3(default_return, rc, rs)
         }
         Ok(RenameAction::Identity) => {

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -5,7 +5,6 @@
 use std::error::Error;
 
 use dbus;
-use dbus::MessageItem;
 use dbus::arg::{ArgType, Iter, IterAppend};
 use dbus::tree::{MethodErr, MTFn, PropInfo};
 
@@ -59,18 +58,14 @@ pub fn engine_to_dbus_err(err: &EngineError) -> (DbusErrorEnum, String) {
 
 /// Convenience function to convert a return code and a string to
 /// appropriately typed MessageItems.
-pub fn code_to_message_items(code: DbusErrorEnum, mes: String) -> (MessageItem, MessageItem) {
-    (MessageItem::UInt16(code.into()), MessageItem::Str(mes))
+pub fn code_to_message_items(code: DbusErrorEnum, mes: String) -> (u16, String) {
+    (code.into(), mes)
 }
 
 /// Convenience function to directly yield MessageItems for OK code and message.
-pub fn ok_message_items() -> (MessageItem, MessageItem) {
+pub fn ok_message_items() -> (u16, String) {
     let code = DbusErrorEnum::OK;
     code_to_message_items(code, code.get_error_string().into())
-}
-
-pub fn default_object_path<'a>() -> dbus::Path<'a> {
-    dbus::Path::new("/").expect("'/' is guaranteed to be a valid Path")
 }
 
 /// Get the UUID for an object path.
@@ -85,7 +80,7 @@ pub fn get_uuid(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<
             .as_ref()
             .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
 
-    i.append(MessageItem::Str(format!("{}", data.uuid.simple())));
+    i.append(format!("{}", data.uuid.simple()));
     Ok(())
 }
 
@@ -102,6 +97,6 @@ pub fn get_parent(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Resul
             .as_ref()
             .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
 
-    i.append(MessageItem::ObjectPath(data.parent.clone()));
+    i.append(data.parent.clone());
     Ok(())
 }

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -57,10 +57,14 @@ pub fn engine_to_dbus_err_tuple(err: &EngineError) -> (u16, String) {
     (error.into(), err.description().to_owned())
 }
 
-/// Convenience function to directly yield MessageItems for OK code and message.
-pub fn ok_message_items() -> (u16, String) {
-    let code = DbusErrorEnum::OK;
-    (code.into(), code.get_error_string().into())
+/// Convenience function to get the error value for "OK"
+pub fn msg_code_ok() -> u16 {
+    DbusErrorEnum::OK.into()
+}
+
+/// Convenience function to get the error string for "OK"
+pub fn msg_string_ok() -> String {
+    DbusErrorEnum::OK.get_error_string().to_owned()
 }
 
 /// Get the UUID for an object path.

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -33,8 +33,9 @@ pub fn get_next_arg<'a, T>(iter: &mut Iter<'a>, loc: u16) -> Result<T, MethodErr
 }
 
 
-/// Translates an engine error to a dbus error.
-pub fn engine_to_dbus_err(err: &EngineError) -> (DbusErrorEnum, String) {
+/// Translates an engine error to the (errorcode, string) tuple that Stratis
+/// D-Bus methods return.
+pub fn engine_to_dbus_err_tuple(err: &EngineError) -> (u16, String) {
     #![allow(match_same_arms)]
     let error = match *err {
         EngineError::Engine(ref e, _) => {
@@ -53,7 +54,7 @@ pub fn engine_to_dbus_err(err: &EngineError) -> (DbusErrorEnum, String) {
         EngineError::Serde(_) => DbusErrorEnum::INTERNAL_ERROR,
         EngineError::DM(_) => DbusErrorEnum::INTERNAL_ERROR,
     };
-    (error, err.description().to_owned())
+    (error.into(), err.description().to_owned())
 }
 
 /// Convenience function to convert a return code and a string to

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -57,16 +57,10 @@ pub fn engine_to_dbus_err_tuple(err: &EngineError) -> (u16, String) {
     (error.into(), err.description().to_owned())
 }
 
-/// Convenience function to convert a return code and a string to
-/// appropriately typed MessageItems.
-pub fn code_to_message_items(code: DbusErrorEnum, mes: String) -> (u16, String) {
-    (code.into(), mes)
-}
-
 /// Convenience function to directly yield MessageItems for OK code and message.
 pub fn ok_message_items() -> (u16, String) {
     let code = DbusErrorEnum::OK;
-    code_to_message_items(code, code.get_error_string().into())
+    (code.into(), code.get_error_string().into())
 }
 
 /// Get the UUID for an object path.


### PR DESCRIPTION
This is necessary because we might be needing some new dbus features for #626 so we should get on a current version. In the process, I ran into https://github.com/diwic/dbus-rs/issues/109, which led to removing our use of the deprecated `MessageItem` API.

This is a big change, we're going to want to verify our DBus return signatures are still correct etc. I've looked at GetManagedObjects and Introspect before/after, but haven't run the dbus CI tests.