### PR TITLE
Use common function for CLI calls

### DIFF
--- a/src/engine/strat_engine/util.rs
+++ b/src/engine/strat_engine/util.rs
@@ -11,64 +11,46 @@ use uuid::Uuid;
 
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 
+/// Common function to call a command line utility, returning an Result with an error message which
+/// also includes stdout & stderr if it fails.
+pub fn execute_cmd(cmd: &mut Command, error_msg: &str) -> EngineResult<()> {
+    let result = cmd.output()?;
+    if result.status.success() {
+        Ok(())
+    } else {
+        let std_out_txt = String::from_utf8_lossy(&result.stdout);
+        let std_err_txt = String::from_utf8_lossy(&result.stderr);
+        let err_msg = format!("{} stdout: {} stderr: {}",
+                              error_msg,
+                              std_out_txt,
+                              std_err_txt);
+        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
+    }
+}
 
 /// Create a filesystem on devnode.
 pub fn create_fs(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
-    if Command::new("mkfs.xfs")
-           .arg("-f")
-           .arg("-q")
-           .arg(&devnode)
-           .arg("-m")
-           .arg(format!("uuid={}", uuid))
-           .status()?
-           .success() {
-        Ok(())
-    } else {
-        let err_msg = format!("Failed to create new filesystem at {:?}", devnode);
-        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
-    }
+    return execute_cmd(Command::new("mkfs.xfs")
+                           .arg("-f")
+                           .arg("-q")
+                           .arg(&devnode)
+                           .arg("-m")
+                           .arg(format!("uuid={}", uuid)),
+                       &format!("Failed to create new filesystem at {:?}", devnode));
 }
 
 /// Use the xfs_growfs command to expand a filesystem mounted at the given
 /// mount point.
 pub fn xfs_growfs(mount_point: &Path) -> EngineResult<()> {
-
-    let result = Command::new("xfs_growfs")
-        .arg(mount_point)
-        .arg("-d")
-        .output()?;
-
-    if result.status.success() {
-        Ok(())
-    } else {
-        let std_out_txt = String::from_utf8_lossy(&result.stdout);
-        let std_err_txt = String::from_utf8_lossy(&result.stderr);
-        let err_msg = format!("Failed to expand filesystem {:?} stdout: {} stderr: {}",
-                              mount_point,
-                              std_out_txt,
-                              std_err_txt);
-        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
-    }
+    return execute_cmd(Command::new("xfs_growfs").arg(mount_point).arg("-d"),
+                       &format!("Failed to expand filesystem {:?}", mount_point));
 }
 
 /// Set a new UUID for filesystem on the devnode.
 pub fn set_uuid(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
-
-    let result = Command::new("xfs_admin")
-        .arg("-U")
-        .arg(format!("{}", uuid))
-        .arg(&devnode)
-        .output()?;
-
-    if result.status.success() {
-        Ok(())
-    } else {
-        let std_out_txt = String::from_utf8_lossy(&result.stdout);
-        let std_err_txt = String::from_utf8_lossy(&result.stderr);
-        let err_msg = format!("Failed to set UUID for filesystem {:?} stdout: {} stderr: {}",
-                              devnode,
-                              std_out_txt,
-                              std_err_txt);
-        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
-    }
+    return execute_cmd(Command::new("xfs_admin")
+                           .arg("-U")
+                           .arg(format!("{}", uuid))
+                           .arg(&devnode),
+                       &format!("Failed to set UUID for filesystem {:?}", devnode));
 }

--- a/src/engine/strat_engine/util.rs
+++ b/src/engine/strat_engine/util.rs
@@ -30,27 +30,27 @@ pub fn execute_cmd(cmd: &mut Command, error_msg: &str) -> EngineResult<()> {
 
 /// Create a filesystem on devnode.
 pub fn create_fs(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
-    return execute_cmd(Command::new("mkfs.xfs")
-                           .arg("-f")
-                           .arg("-q")
-                           .arg(&devnode)
-                           .arg("-m")
-                           .arg(format!("uuid={}", uuid)),
-                       &format!("Failed to create new filesystem at {:?}", devnode));
+    execute_cmd(Command::new("mkfs.xfs")
+                    .arg("-f")
+                    .arg("-q")
+                    .arg(&devnode)
+                    .arg("-m")
+                    .arg(format!("uuid={}", uuid)),
+                &format!("Failed to create new filesystem at {:?}", devnode))
 }
 
 /// Use the xfs_growfs command to expand a filesystem mounted at the given
 /// mount point.
 pub fn xfs_growfs(mount_point: &Path) -> EngineResult<()> {
-    return execute_cmd(Command::new("xfs_growfs").arg(mount_point).arg("-d"),
-                       &format!("Failed to expand filesystem {:?}", mount_point));
+    execute_cmd(Command::new("xfs_growfs").arg(mount_point).arg("-d"),
+                &format!("Failed to expand filesystem {:?}", mount_point))
 }
 
 /// Set a new UUID for filesystem on the devnode.
 pub fn set_uuid(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
-    return execute_cmd(Command::new("xfs_admin")
-                           .arg("-U")
-                           .arg(format!("{}", uuid))
-                           .arg(&devnode),
-                       &format!("Failed to set UUID for filesystem {:?}", devnode));
+    execute_cmd(Command::new("xfs_admin")
+                    .arg("-U")
+                    .arg(format!("{}", uuid))
+                    .arg(&devnode),
+                &format!("Failed to set UUID for filesystem {:?}", devnode))
 }


### PR DESCRIPTION
Create a common function which captures stdout & stderr so that we
never see it get spewed out to the journal unless we want to have it
in a logged error message.  This also has a nice side effect of
removing copy & pasted code.

Note: This is a follow on to changes introduced with 94dbe87.  Corrects https://github.com/stratis-storage/stratisd/issues/670

Signed-off-by: Tony Asleson <tasleson@redhat.com>