### PR TITLE
Rework Table and remove HasName/HasUuid traits

### DIFF
--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -118,7 +118,7 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
 
     let mut engine = dbus_context.engine.borrow_mut();
-    let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
+    let (pool_name, pool) = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
     let id_changed = {
         let blockdev = pool.get_mut_blockdev(blockdev_data.uuid)
@@ -132,7 +132,7 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     // FIXME: engine should decide to save state, not this function
     if id_changed {
-        pool.save_state()
+        pool.save_state(&pool_name)
             .map_err(|err| {
                          MethodErr::failed(&format!("Could not save state for object path {}: {}",
                                                     object_path,
@@ -183,7 +183,7 @@ fn get_blockdev_property<F, R>(i: &mut IterAppend,
         .uuid;
 
     let engine = dbus_context.engine.borrow();
-    let pool =
+    let (_, pool) =
         engine
             .get_pool(pool_uuid)
             .ok_or_else(|| {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -11,6 +11,8 @@ use uuid::Uuid;
 
 use devicemapper::{Device, Sectors};
 
+use super::structures::Name;
+
 use super::errors::EngineResult;
 use super::types::{BlockDevState, DevUuid, FilesystemUuid, PoolUuid, RenameAction};
 
@@ -19,7 +21,7 @@ pub trait HasUuid: Debug {
 }
 
 pub trait HasName: Debug {
-    fn name(&self) -> &str;
+    fn name(&self) -> Name;
 }
 
 pub trait Filesystem: HasName + HasUuid {

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -16,13 +16,13 @@ macro_rules! calculate_redundancy {
 
 macro_rules! get_pool {
     ( $s:ident; $uuid:ident ) => {
-        $s.pools.get_by_uuid($uuid).map(|p| p as &Pool)
+        $s.pools.get_by_uuid($uuid).map(|(name, p)| (name.clone(), p as &Pool))
     }
 }
 
 macro_rules! get_mut_pool {
     ( $s:ident; $uuid:ident ) => {
-        $s.pools.get_mut_by_uuid($uuid).map(|p| p as &mut Pool)
+        $s.pools.get_mut_by_uuid($uuid).map(|(name, p)| (name.clone(), p as &mut Pool))
     }
 }
 
@@ -30,11 +30,11 @@ macro_rules! rename_filesystem_pre {
     ( $s:ident; $uuid:ident; $new_name:ident ) => {
         {
             let old_name = match $s.filesystems.get_by_uuid($uuid) {
-                Some(filesystem) => filesystem.name().to_owned(),
+                Some((name, _)) => name,
                 None => return Ok(RenameAction::NoSource),
             };
 
-            if old_name == $new_name {
+            if &*old_name == $new_name {
                 return Ok(RenameAction::Identity);
             }
 
@@ -50,11 +50,11 @@ macro_rules! rename_pool_pre {
     ( $s:ident; $uuid:ident; $new_name:ident ) => {
         {
             let old_name = match $s.pools.get_by_uuid($uuid) {
-                Some(pool) => pool.name().to_owned(),
+                Some((name, _)) => name,
                 None => return Ok(RenameAction::NoSource),
             };
 
-            if old_name == $new_name {
+            if &*old_name == $new_name {
                 return Ok(RenameAction::Identity);
             }
 
@@ -68,9 +68,9 @@ macro_rules! rename_pool_pre {
 
 macro_rules! check_engine {
     ( $s:ident ) => {
-        for pool in &mut $s.pools {
+        for (pool_name, _, pool) in &mut $s.pools {
             // FIXME: It is not really correct to ignore result of pool.check().
-            let _ = pool.check();
+            let _ = pool.check(pool_name);
         }
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -21,6 +21,7 @@ pub use self::types::FilesystemUuid;
 pub use self::types::PoolUuid;
 pub use self::types::Redundancy;
 pub use self::types::RenameAction;
+pub use self::types::Name;
 
 #[macro_use]
 mod macros;

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -11,8 +11,8 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, IEC, Sectors};
 
-use super::super::engine::{BlockDev, HasUuid};
-use super::super::types::{BlockDevState, DevUuid};
+use super::super::engine::BlockDev;
+use super::super::types::BlockDevState;
 
 use super::randomization::Randomizer;
 
@@ -21,7 +21,6 @@ use super::randomization::Randomizer;
 pub struct SimDev {
     devnode: PathBuf,
     rdm: Rc<RefCell<Randomizer>>,
-    uuid: Uuid,
     user_info: Option<String>,
     hardware_info: Option<String>,
     initialization_time: u64,
@@ -57,22 +56,16 @@ impl BlockDev for SimDev {
     }
 }
 
-impl HasUuid for SimDev {
-    fn uuid(&self) -> DevUuid {
-        self.uuid
-    }
-}
-
 impl SimDev {
     /// Generates a new device from any devnode.
-    pub fn new(rdm: Rc<RefCell<Randomizer>>, devnode: &Path) -> SimDev {
-        SimDev {
-            devnode: devnode.to_owned(),
-            rdm,
-            uuid: Uuid::new_v4(),
-            user_info: None,
-            hardware_info: None,
-            initialization_time: Utc::now().timestamp() as u64,
-        }
+    pub fn new(rdm: Rc<RefCell<Randomizer>>, devnode: &Path) -> (Uuid, SimDev) {
+        (Uuid::new_v4(),
+         SimDev {
+             devnode: devnode.to_owned(),
+             rdm,
+             user_info: None,
+             hardware_info: None,
+             initialization_time: Utc::now().timestamp() as u64,
+         })
     }
 }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -118,7 +118,7 @@ impl Engine for SimEngine {
     }
 
     fn pools(&self) -> Vec<&Pool> {
-        self.pools.into_iter().map(|x| x as &Pool).collect()
+        self.pools.iter().map(|x| x as &Pool).collect()
     }
 
     fn get_eventable(&mut self) -> EngineResult<Option<Box<Eventable>>> {

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -16,7 +16,7 @@ use devicemapper::Device;
 use super::super::engine::{Engine, Eventable, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
-use super::super::types::{PoolUuid, Name, Redundancy, RenameAction};
+use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
 
 use super::pool::SimPool;
 use super::randomization::Randomizer;

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -5,25 +5,27 @@
 use std::path::PathBuf;
 
 use super::super::engine::{Filesystem, HasName, HasUuid};
+use super::super::structures::Name;
 use super::super::types::FilesystemUuid;
+
 
 #[derive(Debug)]
 pub struct SimFilesystem {
     fs_id: FilesystemUuid,
-    name: String,
+    name: Name,
 }
 
 impl SimFilesystem {
     pub fn new(fs_id: FilesystemUuid, name: &str) -> SimFilesystem {
         SimFilesystem {
             fs_id,
-            name: name.to_owned(),
+            name: Name::new(name.to_owned()),
         }
     }
 
     /// Set the name of this filesystem to name.
     pub fn rename(&mut self, name: &str) {
-        self.name = name.to_owned();
+        self.name = Name::new(name.to_owned());
     }
 }
 
@@ -34,8 +36,8 @@ impl Filesystem for SimFilesystem {
 }
 
 impl HasName for SimFilesystem {
-    fn name(&self) -> &str {
-        &self.name
+    fn name(&self) -> Name {
+        self.name.clone()
     }
 }
 

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -2,47 +2,27 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use rand;
+
 use std::path::PathBuf;
 
-use super::super::engine::{Filesystem, HasName, HasUuid};
-use super::super::structures::Name;
-use super::super::types::FilesystemUuid;
-
+use super::super::engine::Filesystem;
 
 #[derive(Debug)]
 pub struct SimFilesystem {
-    fs_id: FilesystemUuid,
-    name: Name,
+    rand: u32,
 }
 
 impl SimFilesystem {
-    pub fn new(fs_id: FilesystemUuid, name: &str) -> SimFilesystem {
-        SimFilesystem {
-            fs_id,
-            name: Name::new(name.to_owned()),
-        }
-    }
-
-    /// Set the name of this filesystem to name.
-    pub fn rename(&mut self, name: &str) {
-        self.name = Name::new(name.to_owned());
+    pub fn new() -> SimFilesystem {
+        SimFilesystem { rand: rand::random::<u32>() }
     }
 }
 
 impl Filesystem for SimFilesystem {
     fn devnode(&self) -> PathBuf {
-        ["/dev/stratis", &self.name].into_iter().collect()
-    }
-}
-
-impl HasName for SimFilesystem {
-    fn name(&self) -> Name {
-        self.name.clone()
-    }
-}
-
-impl HasUuid for SimFilesystem {
-    fn uuid(&self) -> FilesystemUuid {
-        self.fs_id
+        ["/dev/stratis", &format!("random-{}", self.rand)]
+            .into_iter()
+            .collect()
     }
 }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -16,7 +16,7 @@ use devicemapper::{IEC, Sectors};
 
 use super::super::engine::{BlockDev, Filesystem, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::structures::Table;
+use super::super::structures::{Name, Table};
 use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, Redundancy, RenameAction};
 
 use super::blockdev::SimDev;
@@ -25,7 +25,7 @@ use super::randomization::Randomizer;
 
 #[derive(Debug)]
 pub struct SimPool {
-    name: String,
+    name: Name,
     pool_uuid: PoolUuid,
     pub block_devs: HashMap<DevUuid, SimDev>,
     pub filesystems: Table<SimFilesystem>,
@@ -48,7 +48,7 @@ impl SimPool {
                      (bd.uuid(), bd)
                  });
         SimPool {
-            name: name.to_owned(),
+            name: Name::new(name.to_owned()),
             pool_uuid: Uuid::new_v4(),
             block_devs: HashMap::from_iter(device_pairs),
             filesystems: Table::default(),
@@ -151,7 +151,7 @@ impl Pool for SimPool {
     }
 
     fn rename(&mut self, name: &str) {
-        self.name = name.to_owned();
+        self.name = Name::new(name.to_owned());
     }
 
     fn total_physical_size(&self) -> Sectors {
@@ -212,8 +212,8 @@ impl HasUuid for SimPool {
 }
 
 impl HasName for SimPool {
-    fn name(&self) -> &str {
-        &self.name
+    fn name(&self) -> Name {
+        self.name.clone()
     }
 }
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -166,7 +166,7 @@ impl Pool for SimPool {
 
     fn filesystems(&self) -> Vec<&Filesystem> {
         self.filesystems
-            .into_iter()
+            .iter()
             .map(|x| x as &Filesystem)
             .collect()
     }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -14,10 +14,10 @@ use uuid::Uuid;
 
 use devicemapper::{IEC, Sectors};
 
-use super::super::engine::{BlockDev, Filesystem, HasName, HasUuid, Pool};
+use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::structures::{Name, Table};
-use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, Redundancy, RenameAction};
+use super::super::structures::Table;
+use super::super::types::{DevUuid, FilesystemUuid, Name, PoolUuid, Redundancy, RenameAction};
 
 use super::blockdev::SimDev;
 use super::filesystem::SimFilesystem;
@@ -25,8 +25,6 @@ use super::randomization::Randomizer;
 
 #[derive(Debug)]
 pub struct SimPool {
-    name: Name,
-    pool_uuid: PoolUuid,
     pub block_devs: HashMap<DevUuid, SimDev>,
     pub filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
@@ -35,29 +33,22 @@ pub struct SimPool {
 
 impl SimPool {
     pub fn new(rdm: &Rc<RefCell<Randomizer>>,
-               name: &str,
                paths: &[&Path],
                redundancy: Redundancy)
-               -> SimPool {
+               -> (PoolUuid, SimPool) {
 
         let devices: HashSet<_, RandomState> = HashSet::from_iter(paths);
-        let device_pairs = devices
-            .iter()
-            .map(|p| {
-                     let bd = SimDev::new(Rc::clone(rdm), p);
-                     (bd.uuid(), bd)
-                 });
-        SimPool {
-            name: Name::new(name.to_owned()),
-            pool_uuid: Uuid::new_v4(),
-            block_devs: HashMap::from_iter(device_pairs),
-            filesystems: Table::default(),
-            redundancy,
-            rdm: Rc::clone(rdm),
-        }
+        let device_pairs = devices.iter().map(|p| SimDev::new(Rc::clone(rdm), p));
+        (Uuid::new_v4(),
+         SimPool {
+             block_devs: HashMap::from_iter(device_pairs),
+             filesystems: Table::default(),
+             redundancy,
+             rdm: Rc::clone(rdm),
+         })
     }
 
-    pub fn check(&mut self) -> EngineResult<()> {
+    pub fn check(&mut self, _name: &Name) -> EngineResult<()> {
         Ok(())
     }
 
@@ -68,6 +59,7 @@ impl SimPool {
 
 impl Pool for SimPool {
     fn create_filesystems<'a, 'b>(&'a mut self,
+                                  _pool_name: &str,
                                   specs: &[(&'b str, Option<Sectors>)])
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>> {
         let names: HashMap<_, _> = HashMap::from_iter(specs.iter().map(|&tup| (tup.0, tup.1)));
@@ -80,22 +72,24 @@ impl Pool for SimPool {
         let mut result = Vec::new();
         for name in names.keys() {
             let uuid = Uuid::new_v4();
-            let new_filesystem = SimFilesystem::new(uuid, name);
-            self.filesystems.insert(new_filesystem);
+            let new_filesystem = SimFilesystem::new();
+            self.filesystems
+                .insert(Name::new((&**name).to_owned()), uuid, new_filesystem);
             result.push((*name, uuid));
         }
 
         Ok(result)
     }
 
-    fn add_blockdevs(&mut self, paths: &[&Path], _force: bool) -> EngineResult<Vec<DevUuid>> {
+    fn add_blockdevs(&mut self,
+                     _pool_name: &str,
+                     paths: &[&Path],
+                     _force: bool)
+                     -> EngineResult<Vec<DevUuid>> {
         let devices: HashSet<_, RandomState> = HashSet::from_iter(paths);
         let device_pairs: Vec<_> = devices
             .iter()
-            .map(|p| {
-                     let bd = SimDev::new(Rc::clone(&self.rdm), p);
-                     (bd.uuid(), bd)
-                 })
+            .map(|p| SimDev::new(Rc::clone(&self.rdm), p))
             .collect();
         let ret_uuids = device_pairs.iter().map(|&(uuid, _)| uuid).collect();
         self.block_devs.extend(device_pairs);
@@ -108,6 +102,7 @@ impl Pool for SimPool {
     }
 
     fn destroy_filesystems<'a>(&'a mut self,
+                               _pool_name: &str,
                                fs_uuids: &[FilesystemUuid])
                                -> EngineResult<Vec<FilesystemUuid>> {
         let mut removed = Vec::new();
@@ -120,38 +115,38 @@ impl Pool for SimPool {
     }
 
     fn rename_filesystem(&mut self,
+                         _pool_name: &str,
                          uuid: FilesystemUuid,
                          new_name: &str)
                          -> EngineResult<RenameAction> {
         rename_filesystem_pre!(self; uuid; new_name);
 
-        let mut filesystem =
+        let (_, filesystem) =
             self.filesystems
                 .remove_by_uuid(uuid)
                 .expect("Must succeed since self.filesystems.get_by_uuid() returned a value");
 
-        filesystem.rename(new_name);
-        self.filesystems.insert(filesystem);
+        self.filesystems
+            .insert(Name::new(new_name.to_owned()), uuid, filesystem);
+
         Ok(RenameAction::Renamed)
     }
 
     fn snapshot_filesystem(&mut self,
+                           _pool_name: &str,
                            origin_uuid: FilesystemUuid,
                            snapshot_name: &str)
                            -> EngineResult<FilesystemUuid> {
         let uuid = Uuid::new_v4();
         let snapshot = match self.get_filesystem(origin_uuid) {
-            Some(_filesystem) => SimFilesystem::new(uuid, snapshot_name),
+            Some(_filesystem) => SimFilesystem::new(),
             None => {
                 return Err(EngineError::Engine(ErrorEnum::NotFound, origin_uuid.to_string()));
             }
         };
-        self.filesystems.insert(snapshot);
+        self.filesystems
+            .insert(Name::new(snapshot_name.to_owned()), uuid, snapshot);
         Ok(uuid)
-    }
-
-    fn rename(&mut self, name: &str) {
-        self.name = Name::new(name.to_owned());
     }
 
     fn total_physical_size(&self) -> Sectors {
@@ -164,29 +159,29 @@ impl Pool for SimPool {
         Ok(Sectors(0))
     }
 
-    fn filesystems(&self) -> Vec<&Filesystem> {
+    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)> {
         self.filesystems
             .iter()
-            .map(|x| x as &Filesystem)
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &Filesystem))
             .collect()
     }
 
-    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem> {
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)> {
         self.filesystems
             .get_by_uuid(uuid)
-            .map(|p| p as &Filesystem)
+            .map(|(name, p)| (name, p as &Filesystem))
     }
 
-    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<&mut Filesystem> {
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut Filesystem)> {
         self.filesystems
             .get_mut_by_uuid(uuid)
-            .map(|p| p as &mut Filesystem)
+            .map(|(name, p)| (name, p as &mut Filesystem))
     }
 
-    fn blockdevs(&self) -> Vec<&BlockDev> {
+    fn blockdevs(&self) -> Vec<(DevUuid, &BlockDev)> {
         self.block_devs
-            .values()
-            .map(|bd| bd as &BlockDev)
+            .iter()
+            .map(|(uuid, bd)| (*uuid, bd as &BlockDev))
             .collect()
     }
 
@@ -200,23 +195,10 @@ impl Pool for SimPool {
             .map(|p| p as &mut BlockDev)
     }
 
-    fn save_state(&mut self) -> EngineResult<()> {
+    fn save_state(&mut self, _pool_name: &str) -> EngineResult<()> {
         Ok(())
     }
 }
-
-impl HasUuid for SimPool {
-    fn uuid(&self) -> PoolUuid {
-        self.pool_uuid
-    }
-}
-
-impl HasName for SimPool {
-    fn name(&self) -> Name {
-        self.name.clone()
-    }
-}
-
 
 #[cfg(test)]
 mod tests {
@@ -236,9 +218,10 @@ mod tests {
     /// Renaming a filesystem on an empty pool always works
     fn rename_empty() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None, false).unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        assert!(match pool.rename_filesystem(Uuid::new_v4(), "new_name") {
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        assert!(match pool.rename_filesystem(pool_name, Uuid::new_v4(), "new_name") {
                     Ok(RenameAction::NoSource) => true,
                     _ => false,
                 });
@@ -248,10 +231,12 @@ mod tests {
     /// Renaming a filesystem to another filesystem should work if new name not taken
     fn rename_happens() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None, false).unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        let infos = pool.create_filesystems(&[("old_name", None)]).unwrap();
-        assert!(match pool.rename_filesystem(infos[0].1, "new_name") {
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        let infos = pool.create_filesystems(pool_name, &[("old_name", None)])
+            .unwrap();
+        assert!(match pool.rename_filesystem(pool_name, infos[0].1, "new_name") {
                     Ok(RenameAction::Renamed) => true,
                     _ => false,
                 });
@@ -263,12 +248,13 @@ mod tests {
         let old_name = "old_name";
         let new_name = "new_name";
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None, false).unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        let results = pool.create_filesystems(&[(old_name, None), (new_name, None)])
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        let results = pool.create_filesystems(pool_name, &[(old_name, None), (new_name, None)])
             .unwrap();
         let old_uuid = results.iter().find(|x| x.0 == old_name).unwrap().1;
-        assert!(match pool.rename_filesystem(old_uuid, new_name) {
+        assert!(match pool.rename_filesystem(pool_name, old_uuid, new_name) {
                     Err(EngineError::Engine(ErrorEnum::AlreadyExists, _)) => true,
                     _ => false,
                 });
@@ -279,9 +265,10 @@ mod tests {
     fn rename_no_op() {
         let new_name = "new_name";
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None, false).unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        assert!(match pool.rename_filesystem(Uuid::new_v4(), new_name) {
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        assert!(match pool.rename_filesystem(pool_name, Uuid::new_v4(), new_name) {
                     Ok(RenameAction::NoSource) => true,
                     _ => false,
                 });
@@ -291,9 +278,10 @@ mod tests {
     /// Removing an empty list of filesystems should always succeed
     fn destroy_fs_empty() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None, false).unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        assert!(match pool.destroy_filesystems(&[]) {
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        assert!(match pool.destroy_filesystems(pool_name, &[]) {
                     Ok(names) => names.is_empty(),
                     _ => false,
                 });
@@ -303,20 +291,24 @@ mod tests {
     /// Removing a non-empty list of filesystems should succeed on empty pool
     fn destroy_fs_some() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None, false).unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        assert!(pool.destroy_filesystems(&[Uuid::new_v4()]).is_ok());
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        assert!(pool.destroy_filesystems(pool_name, &[Uuid::new_v4()])
+                    .is_ok());
     }
 
     #[test]
     /// Removing a non-empty list of filesystems should succeed on any pool
     fn destroy_fs_any() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None, false).unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        let fs_results = pool.create_filesystems(&[("fs_name", None)]).unwrap();
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        let fs_results = pool.create_filesystems(pool_name, &[("fs_name", None)])
+            .unwrap();
         let fs_uuid = fs_results[0].1;
-        assert!(match pool.destroy_filesystems(&[fs_uuid, Uuid::new_v4()]) {
+        assert!(match pool.destroy_filesystems(pool_name, &[fs_uuid, Uuid::new_v4()]) {
                     Ok(filesystems) => filesystems == vec![fs_uuid],
                     _ => false,
                 });
@@ -326,11 +318,10 @@ mod tests {
     /// Creating an empty list of filesystems should succeed, always
     fn create_fs_none() {
         let mut engine = SimEngine::default();
-        let uuid = engine
-            .create_pool("pool_name", &[], None, false)
-            .unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        assert!(match pool.create_filesystems(&[]) {
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        assert!(match pool.create_filesystems(pool_name, &[]) {
                     Ok(names) => names.is_empty(),
                     _ => false,
                 });
@@ -340,11 +331,10 @@ mod tests {
     /// Creating a non-empty list of filesystems always succeeds.
     fn create_fs_some() {
         let mut engine = SimEngine::default();
-        let uuid = engine
-            .create_pool("pool_name", &[], None, false)
-            .unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        assert!(match pool.create_filesystems(&[("name", None)]) {
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        assert!(match pool.create_filesystems(pool_name, &[("name", None)]) {
                     Ok(names) => (names.len() == 1) & (names[0].0 == "name"),
                     _ => false,
                 });
@@ -355,12 +345,12 @@ mod tests {
     fn create_fs_conflict() {
         let fs_name = "fs_name";
         let mut engine = SimEngine::default();
-        let uuid = engine
-            .create_pool("pool_name", &[], None, false)
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        pool.create_filesystems(pool_name, &[(fs_name, None)])
             .unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        pool.create_filesystems(&[(fs_name, None)]).unwrap();
-        assert!(match pool.create_filesystems(&[(fs_name, None)]) {
+        assert!(match pool.create_filesystems(pool_name, &[(fs_name, None)]) {
                     Err(EngineError::Engine(ErrorEnum::AlreadyExists, _)) => true,
                     _ => false,
                 });
@@ -371,11 +361,10 @@ mod tests {
     fn create_fs_dups() {
         let fs_name = "fs_name";
         let mut engine = SimEngine::default();
-        let uuid = engine
-            .create_pool("pool_name", &[], None, false)
-            .unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
-        assert!(match pool.create_filesystems(&[(fs_name, None), (fs_name, None)]) {
+        let pool_name = "pool_name";
+        let uuid = engine.create_pool(pool_name, &[], None, false).unwrap();
+        let pool = engine.get_mut_pool(uuid).unwrap().1;
+        assert!(match pool.create_filesystems(pool_name, &[(fs_name, None), (fs_name, None)]) {
                     Ok(names) => (names.len() == 1) & (names[0].0 == fs_name),
                     _ => false,
                 });
@@ -388,9 +377,9 @@ mod tests {
         let uuid = engine
             .create_pool("pool_name", &[], None, false)
             .unwrap();
-        let pool = engine.get_mut_pool(uuid).unwrap();
+        let (pool_name, pool) = engine.get_mut_pool(uuid).unwrap();
         let devices = [Path::new("/s/a"), Path::new("/s/b")];
-        assert!(match pool.add_blockdevs(&devices, false) {
+        assert!(match pool.add_blockdevs(&*pool_name, &devices, false) {
                     Ok(devs) => devs.len() == devices.len(),
                     _ => false,
                 });

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, TimeZone, Utc};
 
 use devicemapper::{Device, Sectors};
 
-use super::super::engine::{BlockDev, HasUuid};
+use super::super::engine::BlockDev;
 use super::super::errors::EngineResult;
 use super::super::types::{BlockDevState, DevUuid, PoolUuid};
 
@@ -136,12 +136,6 @@ impl StratBlockDev {
     /// self.max_metadata_size() < self.metadata_size()
     pub fn max_metadata_size(&self) -> Sectors {
         self.bda.max_data_size()
-    }
-}
-
-impl HasUuid for StratBlockDev {
-    fn uuid(&self) -> DevUuid {
-        self.bda.dev_uuid()
     }
 }
 

--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -257,10 +257,10 @@ impl BlockDevMgr {
     }
 
     /// Get references to managed blockdevs.
-    pub fn blockdevs(&self) -> Vec<&BlockDev> {
+    pub fn blockdevs(&self) -> Vec<(DevUuid, &BlockDev)> {
         self.block_devs
-            .values()
-            .map(|bd| bd as &BlockDev)
+            .iter()
+            .map(|(uuid, bd)| (*uuid, bd as &BlockDev))
             .collect()
     }
 

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -4,8 +4,7 @@
 
 // Code to handle cleanup after a failed operation.
 
-use super::super::engine::HasUuid;
-use super::super::errors::{EngineError, EngineResult, ErrorEnum};
+use super::super::errors::{EngineResult, EngineError, ErrorEnum};
 use super::super::structures::Table;
 
 use super::blockdev::StratBlockDev;
@@ -35,10 +34,9 @@ pub fn wipe_blockdevs(blockdevs: &[StratBlockDev]) -> EngineResult<()> {
 /// Teardown pools.
 pub fn teardown_pools(pools: Table<StratPool>) -> EngineResult<()> {
     let mut untorndown_pools = Vec::new();
-    for pool in pools {
-        let pool_uuid = pool.uuid();
+    for (_, uuid, pool) in pools {
         pool.teardown()
-            .unwrap_or_else(|_| untorndown_pools.push(pool_uuid));
+            .unwrap_or_else(|_| untorndown_pools.push(uuid));
     }
     if untorndown_pools.is_empty() {
         Ok(())

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -6,6 +6,7 @@
 
 use super::super::engine::HasUuid;
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
+use super::super::structures::Table;
 
 use super::blockdev::StratBlockDev;
 use super::pool::StratPool;
@@ -32,7 +33,7 @@ pub fn wipe_blockdevs(blockdevs: &[StratBlockDev]) -> EngineResult<()> {
 }
 
 /// Teardown pools.
-pub fn teardown_pools(pools: Vec<StratPool>) -> EngineResult<()> {
+pub fn teardown_pools(pools: Table<StratPool>) -> EngineResult<()> {
     let mut untorndown_pools = Vec::new();
     for pool in pools {
         let pool_uuid = pool.uuid();

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -4,7 +4,7 @@
 
 // Code to handle cleanup after a failed operation.
 
-use super::super::errors::{EngineResult, EngineError, ErrorEnum};
+use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
 
 use super::blockdev::StratBlockDev;

--- a/src/engine/strat_engine/devlinks.rs
+++ b/src/engine/strat_engine/devlinks.rs
@@ -57,7 +57,6 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>
     }
 
     for leftover in existing_dirs {
-        //pool_removed(str::from_utf8(leftover.as_bytes()).expect("is valid utf8"))?
         pool_removed(&Name::new(leftover))?
     }
 

--- a/src/engine/strat_engine/devlinks.rs
+++ b/src/engine/strat_engine/devlinks.rs
@@ -31,11 +31,11 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a Pool>>(pools: I) -> EngineResul
         .collect::<Result<HashSet<_>, _>>()?;
 
     for pool in pools {
-        if !existing_dirs.remove(pool.name()) {
-            pool_added(pool.name())?;
+        if !existing_dirs.remove(&*pool.name()) {
+            pool_added(&*pool.name())?;
         }
 
-        let pool_path: PathBuf = vec![DEV_PATH, pool.name()].iter().collect();
+        let pool_path: PathBuf = vec![DEV_PATH, &*pool.name()].iter().collect();
 
         let mut existing_files = fs::read_dir(pool_path)?
             .map(|dir_e| {
@@ -44,12 +44,12 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a Pool>>(pools: I) -> EngineResul
             .collect::<Result<HashSet<_>, _>>()?;
 
         for fs in pool.filesystems() {
-            filesystem_added(pool.name(), fs.name(), &fs.devnode())?;
-            existing_files.remove(fs.name());
+            filesystem_added(&*pool.name(), &*fs.name(), &fs.devnode())?;
+            existing_files.remove(&*fs.name());
         }
 
         for leftover in existing_files {
-            filesystem_removed(pool.name(), &leftover)?;
+            filesystem_removed(&*pool.name(), &leftover)?;
         }
     }
 

--- a/src/engine/strat_engine/devlinks.rs
+++ b/src/engine/strat_engine/devlinks.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use super::super::errors::EngineResult;
 
 use engine::Pool;
+use engine::types::{Name, PoolUuid};
 
 pub const DEV_PATH: &str = "/dev/stratis";
 
@@ -19,7 +20,9 @@ pub const DEV_PATH: &str = "/dev/stratis";
 /// or filesystem.
 // Don't just remove and recreate everything in case there are processes
 // (e.g. user shells) with the current working directory within the tree.
-pub fn setup_devlinks<'a, I: Iterator<Item = &'a Pool>>(pools: I) -> EngineResult<()> {
+pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>
+    (pools: I)
+     -> EngineResult<()> {
     if let Err(err) = fs::create_dir(DEV_PATH) {
         if err.kind() != ErrorKind::AlreadyExists {
             return Err(From::from(err));
@@ -30,12 +33,12 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a Pool>>(pools: I) -> EngineResul
         .map(|dir_e| dir_e.and_then(|d| Ok(d.file_name().into_string().expect("Unix is utf-8"))))
         .collect::<Result<HashSet<_>, _>>()?;
 
-    for pool in pools {
-        if !existing_dirs.remove(&*pool.name()) {
-            pool_added(&*pool.name())?;
+    for &(ref pool_name, _, pool) in pools {
+        if !existing_dirs.remove(&pool_name.to_owned()) {
+            pool_added(pool_name)?;
         }
 
-        let pool_path: PathBuf = vec![DEV_PATH, &*pool.name()].iter().collect();
+        let pool_path: PathBuf = vec![DEV_PATH, pool_name].iter().collect();
 
         let mut existing_files = fs::read_dir(pool_path)?
             .map(|dir_e| {
@@ -43,18 +46,19 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a Pool>>(pools: I) -> EngineResul
                  })
             .collect::<Result<HashSet<_>, _>>()?;
 
-        for fs in pool.filesystems() {
-            filesystem_added(&*pool.name(), &*fs.name(), &fs.devnode())?;
-            existing_files.remove(&*fs.name());
+        for (fs_name, _, fs) in pool.filesystems() {
+            filesystem_added(pool_name, &fs_name, &fs.devnode())?;
+            existing_files.remove(&fs_name.to_owned());
         }
 
         for leftover in existing_files {
-            filesystem_removed(&*pool.name(), &leftover)?;
+            filesystem_removed(pool_name, &leftover)?;
         }
     }
 
     for leftover in existing_dirs {
-        pool_removed(str::from_utf8(leftover.as_bytes()).expect("is valid utf8"))?
+        //pool_removed(str::from_utf8(leftover.as_bytes()).expect("is valid utf8"))?
+        pool_removed(&Name::new(leftover))?
     }
 
     Ok(())

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -134,7 +134,7 @@ impl Engine for StratEngine {
         let pool = StratPool::initialize(&dm, name, blockdev_paths, redundancy, force)?;
 
         let uuid = pool.uuid();
-        devlinks::pool_added(pool.name())?;
+        devlinks::pool_added(&*pool.name())?;
         self.pools.insert(pool);
 
         Ok(uuid)
@@ -173,7 +173,7 @@ impl Engine for StratEngine {
                     //
                     // We will also _not_ exit the daemon as we do in initialize as we were
                     // previously up and running for some duration of time.
-                    if !self.pools.contains_name(pool.name()) {
+                    if !self.pools.contains_name(&*pool.name()) {
                         self.pools.insert(pool);
                         Some(pool_uuid)
                     } else {
@@ -313,7 +313,7 @@ mod test {
         engine.teardown().unwrap();
 
         let engine = StratEngine::initialize().unwrap();
-        let pool_name: String = engine.get_pool(uuid1).unwrap().name().into();
+        let pool_name: String = engine.get_pool(uuid1).unwrap().name().to_owned();
         assert_eq!(pool_name, name2);
     }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -10,10 +10,10 @@ use std::path::{Path, PathBuf};
 
 use devicemapper::{DM, Device, DmNameBuf};
 
-use super::super::engine::{Engine, Eventable, HasName, HasUuid, Pool};
+use super::super::engine::{Engine, Eventable, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
-use super::super::types::{DevUuid, PoolUuid, Redundancy, RenameAction};
+use super::super::types::{DevUuid, Name, PoolUuid, Redundancy, RenameAction};
 
 use super::cleanup::teardown_pools;
 use super::devlinks;
@@ -83,8 +83,8 @@ impl StratEngine {
 
         for (pool_uuid, devices) in &pools {
             match StratPool::setup(&dm, *pool_uuid, devices) {
-                Ok(pool) => {
-                    let evicted = table.insert(pool);
+                Ok((pool_name, pool)) => {
+                    let evicted = table.insert(pool_name, *pool_uuid, pool);
                     if evicted.is_some() {
                         // TODO: update state machine on failure.
                         let _ = teardown_pools(table);
@@ -105,7 +105,7 @@ impl StratEngine {
             watched_dev_last_event_nrs: HashMap::new(),
         };
 
-        devlinks::setup_devlinks(engine.pools().into_iter())?;
+        devlinks::setup_devlinks(engine.pools().iter())?;
 
         Ok(engine)
     }
@@ -131,12 +131,11 @@ impl Engine for StratEngine {
         }
 
         let dm = DM::new()?;
-        let pool = StratPool::initialize(&dm, name, blockdev_paths, redundancy, force)?;
+        let (uuid, pool) = StratPool::initialize(&dm, name, blockdev_paths, redundancy, force)?;
 
-        let uuid = pool.uuid();
-        devlinks::pool_added(&*pool.name())?;
-        self.pools.insert(pool);
-
+        let name = Name::new(name.to_owned());
+        devlinks::pool_added(&name)?;
+        self.pools.insert(name, uuid, pool);
         Ok(uuid)
     }
 
@@ -166,15 +165,16 @@ impl Engine for StratEngine {
                     .expect("We just retrieved or created a HashMap");
                 devices.insert(device, dev_node);
 
-                let rc = if let Ok(pool) = StratPool::setup(&dm, pool_uuid, &devices) {
+                let rc = if let Ok((pool_name, pool)) =
+                    StratPool::setup(&dm, pool_uuid, &devices) {
                     // We know we have a unique uuid, but the pools table requires a unique name too
                     // so we will ensure unique before we insert as we don't want to change the
                     // existing state if we have a conflict.
                     //
                     // We will also _not_ exit the daemon as we do in initialize as we were
                     // previously up and running for some duration of time.
-                    if !self.pools.contains_name(&*pool.name()) {
-                        self.pools.insert(pool);
+                    if !self.pools.contains_name(&pool_name) {
+                        self.pools.insert(pool_name, pool_uuid, pool);
                         Some(pool_uuid)
                     } else {
                         let dev_paths = devices
@@ -187,7 +187,7 @@ impl Engine for StratEngine {
 
                         error!("udev add: duplicate pool name {:?} for uuid {:?}, \
                                 devices[{}], failing to setup complete pool!",
-                               pool.name(),
+                               pool_name,
                                pool_uuid,
                                dev_paths);
                         if let Err(e) = pool.teardown() {
@@ -208,7 +208,7 @@ impl Engine for StratEngine {
     }
 
     fn destroy_pool(&mut self, uuid: PoolUuid) -> EngineResult<bool> {
-        if let Some(pool) = self.pools.get_by_uuid(uuid) {
+        if let Some((_, pool)) = self.pools.get_by_uuid(uuid) {
             if pool.has_filesystems() {
                 return Err(EngineError::Engine(ErrorEnum::Busy,
                                                "filesystems remaining on pool".into()));
@@ -217,10 +217,11 @@ impl Engine for StratEngine {
             return Ok(false);
         }
 
-        let pool = self.pools
-            .remove_by_uuid(uuid)
-            .expect("Must succeed since self.pools.get_by_uuid() returned a value");
-        let pool_name = pool.name().to_owned();
+        let (pool_name, pool) =
+            self.pools
+                .remove_by_uuid(uuid)
+                .expect("Must succeed since self.pools.get_by_uuid() returned a value");
+
         pool.destroy()?;
         devlinks::pool_removed(&pool_name)?;
         Ok(true)
@@ -229,27 +230,27 @@ impl Engine for StratEngine {
     fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> EngineResult<RenameAction> {
         let old_name = rename_pool_pre!(self; uuid; new_name);
 
-        let mut pool = self.pools
-            .remove_by_uuid(uuid)
-            .expect("Must succeed since self.pools.get_by_uuid() returned a value");
-        pool.rename(new_name);
+        let (_, mut pool) =
+            self.pools
+                .remove_by_uuid(uuid)
+                .expect("Must succeed since self.pools.get_by_uuid() returned a value");
 
-        if let Err(err) = pool.write_metadata() {
-            pool.rename(&old_name);
-            self.pools.insert(pool);
+        let new_name = Name::new(new_name.to_owned());
+        if let Err(err) = pool.write_metadata(&new_name) {
+            self.pools.insert(old_name, uuid, pool);
             Err(err)
         } else {
-            self.pools.insert(pool);
-            devlinks::pool_renamed(&old_name, new_name)?;
+            self.pools.insert(new_name.clone(), uuid, pool);
+            devlinks::pool_renamed(&old_name, &new_name)?;
             Ok(RenameAction::Renamed)
         }
     }
 
-    fn get_pool(&self, uuid: PoolUuid) -> Option<&Pool> {
+    fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &Pool)> {
         get_pool!(self; uuid)
     }
 
-    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<&mut Pool> {
+    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<(Name, &mut Pool)> {
         get_mut_pool!(self; uuid)
     }
 
@@ -261,8 +262,11 @@ impl Engine for StratEngine {
         check_engine!(self);
     }
 
-    fn pools(&self) -> Vec<&Pool> {
-        self.pools.iter().map(|x| x as &Pool).collect()
+    fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)> {
+        self.pools
+            .iter()
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &Pool))
+            .collect()
     }
 
     fn get_eventable(&mut self) -> EngineResult<Option<Box<Eventable>>> {
@@ -278,10 +282,10 @@ impl Engine for StratEngine {
                  })
             .collect();
 
-        for pool in &mut self.pools {
+        for (pool_name, _, pool) in &mut self.pools {
             for dm_name in pool.get_eventing_dev_names() {
                 if device_list.get(&dm_name) > self.watched_dev_last_event_nrs.get(&dm_name) {
-                    pool.event_on(&dm_name)?;
+                    pool.event_on(pool_name, &dm_name)?;
                 }
             }
         }
@@ -313,7 +317,7 @@ mod test {
         engine.teardown().unwrap();
 
         let engine = StratEngine::initialize().unwrap();
-        let pool_name: String = engine.get_pool(uuid1).unwrap().name().to_owned();
+        let pool_name: String = engine.get_pool(uuid1).unwrap().0.to_owned();
         assert_eq!(pool_name, name2);
     }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -85,9 +85,9 @@ impl StratEngine {
             match StratPool::setup(&dm, *pool_uuid, devices) {
                 Ok(pool) => {
                     let evicted = table.insert(pool);
-                    if !evicted.is_empty() {
+                    if evicted.is_some() {
                         // TODO: update state machine on failure.
-                        let _ = teardown_pools(table.empty());
+                        let _ = teardown_pools(table);
                         let err_msg = "found two pools with the same name";
                         return Err(EngineError::Engine(ErrorEnum::Invalid, err_msg.into()));
                     }
@@ -112,7 +112,7 @@ impl StratEngine {
 
     /// Teardown Stratis, preparatory to a shutdown.
     pub fn teardown(self) -> EngineResult<()> {
-        teardown_pools(self.pools.empty())
+        teardown_pools(self.pools)
     }
 }
 
@@ -262,7 +262,7 @@ impl Engine for StratEngine {
     }
 
     fn pools(&self) -> Vec<&Pool> {
-        self.pools.into_iter().map(|x| x as &Pool).collect()
+        self.pools.iter().map(|x| x as &Pool).collect()
     }
 
     fn get_eventable(&mut self) -> EngineResult<Option<Box<Eventable>>> {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -14,6 +14,7 @@ use devicemapper::{DM, Device, DmName, DmNameBuf, Sectors};
 
 use super::super::engine::{BlockDev, Filesystem, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
+use super::super::structures::Name;
 use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, Redundancy, RenameAction};
 
 use super::blockdevmgr::BlockDevMgr;
@@ -26,7 +27,7 @@ pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE};
 
 #[derive(Debug)]
 pub struct StratPool {
-    name: String,
+    name: Name,
     pool_uuid: PoolUuid,
     block_devs: BlockDevMgr,
     redundancy: Redundancy,
@@ -62,7 +63,7 @@ impl StratPool {
         };
 
         let mut pool = StratPool {
-            name: name.to_owned(),
+            name: Name::new(name.to_owned()),
             pool_uuid,
             block_devs: block_mgr,
             redundancy,
@@ -93,7 +94,7 @@ impl StratPool {
                                        &bd_mgr)?;
 
         Ok(StratPool {
-               name: metadata.name,
+               name: Name::new(metadata.name),
                pool_uuid: uuid,
                block_devs: bd_mgr,
                redundancy: Redundancy::NONE,
@@ -219,7 +220,7 @@ impl Pool for StratPool {
     }
 
     fn rename(&mut self, name: &str) {
-        self.name = name.to_owned();
+        self.name = Name::new(name.to_owned());
     }
 
     fn total_physical_size(&self) -> Sectors {
@@ -272,15 +273,15 @@ impl HasUuid for StratPool {
 }
 
 impl HasName for StratPool {
-    fn name(&self) -> &str {
-        &self.name
+    fn name(&self) -> Name {
+        self.name.clone()
     }
 }
 
 impl Recordable<PoolSave> for StratPool {
     fn record(&self) -> PoolSave {
         PoolSave {
-            name: self.name.clone(),
+            name: self.name.to_owned(),
             block_devs: self.block_devs.record(),
             flex_devs: self.thin_pool.record(),
             thinpool_dev: self.thin_pool.record(),

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -12,10 +12,9 @@ use uuid::Uuid;
 
 use devicemapper::{DM, Device, DmName, DmNameBuf, Sectors};
 
-use super::super::engine::{BlockDev, Filesystem, HasName, HasUuid, Pool};
+use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::structures::Name;
-use super::super::types::{DevUuid, FilesystemUuid, PoolUuid, Redundancy, RenameAction};
+use super::super::types::{DevUuid, FilesystemUuid, Name, PoolUuid, Redundancy, RenameAction};
 
 use super::blockdevmgr::BlockDevMgr;
 use super::metadata::MIN_MDA_SECTORS;
@@ -27,8 +26,6 @@ pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE};
 
 #[derive(Debug)]
 pub struct StratPool {
-    name: Name,
-    pool_uuid: PoolUuid,
     block_devs: BlockDevMgr,
     redundancy: Redundancy,
     thin_pool: ThinPool,
@@ -43,7 +40,7 @@ impl StratPool {
                       paths: &[&Path],
                       redundancy: Redundancy,
                       force: bool)
-                      -> EngineResult<StratPool> {
+                      -> EngineResult<(PoolUuid, StratPool)> {
         let pool_uuid = Uuid::new_v4();
 
         let mut block_mgr = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, force)?;
@@ -63,23 +60,21 @@ impl StratPool {
         };
 
         let mut pool = StratPool {
-            name: Name::new(name.to_owned()),
-            pool_uuid,
             block_devs: block_mgr,
             redundancy,
             thin_pool: thinpool,
         };
 
-        pool.write_metadata()?;
+        pool.write_metadata(&Name::new(name.to_owned()))?;
 
-        Ok(pool)
+        Ok((pool_uuid, pool))
     }
 
     /// Setup a StratPool using its UUID and the list of devnodes it has.
     pub fn setup(dm: &DM,
                  uuid: PoolUuid,
                  devnodes: &HashMap<Device, PathBuf>)
-                 -> EngineResult<StratPool> {
+                 -> EngineResult<(Name, StratPool)> {
         let metadata = get_metadata(uuid, devnodes)?
             .ok_or_else(|| {
                             EngineError::Engine(ErrorEnum::NotFound,
@@ -93,29 +88,28 @@ impl StratPool {
                                        &metadata.flex_devs,
                                        &bd_mgr)?;
 
-        Ok(StratPool {
-               name: Name::new(metadata.name),
-               pool_uuid: uuid,
-               block_devs: bd_mgr,
-               redundancy: Redundancy::NONE,
-               thin_pool: thinpool,
-           })
+        Ok((Name::new(metadata.name),
+            StratPool {
+                block_devs: bd_mgr,
+                redundancy: Redundancy::NONE,
+                thin_pool: thinpool,
+            }))
     }
 
     /// Write current metadata to pool members.
-    pub fn write_metadata(&mut self) -> EngineResult<()> {
-        let data = serde_json::to_string(&self.record())?;
+    pub fn write_metadata(&mut self, name: &str) -> EngineResult<()> {
+        let data = serde_json::to_string(&self.record(name))?;
         self.block_devs.save_state(data.as_bytes())
     }
 
-    pub fn check(&mut self) -> EngineResult<()> {
+    pub fn check(&mut self, name: &Name) -> EngineResult<()> {
         // FIXME: The context should not be created here as this is not
         // a public method. Ideally the context should be created in the
         // invoking method, Engine::check(). However, since we hope that
         // method will go away entirely, we just fix half of the problem
         // with this method, and leave the rest alone.
         if self.thin_pool.check(&DM::new()?, &mut self.block_devs)? {
-            self.write_metadata()?;
+            self.write_metadata(name)?;
         }
         Ok(())
     }
@@ -137,20 +131,30 @@ impl StratPool {
     /// Called when a DM device in this pool has generated an event.
     // TODO: Just check the device that evented. Currently checks
     // everything.
-    pub fn event_on(&mut self, dm_name: &DmName) -> EngineResult<()> {
+    pub fn event_on(&mut self, pool_name: &Name, dm_name: &DmName) -> EngineResult<()> {
         assert!(self.thin_pool
                     .get_eventing_dev_names()
                     .iter()
                     .any(|x| dm_name == &**x));
         if self.thin_pool.check(&DM::new()?, &mut self.block_devs)? {
-            self.write_metadata()?;
+            self.write_metadata(pool_name)?;
         }
         Ok(())
+    }
+
+    pub fn record(&self, name: &str) -> PoolSave {
+        PoolSave {
+            name: name.to_owned(),
+            block_devs: self.block_devs.record(),
+            flex_devs: self.thin_pool.record(),
+            thinpool_dev: self.thin_pool.record(),
+        }
     }
 }
 
 impl Pool for StratPool {
     fn create_filesystems<'a, 'b>(&'a mut self,
+                                  pool_name: &str,
                                   specs: &[(&'b str, Option<Sectors>)])
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>> {
         let names: HashMap<_, _> = HashMap::from_iter(specs.iter().map(|&tup| (tup.0, tup.1)));
@@ -164,20 +168,23 @@ impl Pool for StratPool {
 
         // TODO: Roll back on filesystem initialization failure.
         let dm = DM::new()?;
-        let pool_name = self.name().to_owned();
         let mut result = Vec::new();
         for (name, size) in names {
             let fs_uuid = self.thin_pool
-                .create_filesystem(&pool_name, name, &dm, size)?;
+                .create_filesystem(pool_name, name, &dm, size)?;
             result.push((name, fs_uuid));
         }
 
         Ok(result)
     }
 
-    fn add_blockdevs(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<DevUuid>> {
+    fn add_blockdevs(&mut self,
+                     pool_name: &str,
+                     paths: &[&Path],
+                     force: bool)
+                     -> EngineResult<Vec<DevUuid>> {
         let bdev_info = self.block_devs.add(paths, force)?;
-        self.write_metadata()?;
+        self.write_metadata(pool_name)?;
         Ok(bdev_info)
     }
 
@@ -188,14 +195,14 @@ impl Pool for StratPool {
     }
 
     fn destroy_filesystems<'a>(&'a mut self,
+                               pool_name: &str,
                                fs_uuids: &[FilesystemUuid])
                                -> EngineResult<Vec<FilesystemUuid>> {
         let dm = DM::new()?;
 
         let mut removed = Vec::new();
         for &uuid in fs_uuids {
-            self.thin_pool
-                .destroy_filesystem(&dm, &self.name, uuid)?;
+            self.thin_pool.destroy_filesystem(&dm, pool_name, uuid)?;
             removed.push(uuid);
         }
 
@@ -203,24 +210,21 @@ impl Pool for StratPool {
     }
 
     fn rename_filesystem(&mut self,
+                         pool_name: &str,
                          uuid: FilesystemUuid,
                          new_name: &str)
                          -> EngineResult<RenameAction> {
         self.thin_pool
-            .rename_filesystem(&self.name, uuid, new_name)
+            .rename_filesystem(pool_name, uuid, new_name)
     }
 
     fn snapshot_filesystem(&mut self,
+                           pool_name: &str,
                            origin_uuid: FilesystemUuid,
                            snapshot_name: &str)
                            -> EngineResult<FilesystemUuid> {
-        let pool_name = self.name().to_owned();
         self.thin_pool
-            .snapshot_filesystem(&DM::new()?, &pool_name, origin_uuid, snapshot_name)
-    }
-
-    fn rename(&mut self, name: &str) {
-        self.name = Name::new(name.to_owned());
+            .snapshot_filesystem(&DM::new()?, pool_name, origin_uuid, snapshot_name)
     }
 
     fn total_physical_size(&self) -> Sectors {
@@ -233,23 +237,23 @@ impl Pool for StratPool {
             .and_then(|v| Ok(v + self.block_devs.metadata_size()))
     }
 
-    fn filesystems(&self) -> Vec<&Filesystem> {
+    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)> {
         self.thin_pool.filesystems()
     }
 
-    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<&Filesystem> {
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)> {
         self.thin_pool
             .get_filesystem_by_uuid(uuid)
-            .map(|fs| fs as &Filesystem)
+            .map(|(name, fs)| (name, fs as &Filesystem))
     }
 
-    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<&mut Filesystem> {
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut Filesystem)> {
         self.thin_pool
             .get_mut_filesystem_by_uuid(uuid)
-            .map(|fs| fs as &mut Filesystem)
+            .map(|(name, fs)| (name, fs as &mut Filesystem))
     }
 
-    fn blockdevs(&self) -> Vec<&BlockDev> {
+    fn blockdevs(&self) -> Vec<(DevUuid, &BlockDev)> {
         self.block_devs.blockdevs()
     }
 
@@ -261,31 +265,8 @@ impl Pool for StratPool {
         self.block_devs.get_mut_blockdev_by_uuid(uuid)
     }
 
-    fn save_state(&mut self) -> EngineResult<()> {
-        self.write_metadata()
-    }
-}
-
-impl HasUuid for StratPool {
-    fn uuid(&self) -> PoolUuid {
-        self.pool_uuid
-    }
-}
-
-impl HasName for StratPool {
-    fn name(&self) -> Name {
-        self.name.clone()
-    }
-}
-
-impl Recordable<PoolSave> for StratPool {
-    fn record(&self) -> PoolSave {
-        PoolSave {
-            name: self.name.to_owned(),
-            block_devs: self.block_devs.record(),
-            flex_devs: self.thin_pool.record(),
-            thinpool_dev: self.thin_pool.record(),
-        }
+    fn save_state(&mut self, pool_name: &str) -> EngineResult<()> {
+        self.write_metadata(pool_name)
     }
 }
 
@@ -312,14 +293,14 @@ mod tests {
         let dm = DM::new().unwrap();
 
         let name1 = "name1";
-        let pool1 = StratPool::initialize(&dm, &name1, paths1, Redundancy::NONE, false).unwrap();
-        let uuid1 = pool1.uuid();
-        let metadata1 = pool1.record();
+        let (uuid1, pool1) = StratPool::initialize(&dm, &name1, paths1, Redundancy::NONE, false)
+            .unwrap();
+        let metadata1 = pool1.record(name1);
 
         let name2 = "name2";
-        let pool2 = StratPool::initialize(&dm, &name2, paths2, Redundancy::NONE, false).unwrap();
-        let uuid2 = pool2.uuid();
-        let metadata2 = pool2.record();
+        let (uuid2, pool2) = StratPool::initialize(&dm, &name2, paths2, Redundancy::NONE, false)
+            .unwrap();
+        let metadata2 = pool2.record(name2);
 
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 2);

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -13,12 +13,11 @@ use nix::sys::statvfs::statvfs;
 use nix::sys::statvfs::vfs::Statvfs;
 use tempdir::TempDir;
 
-use super::super::super::engine::{Filesystem, HasName, HasUuid};
+use super::super::super::engine::Filesystem;
 use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::super::structures::Name;
-use super::super::super::types::FilesystemUuid;
+use super::super::super::types::{FilesystemUuid, Name};
 
-use super::super::serde_structs::{FilesystemSave, Recordable};
+use super::super::serde_structs::FilesystemSave;
 
 use super::util::{create_fs, set_uuid, xfs_growfs};
 
@@ -28,8 +27,6 @@ pub const FILESYSTEM_LOWATER: Sectors = Sectors(256 * IEC::Mi / (SECTOR_SIZE as 
 
 #[derive(Debug)]
 pub struct StratFilesystem {
-    name: Name,
-    fs_id: FilesystemUuid,
     thin_dev: ThinDev,
 }
 
@@ -42,23 +39,16 @@ pub enum FilesystemStatus {
 
 impl StratFilesystem {
     /// Create a StratFilesystem on top of the given ThinDev.
-    pub fn initialize(fs_id: FilesystemUuid,
-                      name: &str,
-                      thin_dev: ThinDev)
-                      -> EngineResult<StratFilesystem> {
-        let fs = StratFilesystem::setup(fs_id, name, thin_dev);
+    pub fn initialize(fs_id: FilesystemUuid, thin_dev: ThinDev) -> EngineResult<StratFilesystem> {
+        let fs = StratFilesystem::setup(thin_dev);
 
         create_fs(&fs.devnode(), fs_id)?;
         Ok(fs)
     }
 
     /// Build a StratFilesystem that includes the ThinDev and related info.
-    pub fn setup(fs_id: FilesystemUuid, name: &str, thin_dev: ThinDev) -> StratFilesystem {
-        StratFilesystem {
-            fs_id,
-            name: Name::new(name.to_owned()),
-            thin_dev,
-        }
+    pub fn setup(thin_dev: ThinDev) -> StratFilesystem {
+        StratFilesystem { thin_dev }
     }
 
     /// Create a snapshot of the filesystem. Return the resulting filesystem/ThinDev
@@ -67,11 +57,13 @@ impl StratFilesystem {
     /// Mounting a filesystem with a duplicate UUID would require special handling,
     /// so snapshot_fs_uuid is used to update the new snapshot filesystem so it has
     /// a unique UUID.
+    #[allow(too_many_arguments)]
     pub fn snapshot(&self,
                     dm: &DM,
                     thin_pool: &ThinPoolDev,
                     snapshot_name: &str,
                     snapshot_dmname: &DmName,
+                    snapshot_fs_name: &Name,
                     snapshot_fs_uuid: FilesystemUuid,
                     snapshot_thin_id: ThinDevId)
                     -> EngineResult<StratFilesystem> {
@@ -100,13 +92,13 @@ impl StratFilesystem {
                     umount(tmp_dir.path())?;
                 }
                 set_uuid(&thin_dev.devnode(), snapshot_fs_uuid)?;
-                Ok(StratFilesystem::setup(snapshot_fs_uuid, snapshot_name, thin_dev))
+                Ok(StratFilesystem::setup(thin_dev))
             }
             Err(e) => {
                 Err(EngineError::Engine(ErrorEnum::Error,
                                         format!("failed to create {} snapshot for {} - {}",
                                                 snapshot_name,
-                                                self.name,
+                                                snapshot_fs_name,
                                                 e)))
             }
         }
@@ -188,44 +180,25 @@ impl StratFilesystem {
         Ok(())
     }
 
-    /// Set the name of this filesystem to name.
-    pub fn rename(&mut self, name: &str) {
-        self.name = Name::new(name.to_owned());
-    }
-
     /// Destroy the filesystem.
     pub fn destroy(self, dm: &DM, thin_pool: &ThinPoolDev) -> EngineResult<()> {
         self.thin_dev.destroy(dm, thin_pool)?;
         Ok(())
     }
-}
 
-impl HasName for StratFilesystem {
-    fn name(&self) -> Name {
-        self.name.clone()
-    }
-}
-
-impl HasUuid for StratFilesystem {
-    fn uuid(&self) -> FilesystemUuid {
-        self.fs_id
+    pub fn record(&self, name: &Name, uuid: FilesystemUuid) -> FilesystemSave {
+        FilesystemSave {
+            name: name.to_owned(),
+            uuid: uuid,
+            thin_id: self.thin_dev.id(),
+            size: self.thin_dev.size(),
+        }
     }
 }
 
 impl Filesystem for StratFilesystem {
     fn devnode(&self) -> PathBuf {
         self.thin_dev.devnode()
-    }
-}
-
-impl Recordable<FilesystemSave> for StratFilesystem {
-    fn record(&self) -> FilesystemSave {
-        FilesystemSave {
-            name: self.name.to_owned(),
-            uuid: self.fs_id,
-            thin_id: self.thin_dev.id(),
-            size: self.thin_dev.size(),
-        }
     }
 }
 

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -15,6 +15,7 @@ use tempdir::TempDir;
 
 use super::super::super::engine::{Filesystem, HasName, HasUuid};
 use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
+use super::super::super::structures::Name;
 use super::super::super::types::FilesystemUuid;
 
 use super::super::serde_structs::{FilesystemSave, Recordable};
@@ -27,8 +28,8 @@ pub const FILESYSTEM_LOWATER: Sectors = Sectors(256 * IEC::Mi / (SECTOR_SIZE as 
 
 #[derive(Debug)]
 pub struct StratFilesystem {
+    name: Name,
     fs_id: FilesystemUuid,
-    name: String,
     thin_dev: ThinDev,
 }
 
@@ -55,7 +56,7 @@ impl StratFilesystem {
     pub fn setup(fs_id: FilesystemUuid, name: &str, thin_dev: ThinDev) -> StratFilesystem {
         StratFilesystem {
             fs_id,
-            name: name.to_owned(),
+            name: Name::new(name.to_owned()),
             thin_dev,
         }
     }
@@ -189,7 +190,7 @@ impl StratFilesystem {
 
     /// Set the name of this filesystem to name.
     pub fn rename(&mut self, name: &str) {
-        self.name = name.to_owned();
+        self.name = Name::new(name.to_owned());
     }
 
     /// Destroy the filesystem.
@@ -200,8 +201,8 @@ impl StratFilesystem {
 }
 
 impl HasName for StratFilesystem {
-    fn name(&self) -> &str {
-        &self.name
+    fn name(&self) -> Name {
+        self.name.clone()
     }
 }
 
@@ -220,7 +221,7 @@ impl Filesystem for StratFilesystem {
 impl Recordable<FilesystemSave> for StratFilesystem {
     fn record(&self) -> FilesystemSave {
         FilesystemSave {
-            name: self.name.clone(),
+            name: self.name.to_owned(),
             uuid: self.fs_id,
             thin_id: self.thin_dev.id(),
             size: self.thin_dev.size(),

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -18,12 +18,11 @@ use serde_json;
 
 use devicemapper::{DM, DmDevice, LinearDev};
 
-use super::super::super::engine::HasUuid;
 use super::super::super::errors::EngineResult;
-use super::super::super::types::{FilesystemUuid, PoolUuid};
+use super::super::super::types::{FilesystemUuid, Name, PoolUuid};
 
 use super::super::devlinks::DEV_PATH;
-use super::super::serde_structs::{FilesystemSave, Recordable};
+use super::super::serde_structs::FilesystemSave;
 
 use super::util::create_fs;
 
@@ -122,11 +121,15 @@ impl MetadataVol {
     // Write to a temp file and then rename to actual filename, to
     // ensure file contents are not truncated if operation is
     // interrupted.
-    pub fn save_fs(&self, fs: &StratFilesystem) -> EngineResult<()> {
-        let data = serde_json::to_string(&fs.record())?;
+    pub fn save_fs(&self,
+                   name: &Name,
+                   uuid: FilesystemUuid,
+                   fs: &StratFilesystem)
+                   -> EngineResult<()> {
+        let data = serde_json::to_string(&fs.record(name, uuid))?;
         let path = self.mount_pt
             .join(FILESYSTEM_DIR)
-            .join(fs.uuid().simple().to_string())
+            .join(uuid.simple().to_string())
             .with_extension("json");
 
         let temp_path = path.clone().with_extension("temp");

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -499,7 +499,9 @@ impl ThinPool {
 
         let new_filesystem = StratFilesystem::initialize(fs_uuid, name, thin_dev)?;
         self.mdv.save_fs(&new_filesystem)?;
-        devlinks::filesystem_added(pool_name, new_filesystem.name(), &new_filesystem.devnode())?;
+        devlinks::filesystem_added(pool_name,
+                                   &*new_filesystem.name(),
+                                   &new_filesystem.devnode())?;
         self.filesystems.insert(new_filesystem);
 
         Ok(fs_uuid)
@@ -534,7 +536,9 @@ impl ThinPool {
             }
         };
         self.mdv.save_fs(&new_filesystem)?;
-        devlinks::filesystem_added(pool_name, new_filesystem.name(), &new_filesystem.devnode())?;
+        devlinks::filesystem_added(pool_name,
+                                   &*new_filesystem.name(),
+                                   &new_filesystem.devnode())?;
         self.filesystems.insert(new_filesystem);
 
         Ok(snapshot_fs_uuid)
@@ -850,7 +854,8 @@ mod tests {
                                    &mgr)
                 .unwrap();
 
-        assert_eq!(pool.get_filesystem_by_uuid(fs_uuid).unwrap().name(), name2);
+        assert_eq!(&*pool.get_filesystem_by_uuid(fs_uuid).unwrap().name(),
+                   name2);
     }
 
     #[test]

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -254,7 +254,7 @@ impl ThinPool {
         let mut fs_table = Table::default();
         for fs in filesystems {
             let evicted = fs_table.insert(fs);
-            if !evicted.is_empty() {
+            if evicted.is_some() {
                 let err_msg = "filesystems with duplicate UUID or name specified in metadata";
                 return Err(EngineError::Engine(ErrorEnum::Invalid, err_msg.into()));
             }
@@ -332,7 +332,7 @@ impl ThinPool {
 
         let filesystems = self.filesystems
             .borrow_mut()
-            .into_iter()
+            .iter_mut()
             .map(|fs| fs.check(dm))
             .collect::<EngineResult<Vec<_>>>()?;
 
@@ -349,7 +349,7 @@ impl ThinPool {
     pub fn teardown(self, dm: &DM) -> EngineResult<()> {
         // Must succeed in tearing down all filesystems before the
         // thinpool..
-        for fs in self.filesystems.empty() {
+        for fs in self.filesystems {
             fs.teardown(dm)?;
         }
         self.thin_pool.teardown(dm)?;
@@ -475,7 +475,7 @@ impl ThinPool {
 
     pub fn filesystems(&self) -> Vec<&Filesystem> {
         self.filesystems
-            .into_iter()
+            .iter()
             .map(|x| x as &Filesystem)
             .collect()
     }

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -2,49 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::borrow::Borrow;
 use std::collections::{hash_map, HashMap};
-use std::fmt;
 use std::iter::IntoIterator;
-use std::ops::Deref;
-use std::rc::Rc;
 
 use uuid::Uuid;
 
-use super::engine::{HasName, HasUuid};
-
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub struct Name(Rc<String>);
-
-impl Name {
-    pub fn new(name: String) -> Name {
-        Name(Rc::new(name))
-    }
-
-    pub fn to_owned(&self) -> String {
-        self.0.deref().to_owned()
-    }
-}
-
-impl Deref for Name {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Borrow<str> for Name {
-    fn borrow(&self) -> &str {
-        &**self.0
-    }
-}
-
-impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+use engine::Name;
 
 /// Map UUID and name to T items.
 #[derive(Debug)]

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -323,7 +323,7 @@ mod tests {
         // t now contains the inserted thing.
         assert!(t.contains_name(&name));
         assert!(t.contains_uuid(uuid));
-        assert!(t.get_by_uuid(uuid).unwrap().1.stuff == thing_key);
+        assert_eq!(t.get_by_uuid(uuid).unwrap().1.stuff, thing_key);
 
         // Add another thing with the same keys.
         let thing2 = TestThing::new(&name, uuid);
@@ -334,14 +334,14 @@ mod tests {
         // It has displaced the old thing.
         assert!(displaced.is_some());
         let ref displaced_item = displaced.unwrap();
-        assert!(&*displaced_item.0 == name);
-        assert!(displaced_item.1 == uuid);
+        assert_eq!(&*displaced_item.0, name);
+        assert_eq!(displaced_item.1, uuid);
 
         // But it contains a thing with the same keys.
         assert!(t.contains_name(&name));
         assert!(t.contains_uuid(uuid));
-        assert!(t.get_by_uuid(uuid).unwrap().1.stuff == thing_key2);
-        assert!(t.len() == 1);
+        assert_eq!(t.get_by_uuid(uuid).unwrap().1.stuff, thing_key2);
+        assert_eq!(t.len(), 1);
     }
 
     #[test]
@@ -375,17 +375,17 @@ mod tests {
         // The items displaced consist exactly of the first item.
         assert!(displaced.is_some());
         let ref displaced_item = displaced.unwrap();
-        assert!(&*displaced_item.0 == name);
-        assert!(displaced_item.1 == uuid);
-        assert!(displaced_item.2.stuff == thing_key);
+        assert_eq!(&*displaced_item.0, name);
+        assert_eq!(displaced_item.1, uuid);
+        assert_eq!(displaced_item.2.stuff, thing_key);
 
         // The table contains the new item and has no memory of the old.
         assert!(t.contains_name(&name));
         assert!(t.contains_uuid(uuid2));
         assert!(!t.contains_uuid(uuid));
-        assert!(t.get_by_uuid(uuid2).unwrap().1.stuff == thing_key2);
-        assert!(t.get_by_name(&name).unwrap().1.stuff == thing_key2);
-        assert!(t.len() == 1);
+        assert_eq!(t.get_by_uuid(uuid2).unwrap().1.stuff, thing_key2);
+        assert_eq!(t.get_by_name(&name).unwrap().1.stuff, thing_key2);
+        assert_eq!(t.len(), 1);
     }
 
     #[test]
@@ -419,16 +419,16 @@ mod tests {
         // The items displaced consist exactly of the first item.
         assert!(displaced.is_some());
         let ref displaced_item = displaced.unwrap();
-        assert!(&*displaced_item.0 == name);
-        assert!(displaced_item.1 == uuid);
-        assert!(displaced_item.2.stuff == thing_key);
+        assert_eq!(&*displaced_item.0, name);
+        assert_eq!(displaced_item.1, uuid);
+        assert_eq!(displaced_item.2.stuff, thing_key);
 
         // The table contains the new item and has no memory of the old.
         assert!(t.contains_uuid(uuid));
         assert!(t.contains_name(name2));
         assert!(!t.contains_name(name));
-        assert!(t.get_by_uuid(uuid).unwrap().1.stuff == thing_key2);
-        assert!(t.get_by_name(&name2).unwrap().1.stuff == thing_key2);
-        assert!(t.len() == 1);
+        assert_eq!(t.get_by_uuid(uuid).unwrap().1.stuff, thing_key2);
+        assert_eq!(t.get_by_name(&name2).unwrap().1.stuff, thing_key2);
+        assert_eq!(t.len(), 1);
     }
 }

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -190,15 +190,9 @@ impl<T> Table<T> {
 
     /// Removes the item corresponding to the uuid if there is one.
     pub fn remove_by_uuid(&mut self, uuid: Uuid) -> Option<(Name, T)> {
-        if let Some(item) = self.items.remove(&uuid) {
-            let name = self.name_to_uuid
-                .iter()
-                .find(|&(_, item_uuid)| *item_uuid == uuid)
-                .expect("should be there")
-                .0
-                .to_owned();
-            self.name_to_uuid.remove(&*name);
-            Some(item)
+        if let Some((name, item)) = self.items.remove(&uuid) {
+            self.name_to_uuid.remove(&name);
+            Some((name, item))
         } else {
             None
         }

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -181,21 +181,19 @@ impl<T> Table<T> {
 
     /// Removes the item corresponding to name if there is one.
     pub fn remove_by_name(&mut self, name: &str) -> Option<(Uuid, T)> {
-        if let Some(uuid) = self.name_to_uuid.remove(name) {
-            self.items.remove(&uuid).map(|(_, item)| (uuid, item))
-        } else {
-            None
-        }
+        self.name_to_uuid
+            .remove(name)
+            .and_then(|uuid| self.items.remove(&uuid).map(|(_, item)| (uuid, item)))
     }
 
     /// Removes the item corresponding to the uuid if there is one.
     pub fn remove_by_uuid(&mut self, uuid: Uuid) -> Option<(Name, T)> {
-        if let Some((name, item)) = self.items.remove(&uuid) {
-            self.name_to_uuid.remove(&name);
-            Some((name, item))
-        } else {
-            None
-        }
+        self.items
+            .remove(&uuid)
+            .and_then(|(name, item)| {
+                          self.name_to_uuid.remove(&name);
+                          Some((name, item))
+                      })
     }
 
     /// Inserts an item for given uuid and name.

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::collections::{hash_map, HashMap};
+use std::collections::{HashMap, hash_map};
 use std::iter::IntoIterator;
 
 use uuid::Uuid;

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -164,12 +164,12 @@ impl<T> Table<T> {
     /// Get mutable item by name.
     pub fn get_mut_by_name(&mut self, name: &str) -> Option<(Uuid, &mut T)> {
         let uuid = match self.name_to_uuid.get(name) {
-            Some(uuid) => *uuid,
+            Some(uuid) => uuid,
             None => return None,
         };
         self.items
-            .get_mut(&uuid)
-            .map(|&mut (_, ref mut item)| (uuid, item))
+            .get_mut(uuid)
+            .map(|&mut (_, ref mut item)| (*uuid, item))
     }
 
     /// Get mutable item by uuid.

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -2,6 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
+use std::rc::Rc;
+
 use uuid::Uuid;
 
 pub type DevUuid = Uuid;
@@ -39,5 +44,38 @@ macro_attr! {
 impl From<Redundancy> for u16 {
     fn from(r: Redundancy) -> u16 {
         r as u16
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Name(Rc<String>);
+
+impl Name {
+    pub fn new(name: String) -> Name {
+        Name(Rc::new(name))
+    }
+
+    pub fn to_owned(&self) -> String {
+        self.0.deref().to_owned()
+    }
+}
+
+impl Deref for Name {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for Name {
+    fn borrow(&self) -> &str {
+        &**self.0
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }


### PR DESCRIPTION
Change Table in two ways:
1. Implement using two HashMaps instead of Vec and two HashMaps. This seems simpler, although uuid and name are no longer exactly equal when doing lookups.
1. Externalize keys from the stored struct. This should make mutable iteration better. But, this does cause some nontrivial ripples in our code that uses Table (most of it).

Right now I'm looking for general feedback on the acceptability of this approach in review-prelim. If this is a good direction, then we can proceed with detailed review in review-final.

Please read individual commit logs for specifics. Thanks!