### PR TITLE
Add more structure to strat engine

### DIFF
--- a/src/engine/strat_engine/thinpool/dmdevice.rs
+++ b/src/engine/strat_engine/thinpool/dmdevice.rs
@@ -9,9 +9,9 @@ use std::fmt::Display;
 
 use devicemapper::{DmNameBuf, ThinDevId};
 
-use super::super::errors::EngineResult;
+use super::super::super::errors::EngineResult;
 
-use super::super::super::engine::{FilesystemUuid, PoolUuid};
+use super::super::super::super::engine::{FilesystemUuid, PoolUuid};
 
 const FORMAT_VERSION: u16 = 1;
 

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -13,11 +13,12 @@ use nix::sys::statvfs::vfs::Statvfs;
 use nix::mount::{mount, MsFlags, umount};
 use tempdir::TempDir;
 
-use super::super::engine::{Filesystem, HasName, HasUuid};
-use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::types::FilesystemUuid;
+use super::super::super::engine::{Filesystem, HasName, HasUuid};
+use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
+use super::super::super::types::FilesystemUuid;
 
-use super::serde_structs::{FilesystemSave, Recordable};
+use super::super::serde_structs::{FilesystemSave, Recordable};
+
 use super::util::{create_fs, set_uuid, xfs_growfs};
 
 /// TODO: confirm that 256 MiB leaves enough time for stratisd to respond and extend before

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -18,13 +18,15 @@ use serde_json;
 
 use devicemapper::{DmDevice, DM, LinearDev};
 
-use super::super::engine::HasUuid;
-use super::super::errors::EngineResult;
-use super::super::types::{FilesystemUuid, PoolUuid};
+use super::super::super::engine::HasUuid;
+use super::super::super::errors::EngineResult;
+use super::super::super::types::{FilesystemUuid, PoolUuid};
+
+use super::super::serde_structs::{FilesystemSave, Recordable};
+
+use super::util::create_fs;
 
 use super::filesystem::StratFilesystem;
-use super::serde_structs::{FilesystemSave, Recordable};
-use super::util::create_fs;
 
 // TODO: Monitor fs size and extend linear and fs if needed
 // TODO: Document format of stuff on MDV in SWDD (currently ad-hoc)

--- a/src/engine/strat_engine/thinpool/mod.rs
+++ b/src/engine/strat_engine/thinpool/mod.rs
@@ -2,20 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-mod blockdev;
-mod blockdevmgr;
-mod cleanup;
-mod device;
-mod engine;
-mod metadata;
-mod pool;
-mod serde_structs;
-mod setup;
-mod range_alloc;
+mod dmdevice;
+mod filesystem;
+mod mdv;
+#[allow(module_inception)]
 mod thinpool;
 mod util;
 
-pub use self::engine::StratEngine;
-
-#[cfg(test)]
-mod tests;
+pub use self::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE, ThinPool};

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -14,20 +14,20 @@ use devicemapper::{DM, DataBlocks, DmDevice, DmName, DmNameBuf, IEC, LinearDev, 
                    Sectors, Segment, ThinDev, ThinDevId, ThinPoolDev, ThinPoolStatusSummary,
                    device_exists};
 
-use super::super::engine::{Filesystem, HasName};
-use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-use super::super::structures::Table;
-use super::super::types::{DevUuid, PoolUuid, FilesystemUuid, RenameAction};
+use super::super::super::engine::{Filesystem, HasName};
+use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
+use super::super::super::structures::Table;
+use super::super::super::types::{DevUuid, PoolUuid, FilesystemUuid, RenameAction};
 
-use super::blockdevmgr::{BlockDevMgr, BlkDevSegment, map_to_dm};
-use super::device::wipe_sectors;
+use super::super::blockdevmgr::{BlockDevMgr, BlkDevSegment, map_to_dm};
+use super::super::device::wipe_sectors;
+use super::super::serde_structs::{FilesystemSave, FlexDevsSave, Recordable, ThinPoolDevSave};
+
 use super::dmdevice::{FlexRole, ThinDevIdPool, ThinPoolRole, ThinRole, format_flex_name,
                       format_thinpool_name, format_thin_name};
 use super::filesystem::{FilesystemStatus, StratFilesystem};
 use super::mdv::MetadataVol;
-use super::serde_structs::{FilesystemSave, FlexDevsSave, Recordable, ThinPoolDevSave};
 use super::util::execute_cmd;
-
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2048);
 pub const DATA_LOWATER: DataBlocks = DataBlocks(512);
@@ -641,10 +641,11 @@ mod tests {
 
     use devicemapper::{Bytes, SECTOR_SIZE};
 
+    use super::super::super::metadata::MIN_MDA_SECTORS;
+    use super::super::super::tests::{loopbacked, real};
+    use super::super::super::tests::tempdir::TempDir;
+
     use super::super::filesystem::{FILESYSTEM_LOWATER, fs_usage};
-    use super::super::metadata::MIN_MDA_SECTORS;
-    use super::super::tests::{loopbacked, real};
-    use super::super::tests::tempdir::TempDir;
 
     use super::*;
 

--- a/src/engine/strat_engine/thinpool/util.rs
+++ b/src/engine/strat_engine/thinpool/util.rs
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Utilities to support Stratis.
+extern crate libudev;
+
+use std::path::Path;
+use std::process::Command;
+
+use uuid::Uuid;
+
+use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
+
+/// Common function to call a command line utility, returning an Result with an error message which
+/// also includes stdout & stderr if it fails.
+pub fn execute_cmd(cmd: &mut Command, error_msg: &str) -> EngineResult<()> {
+    let result = cmd.output()?;
+    if result.status.success() {
+        Ok(())
+    } else {
+        let std_out_txt = String::from_utf8_lossy(&result.stdout);
+        let std_err_txt = String::from_utf8_lossy(&result.stderr);
+        let err_msg = format!("{} stdout: {} stderr: {}",
+                              error_msg,
+                              std_out_txt,
+                              std_err_txt);
+        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
+    }
+}
+
+/// Create a filesystem on devnode.
+pub fn create_fs(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
+    execute_cmd(Command::new("mkfs.xfs")
+                    .arg("-f")
+                    .arg("-q")
+                    .arg(&devnode)
+                    .arg("-m")
+                    .arg(format!("uuid={}", uuid)),
+                &format!("Failed to create new filesystem at {:?}", devnode))
+}
+
+/// Use the xfs_growfs command to expand a filesystem mounted at the given
+/// mount point.
+pub fn xfs_growfs(mount_point: &Path) -> EngineResult<()> {
+    execute_cmd(Command::new("xfs_growfs").arg(mount_point).arg("-d"),
+                &format!("Failed to expand filesystem {:?}", mount_point))
+}
+
+/// Set a new UUID for filesystem on the devnode.
+pub fn set_uuid(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
+    execute_cmd(Command::new("xfs_admin")
+                    .arg("-U")
+                    .arg(format!("{}", uuid))
+                    .arg(&devnode),
+                &format!("Failed to set UUID for filesystem {:?}", devnode))
+}

--- a/src/engine/strat_engine/util.rs
+++ b/src/engine/strat_engine/util.rs
@@ -6,55 +6,8 @@
 extern crate libudev;
 
 use std::path::Path;
-use std::process::Command;
-
-use uuid::Uuid;
 
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
-
-/// Common function to call a command line utility, returning an Result with an error message which
-/// also includes stdout & stderr if it fails.
-pub fn execute_cmd(cmd: &mut Command, error_msg: &str) -> EngineResult<()> {
-    let result = cmd.output()?;
-    if result.status.success() {
-        Ok(())
-    } else {
-        let std_out_txt = String::from_utf8_lossy(&result.stdout);
-        let std_err_txt = String::from_utf8_lossy(&result.stderr);
-        let err_msg = format!("{} stdout: {} stderr: {}",
-                              error_msg,
-                              std_out_txt,
-                              std_err_txt);
-        Err(EngineError::Engine(ErrorEnum::Error, err_msg))
-    }
-}
-
-/// Create a filesystem on devnode.
-pub fn create_fs(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
-    execute_cmd(Command::new("mkfs.xfs")
-                    .arg("-f")
-                    .arg("-q")
-                    .arg(&devnode)
-                    .arg("-m")
-                    .arg(format!("uuid={}", uuid)),
-                &format!("Failed to create new filesystem at {:?}", devnode))
-}
-
-/// Use the xfs_growfs command to expand a filesystem mounted at the given
-/// mount point.
-pub fn xfs_growfs(mount_point: &Path) -> EngineResult<()> {
-    execute_cmd(Command::new("xfs_growfs").arg(mount_point).arg("-d"),
-                &format!("Failed to expand filesystem {:?}", mount_point))
-}
-
-/// Set a new UUID for filesystem on the devnode.
-pub fn set_uuid(devnode: &Path, uuid: Uuid) -> EngineResult<()> {
-    execute_cmd(Command::new("xfs_admin")
-                    .arg("-U")
-                    .arg(format!("{}", uuid))
-                    .arg(&devnode),
-                &format!("Failed to set UUID for filesystem {:?}", devnode))
-}
 
 /// Lookup the WWN from the udev db using the device node eg. /dev/sda
 pub fn hw_lookup(dev_node_search: &Path) -> EngineResult<Option<String>> {


### PR DESCRIPTION
Isolate parts of thinpool into a subdirectory.
They were already naturally isolated, as can be seen from the small number
of values that are exported from the thinpool subdirectory.

Signed-off-by: mulhern <amulhern@redhat.com>