### PR TITLE
Handle udev add events

### DIFF
--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -12,4 +12,4 @@ mod pool;
 mod types;
 mod util;
 
-pub use self::api::{connect, handle};
+pub use self::api::{connect, handle, register_pool};

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use devicemapper::Sectors;
+use devicemapper::{Sectors, Device};
 
 use super::errors::EngineResult;
 use super::types::{BlockDevState, FilesystemUuid, PoolUuid, DevUuid, RenameAction};
@@ -146,6 +146,14 @@ pub trait Engine: Debug {
                    redundancy: Option<u16>,
                    force: bool)
                    -> EngineResult<PoolUuid>;
+
+    /// Evaluate a device node & devicemapper::Device to see if it's a valid
+    /// stratis device.  If all the devices are present in the pool and the pool isn't already
+    /// up and running, it will get setup and the pool uuid will be returned.
+    fn block_evaluate(&mut self,
+                      dev_node: PathBuf,
+                      device: Device)
+                      -> EngineResult<Option<PoolUuid>>;
 
     /// Destroy a pool.
     /// Ensures that the pool of the given UUID is absent on completion.

--- a/src/engine/errors.rs
+++ b/src/engine/errors.rs
@@ -2,13 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate libudev;
-
 use std::io;
 use std::fmt;
 use std::error;
 use std::str;
 
+use libudev;
 use nix;
 use uuid;
 use serde_json;

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -2,12 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+extern crate libc;
+
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::collections::hash_map::RandomState;
 use std::iter::FromIterator;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
+
+use devicemapper::Device;
 
 use super::super::engine::{Engine, Eventable, HasName, HasUuid, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
@@ -56,6 +60,15 @@ impl Engine for SimEngine {
         self.pools.insert(pool);
 
         Ok(uuid)
+    }
+
+    fn block_evaluate(&mut self,
+                      dev_node: PathBuf,
+                      device: Device)
+                      -> EngineResult<Option<PoolUuid>> {
+        assert_ne!(dev_node, PathBuf::from("/"));
+        assert_ne!(libc::dev_t::from(device), 0);
+        Ok(None)
     }
 
     fn destroy_pool(&mut self, uuid: PoolUuid) -> EngineResult<bool> {

--- a/src/engine/strat_engine/thinpool/util.rs
+++ b/src/engine/strat_engine/thinpool/util.rs
@@ -4,8 +4,6 @@
 
 // Utilities to support Stratis.
 
-extern crate libudev;
-
 use std::path::Path;
 use std::process::Command;
 

--- a/src/engine/strat_engine/util.rs
+++ b/src/engine/strat_engine/util.rs
@@ -4,9 +4,9 @@
 
 // Utilities to support Stratis.
 
-extern crate libudev;
-
 use std::path::Path;
+
+use libudev;
 
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate log;
+extern crate libudev;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/stratis/errors.rs
+++ b/src/stratis/errors.rs
@@ -2,14 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate libudev;
-
 use std::error::Error;
 use std::fmt;
 use std::io;
 
 #[cfg(feature="dbus_enabled")]
 use dbus;
+use libudev;
 
 use engine::EngineError;
 
@@ -88,7 +87,6 @@ impl From<EngineError> for StratisError {
     }
 }
 
-/// Allow ability to convert from libudev error to stratis error
 impl From<libudev::Error> for StratisError {
     fn from(err: libudev::Error) -> StratisError {
         StratisError::Udev(err)


### PR DESCRIPTION
Block devices can be delayed at boot or be systematically added after the system is up and running.  Handle these udev events by evaluating block devices when they are added, to see if they have
a valid stratis signature.  If they do we will attempt to assemble it into a complete pool.

Preliminary manual testing shows that this change appears to work, but it needs quite a bit of scrutiny and a bunch of added unit tests before it can be considered complete.  Making it available so people can see the direction I'm taking with it, to see if it's appropriate.  I'm trying to utilize as much of the existing code as possible. 