### PR TITLE
Improve fs creation

### DIFF
--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -21,8 +21,6 @@ use dbus::tree::PropInfo;
 
 use uuid::Uuid;
 
-use devicemapper::Sectors;
-
 use engine::{Pool, RenameAction};
 
 use super::blockdev::create_dbus_blockdev;
@@ -52,10 +50,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
-    let result =
-        pool.create_filesystems(&filesystems
-                                     .map(|x| (x, None))
-                                     .collect::<Vec<(&str, Option<Sectors>)>>());
+    let result = pool.create_filesystems(&filesystems.collect::<Vec<_>>());
 
     let msg = match result {
         Ok(ref infos) => {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -58,7 +58,7 @@ pub trait Pool: HasName + HasUuid {
     /// for filesystems in this pool. If the same name is passed multiple
     /// times, the size associated with the last item is used.
     fn create_filesystems<'a, 'b>(&'a mut self,
-                                  specs: &[(&'b str, Option<Sectors>)])
+                                  specs: &[&'b str])
                                   -> EngineResult<Vec<(&'b str, FilesystemUuid)>>;
 
     /// Adds blockdevs specified by paths to pool.

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -176,7 +176,7 @@ mod tests {
             .unwrap();
         {
             let pool = engine.get_mut_pool(uuid).unwrap();
-            pool.create_filesystems(&[("test", None)]).unwrap();
+            pool.create_filesystems(&["test"]).unwrap();
         }
         assert!(engine.destroy_pool(uuid).is_err());
     }


### PR DESCRIPTION
When creating more than one filesystem, create the first one, and then snapshot it to create the rest. This should be faster and more space-efficient.