### PR TITLE
cast stat.f_bsize to u64

### DIFF
--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -230,5 +230,9 @@ impl Recordable<FilesystemSave> for StratFilesystem {
 pub fn fs_usage(mount_point: &Path) -> EngineResult<(Bytes, Bytes)> {
     let mut stat = Statvfs::default();
     statvfs(mount_point, &mut stat)?;
-    Ok((Bytes(stat.f_bsize * stat.f_blocks), Bytes(stat.f_bsize * (stat.f_blocks - stat.f_bfree))))
+
+    // stat.f_bsize is type c_ulong, which is 32 bits on some archs. Upcast.
+    let f_bsize = stat.f_bsize as u64;
+
+    Ok((Bytes(f_bsize * stat.f_blocks), Bytes(f_bsize * (stat.f_blocks - stat.f_bfree))))
 }


### PR DESCRIPTION
It's defined as c_ulong and compilation fails on 32bit systems with:
```rust
   --> src/engine/strat_engine/thinpool/filesystem.rs:233:30
    |
233 |     Ok((Bytes(stat.f_bsize * stat.f_blocks), Bytes(stat.f_bsize * (stat.f_blocks - stat.f_bfree))))
    |                              ^^^^^^^^^^^^^ expected u32, found u64
error[E0308]: mismatched types
   --> src/engine/strat_engine/thinpool/filesystem.rs:233:15
    |
233 |     Ok((Bytes(stat.f_bsize * stat.f_blocks), Bytes(stat.f_bsize * (stat.f_blocks - stat.f_bfree))))
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found u32
error[E0277]: the trait bound `u32: std::ops::Mul<u64>` is not satisfied
   --> src/engine/strat_engine/thinpool/filesystem.rs:233:28
    |
233 |     Ok((Bytes(stat.f_bsize * stat.f_blocks), Bytes(stat.f_bsize * (stat.f_blocks - stat.f_bfree))))
    |                            ^ no implementation for `u32 * u64`
    |
    = help: the trait `std::ops::Mul<u64>` is not implemented for `u32`
error[E0308]: mismatched types
   --> src/engine/strat_engine/thinpool/filesystem.rs:233:67
    |
233 |     Ok((Bytes(stat.f_bsize * stat.f_blocks), Bytes(stat.f_bsize * (stat.f_blocks - stat.f_bfree))))
    |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u32, found u64
error[E0308]: mismatched types
   --> src/engine/strat_engine/thinpool/filesystem.rs:233:52
    |
233 |     Ok((Bytes(stat.f_bsize * stat.f_blocks), Bytes(stat.f_bsize * (stat.f_blocks - stat.f_bfree))))
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found u32
error[E0277]: the trait bound `u32: std::ops::Mul<u64>` is not satisfied
   --> src/engine/strat_engine/thinpool/filesystem.rs:233:65
    |
233 |     Ok((Bytes(stat.f_bsize * stat.f_blocks), Bytes(stat.f_bsize * (stat.f_blocks - stat.f_bfree))))
    |                                                                 ^ no implementation for `u32 * u64`
    |
    = help: the trait `std::ops::Mul<u64>` is not implemented for `u32`
```

Fixes: https://github.com/stratis-storage/stratisd/issues/707
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>