### PR TITLE
add dbus service

### DIFF
--- a/org.storage.stratis1.service
+++ b/org.storage.stratis1.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.storage.stratis1
+Exec=/usr/libexec/stratisd
+User=root


### PR DESCRIPTION
Without it, stratisd is not activatable.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>