### PR TITLE
Make dbus support a "feature" via "dbus_enabled"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.4"
 authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.com>"]
 
 [dependencies]
-dbus = "0.6.1"
+dbus = {version = "0.6.1", optional = true}
 clap = "2"
 nix = "0.9"
 devicemapper = "0.15"
@@ -33,3 +33,6 @@ features = ["serde", "v4"]
 [dev-dependencies]
 quickcheck = "0.6"
 loopdev = "0.2"
+
+[features]
+dbus_enabled = ["dbus"]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ travis_fmt:
 	cargo fmt -- --write-mode=diff
 
 build:
-	RUSTFLAGS='-D warnings' cargo build
+	RUSTFLAGS='-D warnings' cargo build --features "dbus_enabled"
 
 test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ extern crate crc;
 extern crate byteorder;
 extern crate uuid;
 extern crate chrono;
+
+#[cfg(feature="dbus_enabled")]
 extern crate dbus;
+
 extern crate tempdir;
 extern crate term;
 extern crate rand;
@@ -31,7 +34,10 @@ extern crate error_chain;
 extern crate quickcheck;
 
 pub mod engine;
+
+#[cfg(feature="dbus_enabled")]
 pub mod dbus_api;
+
 pub mod stratis;
 
 

--- a/src/stratis/errors.rs
+++ b/src/stratis/errors.rs
@@ -6,7 +6,9 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
+#[cfg(feature="dbus_enabled")]
 use dbus;
+
 use term;
 
 use engine::EngineError;
@@ -18,7 +20,10 @@ pub enum StratisError {
     Engine(EngineError),
     StderrNotFound,
     Io(io::Error),
+
+    #[cfg(feature="dbus_enabled")]
     Dbus(dbus::Error),
+
     Term(term::Error),
 }
 
@@ -30,9 +35,12 @@ impl fmt::Display for StratisError {
             }
             StratisError::StderrNotFound => write!(f, "stderr not found"),
             StratisError::Io(ref err) => write!(f, "IO error: {}", err),
+
+            #[cfg(feature="dbus_enabled")]
             StratisError::Dbus(ref err) => {
                 write!(f, "Dbus error: {}", err.message().unwrap_or("Unknown"))
             }
+
             StratisError::Term(ref err) => write!(f, "Term error: {}", err),
         }
     }
@@ -44,7 +52,10 @@ impl Error for StratisError {
             StratisError::Engine(ref err) => Error::description(err),
             StratisError::StderrNotFound => "stderr not found",
             StratisError::Io(ref err) => err.description(),
+
+            #[cfg(feature="dbus_enabled")]
             StratisError::Dbus(ref err) => err.message().unwrap_or("D-Bus Error"),
+
             StratisError::Term(ref err) => Error::description(err),
         }
     }
@@ -54,7 +65,10 @@ impl Error for StratisError {
             StratisError::Engine(ref err) => Some(err),
             StratisError::StderrNotFound => None,
             StratisError::Io(ref err) => Some(err),
+
+            #[cfg(feature="dbus_enabled")]
             StratisError::Dbus(ref err) => Some(err),
+
             StratisError::Term(ref err) => Some(err),
         }
     }
@@ -66,6 +80,7 @@ impl From<io::Error> for StratisError {
     }
 }
 
+#[cfg(feature="dbus_enabled")]
 impl From<dbus::Error> for StratisError {
     fn from(err: dbus::Error) -> StratisError {
         StratisError::Dbus(err)


### PR DESCRIPTION
We need the ability to run stratis daemon in initramfs.  In this
environment we don't have dbus support and need to have a binary
that doesn't require libdbus-1.so.* .

Signed-off-by: Tony Asleson <tasleson@redhat.com>