### PR TITLE
Remove devnodes() from BlockDevMgr interface

### DIFF
--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use chrono::{DateTime, Duration, Utc};
 use rand::{thread_rng, seq};
@@ -168,14 +168,6 @@ impl BlockDevMgr {
         }
 
         Some(lists)
-    }
-
-    #[allow(dead_code)]
-    pub fn devnodes(&self) -> Vec<PathBuf> {
-        self.block_devs
-            .values()
-            .map(|d| d.devnode.clone())
-            .collect()
     }
 
     /// Write the given data to all blockdevs marking with current time.


### PR DESCRIPTION
It was left in because at one time it was thought that it would be useful
for the D-Bus API. But now that blockdevs are exposed on the D-Bus API, this
method no longer seems to have any point.

Signed-off-by: mulhern <amulhern@redhat.com>