### PR TITLE
Dbus propertychanged signals

### DIFF
--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -24,6 +24,7 @@ use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::STRATIS_BASE_PATH;
 use super::util::STRATIS_BASE_SERVICE;
+use super::util::build_propchanged;
 use super::util::engine_to_dbus_err_tuple;
 use super::util::get_next_arg;
 use super::util::get_parent;
@@ -51,7 +52,7 @@ pub fn create_dbus_filesystem<'a>(dbus_context: &DbusContext,
 
     let name_property = f.property::<&str, _>("Name", ())
         .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
+        .emits_changed(EmitsChangedSignal::True)
         .on_get(get_filesystem_name);
 
     let pool_property = f.property::<&dbus::Path, _>("Pool", ())
@@ -106,25 +107,28 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut engine = dbus_context.engine.borrow_mut();
     let pool = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
-    let msg = match pool.rename_filesystem(filesystem_data.uuid, new_name) {
+    let msgs = match pool.rename_filesystem(filesystem_data.uuid, new_name) {
         Ok(RenameAction::NoSource) => {
             let error_message = format!("pool {} doesn't know about filesystem {}",
                                         pool_uuid,
                                         filesystem_data.uuid);
             let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), error_message);
-            return_message.append3(default_return, rc, rs)
+            vec![return_message.append3(default_return, rc, rs)]
         }
         Ok(RenameAction::Identity) => {
-            return_message.append3(default_return, msg_code_ok(), msg_string_ok())
+            vec![return_message.append3(default_return, msg_code_ok(), msg_string_ok())]
         }
-        Ok(RenameAction::Renamed) => return_message.append3(true, msg_code_ok(), msg_string_ok()),
+        Ok(RenameAction::Renamed) => {
+            vec![return_message.append3(true, msg_code_ok(), msg_string_ok()),
+                 build_propchanged("Name", new_name, object_path)]
+        }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
-            return_message.append3(default_return, rc, rs)
+            vec![return_message.append3(default_return, rc, rs)]
         }
     };
 
-    Ok(vec![msg])
+    Ok(msgs)
 }
 
 /// Get a filesystem property and place it on the D-Bus. The property is

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -30,7 +30,7 @@ use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::{engine_to_dbus_err_tuple, get_next_arg, get_uuid, msg_code_ok, msg_string_ok,
-                  STRATIS_BASE_PATH, STRATIS_BASE_SERVICE};
+                  build_propchanged, STRATIS_BASE_PATH, STRATIS_BASE_SERVICE};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
@@ -213,7 +213,11 @@ fn add_devs(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         }
     };
 
-    Ok(vec![msg])
+    let sig_msg = build_propchanged("TotalPhysicalSize",
+                                    &*pool.total_physical_size().to_string(),
+                                    object_path);
+
+    Ok(vec![msg, sig_msg])
 }
 
 fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -232,23 +236,29 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         .expect("implicit argument must be in tree");
     let pool_uuid = get_data!(pool_path; default_return; return_message).uuid;
 
-    let msg = match dbus_context
+    let msgs = match dbus_context
               .engine
               .borrow_mut()
               .rename_pool(pool_uuid, new_name) {
         Ok(RenameAction::NoSource) => {
             let error_message = format!("engine doesn't know about pool {}", &pool_uuid);
             let (rc, rs) = (u16::from(DbusErrorEnum::INTERNAL_ERROR), error_message);
-            return_message.append3(default_return, rc, rs)
+            vec![return_message.append3(default_return, rc, rs)]
         }
-        Ok(RenameAction::Identity) => return_message.append3(false, msg_code_ok(), msg_string_ok()),
-        Ok(RenameAction::Renamed) => return_message.append3(true, msg_code_ok(), msg_string_ok()),
+        Ok(RenameAction::Identity) => {
+            vec![return_message.append3(false, msg_code_ok(), msg_string_ok())]
+        }
+        Ok(RenameAction::Renamed) => {
+            vec![return_message.append3(true, msg_code_ok(), msg_string_ok()),
+                 build_propchanged("Name", new_name, object_path)]
+        }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
-            return_message.append3(default_return, rc, rs)
+            vec![return_message.append3(default_return, rc, rs)]
         }
     };
-    Ok(vec![msg])
+
+    Ok(msgs)
 }
 
 /// Get a pool property and place it on the D-Bus. The property is
@@ -354,12 +364,12 @@ pub fn create_dbus_pool<'a>(dbus_context: &DbusContext,
 
     let name_property = f.property::<&str, _>("Name", ())
         .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
+        .emits_changed(EmitsChangedSignal::True)
         .on_get(get_pool_name);
 
     let total_physical_size_property = f.property::<&str, _>("TotalPhysicalSize", ())
         .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
+        .emits_changed(EmitsChangedSignal::True)
         .on_get(get_pool_total_physical_size);
 
     let total_physical_used_property = f.property::<&str, _>("TotalPhysicalUsed", ())

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -7,6 +7,9 @@ use std::error::Error;
 use dbus;
 use dbus::arg::{ArgType, Iter, IterAppend};
 use dbus::tree::{MethodErr, MTFn, PropInfo};
+use dbus::arg::Variant;
+use dbus::{Message, SignalArgs};
+use dbus::stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged;
 
 use engine::{EngineError, ErrorEnum};
 
@@ -99,4 +102,15 @@ pub fn get_parent(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Resul
 
     i.append(data.parent.clone());
     Ok(())
+}
+
+/// Construct a signal that a property has changed.
+// Currently only handles returning string properties, since that's all that's
+// needed right now
+pub fn build_propchanged(prop_name: &str, new_value: &str, path: &dbus::Path) -> Message {
+    let mut prop_changed: PropertiesPropertiesChanged = Default::default();
+    prop_changed
+        .changed_properties
+        .insert(prop_name.into(), Variant(Box::new(new_value.to_owned())));
+    prop_changed.to_emit_message(path)
 }


### PR DESCRIPTION
see #201. We want methods to be capable of emitting PropertyChanged signals when appropriate, as well as to generate signals outside the context of a D-Bus method call.

This is important because we want to make it very easy and clear for clients to monitor when a pool is approaching its capacity! They could do this by monitoring PropertyChanged events on `TotalPhysicalSize` and `TotalPhysicalUsed` and doing some math, or we will probably have a pool `State` property that would indicate trouble that could be monitored.

This PR will let us explore what properties we want to signal for, verify signals work, and develop CI tests for our signals.