### PR TITLE
Pass last_update_time as a parameter in BlockDevMgr::new

### DIFF
--- a/src/engine/strat_engine/blockdevmgr.rs
+++ b/src/engine/strat_engine/blockdevmgr.rs
@@ -111,14 +111,18 @@ pub struct BlockDevMgr {
 }
 
 impl BlockDevMgr {
-    pub fn new(pool_uuid: PoolUuid, block_devs: Vec<StratBlockDev>) -> BlockDevMgr {
+    /// Create a new BlockDevMgr struct
+    pub fn new(pool_uuid: PoolUuid,
+               block_devs: Vec<StratBlockDev>,
+               last_update_time: Option<DateTime<Utc>>)
+               -> BlockDevMgr {
         BlockDevMgr {
             pool_uuid: pool_uuid,
             block_devs: block_devs
                 .into_iter()
                 .map(|bd| (bd.uuid(), bd))
                 .collect(),
-            last_update_time: None,
+            last_update_time: last_update_time,
         }
     }
 
@@ -130,7 +134,8 @@ impl BlockDevMgr {
                       -> EngineResult<BlockDevMgr> {
         let devices = resolve_devices(paths)?;
         Ok(BlockDevMgr::new(pool_uuid,
-                            initialize(pool_uuid, devices, mda_size, force, &HashSet::new())?))
+                            initialize(pool_uuid, devices, mda_size, force, &HashSet::new())?,
+                            None))
     }
 
     /// Get a function that maps UUIDs to Devices.

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -82,7 +82,7 @@ impl StratPool {
                             EngineError::Engine(ErrorEnum::NotFound,
                                                 format!("no metadata for pool {}", uuid))
                         })?;
-        let bd_mgr = BlockDevMgr::new(uuid, get_blockdevs(uuid, &metadata, devnodes)?);
+        let bd_mgr = BlockDevMgr::new(uuid, get_blockdevs(uuid, &metadata, devnodes)?, None);
         let thinpool = ThinPool::setup(uuid,
                                        &DM::new()?,
                                        metadata.thinpool_dev.data_block_size,


### PR DESCRIPTION
Previously, it was set unconditionally.

If the parameter is not passed then the method is restricted in how and
when during execution it can be invoked. If we choose not to pass the
parameter, then we should document BlockDevMgr::new() a whole lot better.
It is easier to pass the parameter.

Signed-off-by: mulhern <amulhern@redhat.com>