### PR TITLE
Do not forget thin_meta_dev_spare when getting segments for metadata

### DIFF
--- a/src/engine/strat_engine/setup.rs
+++ b/src/engine/strat_engine/setup.rs
@@ -169,12 +169,13 @@ pub fn get_blockdevs(pool_uuid: PoolUuid,
                      pool_save: &PoolSave,
                      devnodes: &HashMap<Device, PathBuf>)
                      -> EngineResult<Vec<StratBlockDev>> {
-    let segments = pool_save
-        .flex_devs
+    let flex_devs = &pool_save.flex_devs;
+    let segments = flex_devs
         .meta_dev
         .iter()
-        .chain(pool_save.flex_devs.thin_meta_dev.iter())
-        .chain(pool_save.flex_devs.thin_data_dev.iter());
+        .chain(flex_devs.thin_meta_dev.iter())
+        .chain(flex_devs.thin_data_dev.iter())
+        .chain(flex_devs.thin_meta_dev_spare.iter());
 
     let mut segment_table = HashMap::new();
     for seg in segments {


### PR DESCRIPTION
This is a bug fix. Presumably tests were passing because we have difficulty
executing code paths where we need to use the spare.

Signed-off-by: mulhern <amulhern@redhat.com>