### PR TITLE
Do not allocate blocks reserved for Stratis metadata

### DIFF
--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -63,17 +63,6 @@ impl StratBlockDev {
         self.bda.save_state(time, metadata, &mut f)
     }
 
-    /// List the available-for-upper-layer-use range in this blockdev.
-    pub fn avail_range(&self) -> (Sectors, Sectors) {
-        let start = self.metadata_size();
-        let size = self.current_capacity();
-        // Blockdev size is at least MIN_DEV_SIZE, so this can fail only if
-        // size of metadata area exceeds 1 GiB. Initial metadata area size
-        // is 4 MiB.
-        assert!(start <= size);
-        (start, size - start)
-    }
-
     /// The device's UUID.
     pub fn uuid(&self) -> DevUuid {
         self.bda.dev_uuid()
@@ -159,7 +148,13 @@ impl BlockDev for StratBlockDev {
     }
 
     fn total_size(&self) -> Sectors {
-        self.avail_range().1
+        let start = self.metadata_size();
+        let size = self.current_capacity();
+        // Blockdev size is at least MIN_DEV_SIZE, so this can fail only if
+        // size of metadata area exceeds 1 GiB. Initial metadata area size
+        // is 4 MiB.
+        assert!(start <= size);
+        size - start
     }
 
     fn state(&self) -> BlockDevState {

--- a/src/engine/strat_engine/blockdev.rs
+++ b/src/engine/strat_engine/blockdev.rs
@@ -31,21 +31,42 @@ pub struct StratBlockDev {
 }
 
 impl StratBlockDev {
+    /// Make a new BlockDev from the parameters.
+    /// Allocate space for the Stratis metadata on the device.
+    /// - dev: the device, identified by number
+    /// - devnode: the device node
+    /// - dev_size: the total size of the device
+    /// - bda: the device's BDA
+    /// - other_segments: segments claimed for non-Stratis metadata use
+    /// - user_info: user settable identifying information
+    /// - hardware_info: identifying information in the hardware
+    /// Returns an error if it is impossible to allocate all segments on the
+    /// device. This can happen even if upper_segments is empty,
+    /// if the device size is less than the size required for the Stratis
+    /// metadata.
     pub fn new(dev: Device,
                devnode: PathBuf,
+               dev_size: Sectors,
                bda: BDA,
-               allocator: RangeAllocator,
+               upper_segments: &[(Sectors, Sectors)],
                user_info: Option<String>,
                hardware_info: Option<String>)
-               -> StratBlockDev {
-        StratBlockDev {
-            dev,
-            devnode,
-            bda,
-            used: allocator,
-            user_info,
-            hardware_info,
-        }
+               -> EngineResult<StratBlockDev> {
+        let mut segments = vec![(Sectors(0), bda.size())];
+        segments.extend(upper_segments);
+        let allocator = RangeAllocator::new(dev_size, &segments)?;
+
+        assert!(bda.size() <= dev_size,
+                "Otherwise the segments for the metadata could not have been allocated");
+
+        Ok(StratBlockDev {
+               dev,
+               devnode,
+               bda,
+               used: allocator,
+               user_info,
+               hardware_info,
+           })
     }
 
     /// Returns the blockdev's Device
@@ -150,9 +171,6 @@ impl BlockDev for StratBlockDev {
     fn total_size(&self) -> Sectors {
         let start = self.metadata_size();
         let size = self.current_capacity();
-        // Blockdev size is at least MIN_DEV_SIZE, so this can fail only if
-        // size of metadata area exceeds 1 GiB. Initial metadata area size
-        // is 4 MiB.
         assert!(start <= size);
         size - start
     }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -334,6 +334,18 @@ mod tests {
         assert_eq!(blockdevs1.len(), pool_save1.block_devs.len());
         assert_eq!(blockdevs2.len(), pool_save2.block_devs.len());
 
+        for mut blockdev in blockdevs1 {
+            let (amt, seg) = blockdev.request_space(Sectors(1));
+            assert_eq!(amt, Sectors(1));
+            assert!(seg[0].0 >= blockdev.metadata_size());
+        }
+
+        for mut blockdev in blockdevs2 {
+            let (amt, seg) = blockdev.request_space(Sectors(1));
+            assert_eq!(amt, Sectors(1));
+            assert!(seg[0].0 >= blockdev.metadata_size());
+        }
+
         pool1.teardown().unwrap();
         pool2.teardown().unwrap();
         let pools = find_all().unwrap();
@@ -348,6 +360,18 @@ mod tests {
         let blockdevs2 = get_blockdevs(uuid2, &pool_save2, devnodes2).unwrap();
         assert_eq!(blockdevs1.len(), pool_save1.block_devs.len());
         assert_eq!(blockdevs2.len(), pool_save2.block_devs.len());
+
+        for mut blockdev in blockdevs1 {
+            let (amt, seg) = blockdev.request_space(Sectors(1));
+            assert_eq!(amt, Sectors(1));
+            assert!(seg[0].0 >= blockdev.metadata_size());
+        }
+
+        for mut blockdev in blockdevs2 {
+            let (amt, seg) = blockdev.request_space(Sectors(1));
+            assert_eq!(amt, Sectors(1));
+            assert!(seg[0].0 >= blockdev.metadata_size());
+        }
     }
 
     #[test]


### PR DESCRIPTION
This corrects a problem which, when an existing pool was set up, it was possible to allocate the space assigned to the metadata to the upper layer.