### PR TITLE
Export BlockDevState in engine module API

### DIFF
--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -10,8 +10,7 @@ use dbus::tree::{Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInf
 
 use uuid::Uuid;
 
-use super::super::engine::BlockDev;
-use super::super::engine::types::BlockDevState;
+use super::super::engine::{BlockDev, BlockDevState};
 
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -16,6 +16,7 @@ pub use self::errors::ErrorEnum;
 pub use self::sim_engine::SimEngine;
 pub use self::strat_engine::StratEngine;
 
+pub use self::types::BlockDevState;
 pub use self::types::DevUuid;
 pub use self::types::FilesystemUuid;
 pub use self::types::PoolUuid;


### PR DESCRIPTION
It is just the sort of useful type that D-Bus API needs to know about.

Signed-off-by: mulhern <amulhern@redhat.com>