### PR TITLE
Correct /dev/stratis missing

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -92,7 +92,10 @@ impl StratEngine {
                         return Err(EngineError::Engine(ErrorEnum::Invalid, err_msg.into()));
                     }
                 }
-                Err(_) => {
+                Err(e) => {
+                    // TODO: Add ability to distinguish expected vs. unexpected errors
+                    // (expected error would be caused by missing block device(s).
+                    warn!("Pool {} failed to setup, reason ({:?}", pool_uuid, e);
                     // Unable to setup pool, it might become complete later.
                     incomplete_pools.insert(*pool_uuid, devices.clone());
                 }
@@ -165,40 +168,45 @@ impl Engine for StratEngine {
                     .expect("We just retrieved or created a HashMap");
                 devices.insert(device, dev_node);
 
-                let rc = if let Ok((pool_name, pool)) =
-                    StratPool::setup(&dm, pool_uuid, &devices) {
-                    // We know we have a unique uuid, but the pools table requires a unique name too
-                    // so we will ensure unique before we insert as we don't want to change the
-                    // existing state if we have a conflict.
-                    //
-                    // We will also _not_ exit the daemon as we do in initialize as we were
-                    // previously up and running for some duration of time.
-                    if !self.pools.contains_name(&pool_name) {
-                        self.pools.insert(pool_name, pool_uuid, pool);
-                        Some(pool_uuid)
-                    } else {
-                        let dev_paths = devices
-                            .values()
-                            .map(|p| p.to_str().expect("Expecting valid device path!"))
-                            .collect::<Vec<&str>>()
-                            .join(", ");
+                let rc = match StratPool::setup(&dm, pool_uuid, &devices) {
+                    Ok((pool_name, pool)) => {
+                        // We know we have a unique uuid, but the pools table requires a unique
+                        // name too so we will ensure unique before we insert as we don't want to
+                        // change the existing state if we have a conflict.
+                        //
+                        // We will also _not_ exit the daemon as we do in initialize as we were
+                        // previously up and running for some duration of time.
+                        if !self.pools.contains_name(&pool_name) {
+                            self.pools.insert(pool_name, pool_uuid, pool);
+                            Some(pool_uuid)
+                        } else {
+                            let dev_paths = devices
+                                .values()
+                                .map(|p| p.to_str().expect("Expecting valid device path!"))
+                                .collect::<Vec<&str>>()
+                                .join(", ");
 
-                        self.incomplete_pools.insert(pool_uuid, devices);
+                            self.incomplete_pools.insert(pool_uuid, devices);
 
-                        error!("udev add: duplicate pool name {:?} for uuid {:?}, \
+                            error!("udev add: duplicate pool name {:?} for uuid {:?}, \
                                 devices[{}], failing to setup complete pool!",
-                               pool_name,
-                               pool_uuid,
-                               dev_paths);
-                        if let Err(e) = pool.teardown() {
-                            error!("Error while tearing down pool with duplicate name! {:?}!",
-                                   e);
+                                   pool_name,
+                                   pool_uuid,
+                                   dev_paths);
+                            if let Err(e) = pool.teardown() {
+                                error!("Error while tearing down pool with duplicate name! {:?}!",
+                                       e);
+                            }
+                            None
                         }
+                    }
+                    Err(e) => {
+                        warn!("udev add: pool {} failed to setup, reason ({:?}",
+                              pool_uuid,
+                              e);
+                        self.incomplete_pools.insert(pool_uuid, devices);
                         None
                     }
-                } else {
-                    self.incomplete_pools.insert(pool_uuid, devices);
-                    None
                 };
                 Ok(rc)
             }


### PR DESCRIPTION
If `/dev/stratis` is missing we partially bring a pool up.

Another idea we could do is replace `create_dir` with `create_dir_all`.

Corrects: https://github.com/stratis-storage/stratisd/issues/773
