### PR TITLE
Make sure the dev path exists before setting up pools

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -78,6 +78,8 @@ impl StratEngine {
             return Err(EngineError::Engine(ErrorEnum::Error, err_msg));
         }
 
+        devlinks::setup_dev_path()?;
+
         let pools = find_all()?;
 
         let mut table = Table::default();


### PR DESCRIPTION
/dev/stratis must exist both for devlinks to work, as well as each pool's
MDV setup.

fixes #773

Signed-off-by: Andy Grover <agrover@redhat.com>