### PR TITLE
Set Dm UUID fields when creating devices

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -15,7 +15,7 @@ use super::super::super::engine::BlockDev;
 use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::super::types::{DevUuid, PoolUuid};
 
-use super::super::dmnames::{CacheRole, format_backstore_name};
+use super::super::dmnames::{CacheRole, format_backstore_ids};
 use super::super::serde_structs::{BackstoreSave, Recordable};
 
 use super::blockdevmgr::{BlkDevSegment, BlockDevMgr, Segment, coalesce_blkdevsegs, map_to_dm};
@@ -74,11 +74,8 @@ impl DataTier {
             .map(&mapper)
             .collect::<EngineResult<Vec<_>>>()?;
 
-        let ld = LinearDev::setup(dm,
-                                  &format_backstore_name(block_mgr.pool_uuid(),
-                                                         CacheRole::OriginSub),
-                                  None,
-                                  map_to_dm(&segments))?;
+        let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::OriginSub);
+        let ld = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&segments))?;
 
         Ok(DataTier {
                block_mgr,
@@ -100,11 +97,8 @@ impl DataTier {
             .flat_map(|s| s.iter())
             .cloned()
             .collect::<Vec<_>>();
-        let ld = LinearDev::setup(dm,
-                                  &format_backstore_name(block_mgr.pool_uuid(),
-                                                         CacheRole::OriginSub),
-                                  None,
-                                  map_to_dm(&segments))?;
+        let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::OriginSub);
+        let ld = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&segments))?;
         Ok(DataTier {
                block_mgr,
                dm_device: ld,

--- a/src/engine/strat_engine/dmnames.rs
+++ b/src/engine/strat_engine/dmnames.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 use std::fmt::Display;
 
-use devicemapper::DmNameBuf;
+use devicemapper::{DmNameBuf, DmUuidBuf};
 
 use super::super::super::engine::{FilesystemUuid, PoolUuid};
 
@@ -85,43 +85,63 @@ impl Display for CacheRole {
     }
 }
 
-/// Format a name for the flex layer.
+/// Format a name & uuid for the flex layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 72
-pub fn format_flex_name(pool_uuid: PoolUuid, role: FlexRole) -> DmNameBuf {
-    DmNameBuf::new(format!("stratis-{}-{}-flex-{}",
-                           FORMAT_VERSION,
-                           pool_uuid.simple().to_string(),
-                           role))
-            .expect("FORMAT_VERSION display length < 72")
+pub fn format_flex_ids(pool_uuid: PoolUuid, role: FlexRole) -> (DmNameBuf, DmUuidBuf) {
+    (DmNameBuf::new(format!("stratis-{}-{}-flex-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display length < 72"),
+     DmUuidBuf::new(format!("stratis-{}-{}-flex-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display length < 72"))
 
 }
 
-/// Format a name for the thin layer.
+/// Format a name & uuid for the thin layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 50
-pub fn format_thin_name(pool_uuid: PoolUuid, role: ThinRole) -> DmNameBuf {
-    DmNameBuf::new(format!("stratis-{}-{}-thin-{}",
-                           FORMAT_VERSION,
-                           pool_uuid.simple().to_string(),
-                           role))
-            .expect("FORMAT_VERSION display length < 50")
+pub fn format_thin_ids(pool_uuid: PoolUuid, role: ThinRole) -> (DmNameBuf, DmUuidBuf) {
+    (DmNameBuf::new(format!("stratis-{}-{}-thin-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display length < 50"),
+     DmUuidBuf::new(format!("stratis-{}-{}-thin-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display length < 50"))
 }
 
-/// Format a name for the thin pool layer.
+/// Format a name & uuid for the thin pool layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 81
-pub fn format_thinpool_name(pool_uuid: PoolUuid, role: ThinPoolRole) -> DmNameBuf {
-    DmNameBuf::new(format!("stratis-{}-{}-thinpool-{}",
-                           FORMAT_VERSION,
-                           pool_uuid.simple().to_string(),
-                           role))
-            .expect("FORMAT_VERSION display_length < 81")
+pub fn format_thinpool_ids(pool_uuid: PoolUuid, role: ThinPoolRole) -> (DmNameBuf, DmUuidBuf) {
+    (DmNameBuf::new(format!("stratis-{}-{}-thinpool-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display_length < 81"),
+     DmUuidBuf::new(format!("stratis-{}-{}-thinpool-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display_length < 81"))
 }
 
-/// Format a name for dm devices in the backstore.
+/// Format a name & uuid for dm devices in the backstore.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION) < 76
-pub fn format_backstore_name(pool_uuid: PoolUuid, role: CacheRole) -> DmNameBuf {
-    DmNameBuf::new(format!("stratis-{}-{}-physical-{}",
-                           FORMAT_VERSION,
-                           pool_uuid.simple().to_string(),
-                           role))
-            .expect("FORMAT_VERSION display_length < 78")
+pub fn format_backstore_ids(pool_uuid: PoolUuid, role: CacheRole) -> (DmNameBuf, DmUuidBuf) {
+    (DmNameBuf::new(format!("stratis-{}-{}-physical-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display_length < 76"),
+     DmUuidBuf::new(format!("stratis-{}-{}-physical-{}",
+                            FORMAT_VERSION,
+                            pool_uuid.simple().to_string(),
+                            role))
+             .expect("FORMAT_VERSION display_length < 76"))
 }

--- a/src/engine/strat_engine/dmnames.rs
+++ b/src/engine/strat_engine/dmnames.rs
@@ -88,60 +88,44 @@ impl Display for CacheRole {
 /// Format a name & uuid for the flex layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 72
 pub fn format_flex_ids(pool_uuid: PoolUuid, role: FlexRole) -> (DmNameBuf, DmUuidBuf) {
-    (DmNameBuf::new(format!("stratis-{}-{}-flex-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display length < 72"),
-     DmUuidBuf::new(format!("stratis-{}-{}-flex-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display length < 72"))
+    let value = format!("stratis-{}-{}-flex-{}",
+                        FORMAT_VERSION,
+                        pool_uuid.simple().to_string(),
+                        role);
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 72"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 73"))
 
 }
 
 /// Format a name & uuid for the thin layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 50
 pub fn format_thin_ids(pool_uuid: PoolUuid, role: ThinRole) -> (DmNameBuf, DmUuidBuf) {
-    (DmNameBuf::new(format!("stratis-{}-{}-thin-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display length < 50"),
-     DmUuidBuf::new(format!("stratis-{}-{}-thin-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display length < 50"))
+    let value = format!("stratis-{}-{}-thin-{}",
+                        FORMAT_VERSION,
+                        pool_uuid.simple().to_string(),
+                        role);
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 50"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 51"))
 }
 
 /// Format a name & uuid for the thin pool layer.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 81
 pub fn format_thinpool_ids(pool_uuid: PoolUuid, role: ThinPoolRole) -> (DmNameBuf, DmUuidBuf) {
-    (DmNameBuf::new(format!("stratis-{}-{}-thinpool-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display_length < 81"),
-     DmUuidBuf::new(format!("stratis-{}-{}-thinpool-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display_length < 81"))
+    let value = format!("stratis-{}-{}-thinpool-{}",
+                        FORMAT_VERSION,
+                        pool_uuid.simple().to_string(),
+                        role);
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 81"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 82"))
 }
 
 /// Format a name & uuid for dm devices in the backstore.
 /// Prerequisite: len(format!("{}", FORMAT_VERSION) < 76
 pub fn format_backstore_ids(pool_uuid: PoolUuid, role: CacheRole) -> (DmNameBuf, DmUuidBuf) {
-    (DmNameBuf::new(format!("stratis-{}-{}-physical-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display_length < 76"),
-     DmUuidBuf::new(format!("stratis-{}-{}-physical-{}",
-                            FORMAT_VERSION,
-                            pool_uuid.simple().to_string(),
-                            role))
-             .expect("FORMAT_VERSION display_length < 76"))
+    let value = format!("stratis-{}-{}-physical-{}",
+                        FORMAT_VERSION,
+                        pool_uuid.simple().to_string(),
+                        role);
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 76"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 77"))
 }

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -4,8 +4,8 @@
 
 use std::path::{Path, PathBuf};
 
-use devicemapper::{Bytes, DM, DmDevice, DmName, IEC, SECTOR_SIZE, Sectors, ThinDev, ThinDevId,
-                   ThinPoolDev, ThinStatus};
+use devicemapper::{Bytes, DM, DmDevice, DmName, DmUuid, IEC, SECTOR_SIZE, Sectors, ThinDev,
+                   ThinDevId, ThinPoolDev, ThinStatus};
 
 use mnt::{MountIter, MountParam};
 use nix::mount::{MsFlags, mount, umount};
@@ -61,14 +61,19 @@ impl StratFilesystem {
                     dm: &DM,
                     thin_pool: &ThinPoolDev,
                     snapshot_name: &str,
-                    snapshot_dmname: &DmName,
+                    snapshot_dm_name: &DmName,
+                    snapshot_dm_uuid: Option<&DmUuid>,
                     snapshot_fs_name: &Name,
                     snapshot_fs_uuid: FilesystemUuid,
                     snapshot_thin_id: ThinDevId)
                     -> EngineResult<StratFilesystem> {
 
         match self.thin_dev
-                  .snapshot(dm, snapshot_dmname, None, thin_pool, snapshot_thin_id) {
+                  .snapshot(dm,
+                            snapshot_dm_name,
+                            snapshot_dm_uuid,
+                            thin_pool,
+                            snapshot_thin_id) {
             Ok(thin_dev) => {
                 // If the source is mounted, XFS puts a dummy record in the
                 // log to enforce replay of the snapshot to deal with any

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -566,8 +566,8 @@ impl ThinPool {
                                snapshot_name: &str)
                                -> EngineResult<FilesystemUuid> {
         let snapshot_fs_uuid = Uuid::new_v4();
-        let (snapshot_dm_name, _) = format_thin_ids(self.pool_uuid,
-                                                    ThinRole::Filesystem(snapshot_fs_uuid));
+        let (snapshot_dm_name, snapshot_dm_uuid) =
+            format_thin_ids(self.pool_uuid, ThinRole::Filesystem(snapshot_fs_uuid));
         let snapshot_id = self.id_gen.new_id()?;
         let new_filesystem = match self.get_filesystem_by_uuid(origin_uuid) {
             Some((fs_name, filesystem)) => {
@@ -576,6 +576,7 @@ impl ThinPool {
                               &self.thin_pool,
                               snapshot_name,
                               &snapshot_dm_name,
+                              Some(&snapshot_dm_uuid),
                               &fs_name,
                               snapshot_fs_uuid,
                               snapshot_id)?

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -23,8 +23,8 @@ use super::super::super::types::{FilesystemUuid, Name, PoolUuid, RenameAction};
 use super::super::backstore::Backstore;
 use super::super::device::wipe_sectors;
 use super::super::devlinks;
-use super::super::dmnames::{FlexRole, ThinPoolRole, ThinRole, format_flex_name, format_thin_name,
-                            format_thinpool_name};
+use super::super::dmnames::{FlexRole, ThinPoolRole, ThinRole, format_flex_ids, format_thin_ids,
+                            format_thinpool_ids};
 use super::super::serde_structs::{FlexDevsSave, Recordable, ThinPoolDevSave};
 
 use super::filesystem::{FilesystemStatus, StratFilesystem};
@@ -186,28 +186,30 @@ impl ThinPool {
         // superblock DM issue error messages because it triggers code paths
         // that are trying to re-adopt the device with the attributes that
         // have been passed.
+        let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::ThinMeta);
         let meta_dev = LinearDev::setup(dm,
-                                        &format_flex_name(pool_uuid, FlexRole::ThinMeta),
-                                        None,
+                                        &dm_name,
+                                        Some(&dm_uuid),
                                         segs_to_table(backstore.device(), &meta_segments))?;
         wipe_sectors(&meta_dev.devnode(), Sectors(0), thin_pool_size.meta_size())?;
 
+        let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::ThinData);
         let data_dev = LinearDev::setup(dm,
-                                        &format_flex_name(pool_uuid, FlexRole::ThinData),
-                                        None,
+                                        &dm_name,
+                                        Some(&dm_uuid),
                                         segs_to_table(backstore.device(), &data_segments))?;
 
-        let mdv_name = format_flex_name(pool_uuid, FlexRole::MetadataVolume);
+        let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::MetadataVolume);
         let mdv_dev = LinearDev::setup(dm,
-                                       &mdv_name,
-                                       None,
+                                       &dm_name,
+                                       Some(&dm_uuid),
                                        segs_to_table(backstore.device(), &mdv_segments))?;
         let mdv = MetadataVol::initialize(pool_uuid, mdv_dev)?;
 
-        let name = format_thinpool_name(pool_uuid, ThinPoolRole::Pool);
+        let (dm_name, dm_uuid) = format_thinpool_ids(pool_uuid, ThinPoolRole::Pool);
         let thinpool_dev = ThinPoolDev::new(dm,
-                                            &name,
-                                            None,
+                                            &dm_name,
+                                            Some(&dm_uuid),
                                             meta_dev,
                                             data_dev,
                                             data_block_size,
@@ -244,7 +246,7 @@ impl ThinPool {
         let data_segments = flex_devs.thin_data_dev.to_vec();
         let spare_segments = flex_devs.thin_meta_dev_spare.to_vec();
 
-        let thinpool_name = format_thinpool_name(pool_uuid, ThinPoolRole::Pool);
+        let (thinpool_name, thinpool_uuid) = format_thinpool_ids(pool_uuid, ThinPoolRole::Pool);
         let (meta_dev, meta_segments, spare_segments) = setup_metadev(dm,
                                                                       pool_uuid,
                                                                       &thinpool_name,
@@ -252,22 +254,24 @@ impl ThinPool {
                                                                       meta_segments,
                                                                       spare_segments)?;
 
+        let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::ThinData);
         let data_dev = LinearDev::setup(dm,
-                                        &format_flex_name(pool_uuid, FlexRole::ThinData),
-                                        None,
+                                        &dm_name,
+                                        Some(&dm_uuid),
                                         segs_to_table(backstore.device(), &data_segments))?;
 
         let thinpool_dev = ThinPoolDev::setup(dm,
                                               &thinpool_name,
-                                              None,
+                                              Some(&thinpool_uuid),
                                               meta_dev,
                                               data_dev,
                                               data_block_size,
                                               low_water_mark)?;
 
+        let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::MetadataVolume);
         let mdv_dev = LinearDev::setup(dm,
-                                       &format_flex_name(pool_uuid, FlexRole::MetadataVolume),
-                                       None,
+                                       &dm_name,
+                                       Some(&dm_uuid),
                                        segs_to_table(backstore.device(), &mdv_segments))?;
         let mdv = MetadataVol::setup(pool_uuid, mdv_dev)?;
         let filesystem_metadatas = mdv.filesystems()?;
@@ -276,10 +280,11 @@ impl ThinPool {
         let filesystems = filesystem_metadatas
             .iter()
             .map(|fssave| {
-                let device_name = format_thin_name(pool_uuid, ThinRole::Filesystem(fssave.uuid));
+                let (dm_name, dm_uuid) = format_thin_ids(pool_uuid,
+                                                         ThinRole::Filesystem(fssave.uuid));
                 let thin_dev = ThinDev::setup(dm,
-                                              &device_name,
-                                              None,
+                                              &dm_name,
+                                              Some(&dm_uuid),
                                               fssave.size,
                                               &thinpool_dev,
                                               fssave.thin_id)?;
@@ -535,10 +540,10 @@ impl ThinPool {
                              size: Option<Sectors>)
                              -> EngineResult<FilesystemUuid> {
         let fs_uuid = Uuid::new_v4();
-        let device_name = format_thin_name(self.pool_uuid, ThinRole::Filesystem(fs_uuid));
+        let (dm_name, dm_uuid) = format_thin_ids(self.pool_uuid, ThinRole::Filesystem(fs_uuid));
         let thin_dev = ThinDev::new(dm,
-                                    &device_name,
-                                    None,
+                                    &dm_name,
+                                    Some(&dm_uuid),
                                     size.unwrap_or(DEFAULT_THIN_DEV_SIZE),
                                     &self.thin_pool,
                                     self.id_gen.new_id()?)?;
@@ -561,8 +566,8 @@ impl ThinPool {
                                snapshot_name: &str)
                                -> EngineResult<FilesystemUuid> {
         let snapshot_fs_uuid = Uuid::new_v4();
-        let snapshot_dmname = format_thin_name(self.pool_uuid,
-                                               ThinRole::Filesystem(snapshot_fs_uuid));
+        let (snapshot_dm_name, _) = format_thin_ids(self.pool_uuid,
+                                                    ThinRole::Filesystem(snapshot_fs_uuid));
         let snapshot_id = self.id_gen.new_id()?;
         let new_filesystem = match self.get_filesystem_by_uuid(origin_uuid) {
             Some((fs_name, filesystem)) => {
@@ -570,7 +575,7 @@ impl ThinPool {
                     .snapshot(dm,
                               &self.thin_pool,
                               snapshot_name,
-                              &snapshot_dmname,
+                              &snapshot_dm_name,
                               &fs_name,
                               snapshot_fs_uuid,
                               snapshot_id)?
@@ -632,10 +637,10 @@ impl ThinPool {
 
     /// The names of DM devices belonging to this pool that may generate events
     pub fn get_eventing_dev_names(&self) -> Vec<DmNameBuf> {
-        vec![format_flex_name(self.pool_uuid, FlexRole::ThinMeta),
-             format_flex_name(self.pool_uuid, FlexRole::ThinData),
-             format_flex_name(self.pool_uuid, FlexRole::MetadataVolume),
-             format_thinpool_name(self.pool_uuid, ThinPoolRole::Pool)]
+        vec![format_flex_ids(self.pool_uuid, FlexRole::ThinMeta).0,
+             format_flex_ids(self.pool_uuid, FlexRole::ThinData).0,
+             format_flex_ids(self.pool_uuid, FlexRole::MetadataVolume).0,
+             format_thinpool_ids(self.pool_uuid, ThinPoolRole::Pool).0]
 
     }
 }
@@ -672,9 +677,10 @@ fn setup_metadev(dm: &DM,
                  spare_segments: Vec<(Sectors, Sectors)>)
                  -> EngineResult<(LinearDev, Vec<(Sectors, Sectors)>, Vec<(Sectors, Sectors)>)> {
     #![allow(collapsible_if)]
+    let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::ThinMeta);
     let mut meta_dev = LinearDev::setup(dm,
-                                        &format_flex_name(pool_uuid, FlexRole::ThinMeta),
-                                        None,
+                                        &dm_name,
+                                        Some(&dm_uuid),
                                         segs_to_table(device, &meta_segments))?;
 
     if !device_exists(dm, thinpool_name)? {
@@ -703,9 +709,10 @@ fn attempt_thin_repair(pool_uuid: PoolUuid,
                        device: Device,
                        spare_segments: &[(Sectors, Sectors)])
                        -> EngineResult<LinearDev> {
+    let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::ThinMetaSpare);
     let mut new_meta_dev = LinearDev::setup(dm,
-                                            &format_flex_name(pool_uuid, FlexRole::ThinMetaSpare),
-                                            None,
+                                            &dm_name,
+                                            Some(&dm_uuid),
                                             segs_to_table(device, spare_segments))?;
 
     execute_cmd(Command::new("thin_repair")
@@ -968,10 +975,10 @@ mod tests {
             .unwrap()
             .1
             .thin_id();
-        let device_name = format_thin_name(pool_uuid, ThinRole::Filesystem(fs_uuid));
+        let (dm_name, dm_uuid) = format_thin_ids(pool_uuid, ThinRole::Filesystem(fs_uuid));
         let thindev = ThinDev::setup(&dm,
-                                     &device_name,
-                                     None,
+                                     &dm_name,
+                                     Some(&dm_uuid),
                                      DEFAULT_THIN_DEV_SIZE,
                                      &pool.thin_pool,
                                      thin_id);
@@ -979,7 +986,7 @@ mod tests {
         pool.destroy_filesystem(&dm, pool_name, fs_uuid).unwrap();
 
         let thindev = ThinDev::setup(&dm,
-                                     &device_name,
+                                     &dm_name,
                                      None,
                                      DEFAULT_THIN_DEV_SIZE,
                                      &pool.thin_pool,


### PR DESCRIPTION
Change dm name generation functions in dmnames.rs to also generate
DmUuidBufs.

Change calls to DM setup functions to specify UUID instead of None.

The only spot that still needs work is where we call ThinDev::snapshot,
because it needs to additionally take an Option<&DmUuid>.

see https://github.com/stratis-storage/devicemapper-rs/pull/270

fixes #782

Signed-off-by: Andy Grover <agrover@redhat.com>