### PR TITLE
Remove an obsoleted comment

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -43,10 +43,8 @@ struct DataTier {
 
 impl DataTier {
     /// Setup a previously existing data layer from the block_mgr and
-    /// previously allocated segments. There is a possibility that the
-    /// size of some blockdev has changed for the bigger since the last time
-    /// its metadata was recorded, so allocate any unallocated segments that
-    /// might have resulted from this.
+    /// previously allocated segments.
+    ///
     /// WARNING: metadata changing event
     pub fn setup(dm: &DM,
                  block_mgr: BlockDevMgr,


### PR DESCRIPTION
The method can no longer be called in a context where the block_mgr
has any available space.

This should have gone in with
https://github.com/stratis-storage/stratisd/pull/793, really.

Signed-off-by: mulhern <amulhern@redhat.com>