### PR TITLE
SeekFrom::Start() takes bytes as a parameter (not Sectors)

### DIFF
--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -22,7 +22,7 @@ pub fn write_sectors<P: AsRef<Path>>(path: P,
     let mut f = BufWriter::with_capacity(IEC::Mi as usize,
                                          OpenOptions::new().write(true).open(path)?);
 
-    f.seek(SeekFrom::Start(*offset))?;
+    f.seek(SeekFrom::Start(*offset.bytes()))?;
     for _ in 0..*length {
         f.write_all(buf)?;
     }


### PR DESCRIPTION
See: https://doc.rust-lang.org/std/io/enum.SeekFrom.html

Note: Currently only called with an offset of 0.

Signed-off-by: Todd Gill <tgill@redhat.com>