### PR TITLE
Use available space if double isn't available

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -248,6 +248,11 @@ impl Backstore {
         self.data_tier.current_capacity()
     }
 
+    /// The available number of Sectors.
+    pub fn available(&self) -> Sectors {
+        self.data_tier.available()
+    }
+
     /// Destroy the entire store.
     pub fn destroy(self, dm: &DM) -> EngineResult<()> {
         self.data_tier.destroy(dm)

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -358,9 +358,14 @@ impl ThinPool {
 
                 if usage.used_data > cmp::max(usage.total_data, DATA_LOWATER) - DATA_LOWATER {
                     // Request expansion of physical space allocated to the pool
-                    // TODO: we just request that the space be doubled here.
+                    // TODO: we request that the space be doubled or use the remaining space by
+                    // requesting the minimum total_data vs. available space.
                     // A more sophisticated approach might be in order.
-                    match self.extend_thinpool(dm, usage.total_data, backstore) {
+                    match self.extend_thinpool(dm,
+                                               DataBlocks(cmp::min(*usage.total_data,
+                                                                   backstore.available() /
+                                                                   DATA_BLOCK_SIZE)),
+                                               backstore) {
                         #![allow(single_match)]
                         Ok(_) => should_save = true,
                         Err(_) => {} // TODO: Take pool offline?


### PR DESCRIPTION
If there is insufficient space available to double the physical space
allocated to a pool.  Request the remaining available space.

Signed-off-by: Todd Gill <tgill@redhat.com>