### PR TITLE
Add 'private' to uuid for internal device mapper devices

### DIFF
--- a/src/engine/strat_engine/dmnames.rs
+++ b/src/engine/strat_engine/dmnames.rs
@@ -89,20 +89,21 @@ impl Display for CacheRole {
 ///
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)
 ///             + len("stratis")                         7
+///             + len("private")                         7
 ///             + len("flex")                            4
-///             + num_dashes                             4
+///             + num_dashes                             5
 ///             + len(pool uuid)                         32
 ///             + max(len(FlexRole))                     13
 ///             < 128 (129 for UUID)
 ///
-/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 68 (69 for UUID)
+/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 60 (61 for UUID)
 pub fn format_flex_ids(pool_uuid: PoolUuid, role: FlexRole) -> (DmNameBuf, DmUuidBuf) {
-    let value = format!("stratis-{}-{}-flex-{}",
+    let value = format!("stratis-{}-private-{}-flex-{}",
                         FORMAT_VERSION,
                         pool_uuid.simple().to_string(),
                         role);
-    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 68"),
-     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 69"))
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 60"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 61"))
 
 }
 
@@ -130,38 +131,40 @@ pub fn format_thin_ids(pool_uuid: PoolUuid, role: ThinRole) -> (DmNameBuf, DmUui
 ///
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)
 ///             + len("stratis")                         7
+///             + len("private")                         7
 ///             + len("thinpool")                        8
-///             + num_dashes                             4
+///             + num_dashes                             5
 ///             + len(pool uuid)                         32
 ///             + max(len(ThinPoolRole))                 4
 ///             < 128 (129 for UUID)
 ///
-/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 73 (74 for UUID)
+/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 65 (66 for UUID)
 pub fn format_thinpool_ids(pool_uuid: PoolUuid, role: ThinPoolRole) -> (DmNameBuf, DmUuidBuf) {
-    let value = format!("stratis-{}-{}-thinpool-{}",
+    let value = format!("stratis-{}-private-{}-thinpool-{}",
                         FORMAT_VERSION,
                         pool_uuid.simple().to_string(),
                         role);
-    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 73"),
-     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 74"))
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 65"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 66"))
 }
 
 /// Format a name & uuid for dm devices in the backstore.
 ///
 /// Prerequisite: len(format!("{}", FORMAT_VERSION)
 ///             + len("stratis")                         7
+///             + len("private")                         7
 ///             + len("physical")                        8
-///             + num_dashes                             4
+///             + num_dashes                             5
 ///             + len(pool uuid)                         32
 ///             + max(len(CacheRole))                    9
 ///             < 128 (129 for UUID)
 ///
-/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 68 (69 for UUID)
+/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 60 (61 for UUID)
 pub fn format_backstore_ids(pool_uuid: PoolUuid, role: CacheRole) -> (DmNameBuf, DmUuidBuf) {
-    let value = format!("stratis-{}-{}-physical-{}",
+    let value = format!("stratis-{}-private-{}-physical-{}",
                         FORMAT_VERSION,
                         pool_uuid.simple().to_string(),
                         role);
-    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 68"),
-     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 69"))
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 60"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 61"))
 }


### PR DESCRIPTION
As requested by upstream `util-linux` lets make the uuid simpler for comparison.  I'm following the suggestion by Andy during our meeting.

I've also made the corresponding change to `util-linux` for our review before posting upstream on mailing list, ref. https://github.com/tasleson/utils-linux/pull/2

Signed-off-by: Tony Asleson <tasleson@redhat.com>