### PR TITLE
Formalize prerequisites about length of FORMAT_VERSION

### DIFF
--- a/src/engine/strat_engine/dmnames.rs
+++ b/src/engine/strat_engine/dmnames.rs
@@ -86,46 +86,82 @@ impl Display for CacheRole {
 }
 
 /// Format a name & uuid for the flex layer.
-/// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 72
+///
+/// Prerequisite: len(format!("{}", FORMAT_VERSION)
+///             + len("stratis")                         7
+///             + len("flex")                            4
+///             + num_dashes                             4
+///             + len(pool uuid)                         32
+///             + max(len(FlexRole))                     13
+///             < 128 (129 for UUID)
+///
+/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 68 (69 for UUID)
 pub fn format_flex_ids(pool_uuid: PoolUuid, role: FlexRole) -> (DmNameBuf, DmUuidBuf) {
     let value = format!("stratis-{}-{}-flex-{}",
                         FORMAT_VERSION,
                         pool_uuid.simple().to_string(),
                         role);
-    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 72"),
-     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 73"))
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 68"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 69"))
 
 }
 
 /// Format a name & uuid for the thin layer.
-/// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 50
+///
+/// Prerequisite: len(format!("{}", FORMAT_VERSION)
+///             + len("stratis")                         7
+///             + len("thin")                            4
+///             + num_dashes                             4
+///             + len(pool uuid)                         32
+///             + max(len(ThinRole))                     35
+///             < 128 (129 for UUID)
+///
+/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 46 (47 for UUID)
 pub fn format_thin_ids(pool_uuid: PoolUuid, role: ThinRole) -> (DmNameBuf, DmUuidBuf) {
     let value = format!("stratis-{}-{}-thin-{}",
                         FORMAT_VERSION,
                         pool_uuid.simple().to_string(),
                         role);
-    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 50"),
-     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 51"))
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display length < 46"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display length < 47"))
 }
 
 /// Format a name & uuid for the thin pool layer.
-/// Prerequisite: len(format!("{}", FORMAT_VERSION)) < 81
+///
+/// Prerequisite: len(format!("{}", FORMAT_VERSION)
+///             + len("stratis")                         7
+///             + len("thinpool")                        8
+///             + num_dashes                             4
+///             + len(pool uuid)                         32
+///             + max(len(ThinPoolRole))                 4
+///             < 128 (129 for UUID)
+///
+/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 73 (74 for UUID)
 pub fn format_thinpool_ids(pool_uuid: PoolUuid, role: ThinPoolRole) -> (DmNameBuf, DmUuidBuf) {
     let value = format!("stratis-{}-{}-thinpool-{}",
                         FORMAT_VERSION,
                         pool_uuid.simple().to_string(),
                         role);
-    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 81"),
-     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 82"))
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 73"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 74"))
 }
 
 /// Format a name & uuid for dm devices in the backstore.
-/// Prerequisite: len(format!("{}", FORMAT_VERSION) < 76
+///
+/// Prerequisite: len(format!("{}", FORMAT_VERSION)
+///             + len("stratis")                         7
+///             + len("physical")                        8
+///             + num_dashes                             4
+///             + len(pool uuid)                         32
+///             + max(len(CacheRole))                    9
+///             < 128 (129 for UUID)
+///
+/// which is equivalent to len(format!("{}", FORMAT_VERSION) < 68 (69 for UUID)
 pub fn format_backstore_ids(pool_uuid: PoolUuid, role: CacheRole) -> (DmNameBuf, DmUuidBuf) {
     let value = format!("stratis-{}-{}-physical-{}",
                         FORMAT_VERSION,
                         pool_uuid.simple().to_string(),
                         role);
-    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 76"),
-     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 77"))
+    (DmNameBuf::new(value.clone()).expect("FORMAT_VERSION display_length < 68"),
+     DmUuidBuf::new(value).expect("FORMAT_VERSION display_length < 69"))
 }


### PR DESCRIPTION
So that the values are more likely to remain correct as the values on
which they depend change.

Signed-off-by: mulhern <amulhern@redhat.com>