### PR TITLE
Temporarily do not use get_mount_point in fs snapshot code

### DIFF
--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -84,17 +84,18 @@ impl StratFilesystem {
                 //
                 // If the source is unmounted the XFS log will be clean so
                 // we can skip the mount/unmount.
-                if self.get_mount_point()?.is_some() {
-                    let tmp_dir = TempDir::new("stratis_mp_")?;
-                    // Mount the snapshot with the "nouuid" option. mount
-                    // will fail due to duplicate UUID otherwise.
-                    mount(Some(&thin_dev.devnode()),
-                          tmp_dir.path(),
-                          Some("xfs"),
-                          MsFlags::empty(),
-                          Some("nouuid"))?;
-                    umount(tmp_dir.path())?;
-                }
+
+                // FIXME: get_mount_point doesn't work so assume we need to mount/unmount
+                let tmp_dir = TempDir::new("stratis_mp_")?;
+                // Mount the snapshot with the "nouuid" option. mount
+                // will fail due to duplicate UUID otherwise.
+                mount(Some(&thin_dev.devnode()),
+                      tmp_dir.path(),
+                      Some("xfs"),
+                      MsFlags::empty(),
+                      Some("nouuid"))?;
+                umount(tmp_dir.path())?;
+
                 set_uuid(&thin_dev.devnode(), snapshot_fs_uuid)?;
                 Ok(StratFilesystem::setup(thin_dev))
             }


### PR DESCRIPTION
It doesn't currently work, because its implementation via mnt-rs crate only
looks at /proc/mounts not /proc/self/mountinfo.

It should be safe to unconditionally do this, both when the origin fs is
mounted and when it is unmounted.

Signed-off-by: Andy Grover <agrover@redhat.com>