### PR TITLE
Correct BDA layout

### DIFF
--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -55,12 +55,12 @@ impl BDA {
 
         // Write 8K header. Static_Header copies go in sectors 1 and 9.
         f.seek(SeekFrom::Start(0))?;
-        f.write_all(&zeroed[..SECTOR_SIZE])?;               // Zero 1 unused sector
+        f.write_all(&zeroed[..SECTOR_SIZE])?; // Zero 1 unused sector
         f.write_all(&hdr_buf)?;
-        f.write_all(&zeroed[..SECTOR_SIZE * 7])?;           // Zero 7 unused sectors
+        f.write_all(&zeroed[..SECTOR_SIZE * 7])?; // Zero 7 unused sectors
         f.flush()?;
         f.write_all(&hdr_buf)?;
-        f.write_all(&zeroed[..SECTOR_SIZE * 6])?;           // Zero 6 unused sectors
+        f.write_all(&zeroed[..SECTOR_SIZE * 6])?; // Zero 6 unused sectors
         f.flush()?;
 
         let regions = mda::MDARegions::initialize(BDA_STATIC_HDR_SIZE, header.mda_size, &mut f)?;

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -55,12 +55,12 @@ impl BDA {
 
         // Write 8K header. Static_Header copies go in sectors 1 and 9.
         f.seek(SeekFrom::Start(0))?;
-        f.write_all(&zeroed[..SECTOR_SIZE])?;
+        f.write_all(&zeroed[..SECTOR_SIZE])?;               // Zero 1 unused sector
         f.write_all(&hdr_buf)?;
-        f.write_all(&zeroed[SECTOR_SIZE * 7..])?;
+        f.write_all(&zeroed[..SECTOR_SIZE * 7])?;           // Zero 7 unused sectors
         f.flush()?;
         f.write_all(&hdr_buf)?;
-        f.write_all(&zeroed[SECTOR_SIZE * 6..])?;
+        f.write_all(&zeroed[..SECTOR_SIZE * 6])?;           // Zero 6 unused sectors
         f.flush()?;
 
         let regions = mda::MDARegions::initialize(BDA_STATIC_HDR_SIZE, header.mda_size, &mut f)?;


### PR DESCRIPTION
The code was incorrectly placing the second copy BDA @ sector 11 instead of
sector 9.  This was because:

f.write_all(&zeroed[SECTOR_SIZE * 7..])?;

actually writes 9 sectors (sectors 7..15).  This coupled with the first
2 sector writes places the second BDA copy at sector 11.  This was
found because libblkid was failing to zero the second copy signature.

Signed-off-by: Tony Asleson <tasleson@redhat.com>