### PR TITLE
Fix fs_usage() for variable-size return values

### DIFF
--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -221,10 +221,8 @@ impl Filesystem for StratFilesystem {
 pub fn fs_usage(mount_point: &Path) -> EngineResult<(Bytes, Bytes)> {
     let stat = statvfs(mount_point)?;
 
-    // stat.block_size() is type c_ulong, which is 32 bits on some archs.
-    // Upcast to u64.
-    let f_bsize = stat.block_size() as u64;
-
-    let blocks = stat.blocks();
-    Ok((Bytes(f_bsize * blocks), Bytes(f_bsize * (blocks - stat.blocks_free()))))
+    // Upcast all arch-dependent variable width values to u64
+    let (block_size, blocks, blocks_free) =
+        (stat.block_size() as u64, stat.blocks() as u64, stat.blocks_free() as u64);
+    Ok((Bytes(block_size * blocks), Bytes(block_size * (blocks - blocks_free))))
 }


### PR DESCRIPTION
The nix::sys::statvfs::Statfvs object returned from Nix's statvfs()
function has methods that change return value depending on the
CPU architecture width. In order to work on 32 bit systems, we need to cast
these return values to u64, since our data types are not defined using
arch-specific sizes.

Signed-off-by: Andy Grover <agrover@redhat.com>