### PR TITLE
Add targets to the Makefile PEP8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ matrix:
           before_script:
               - cd tests/client-dbus
           env: TASK=lint
+        - language: python
+          python: "3.4"
+          install: pip3 install -r tests/client-dbus/requirements.txt
+          before_script:
+              - cd tests/client-dbus
+          env: TASK=fmt-travis
 
 branches:
     only: master

--- a/tests/client-dbus/Makefile
+++ b/tests/client-dbus/Makefile
@@ -1,8 +1,16 @@
 TOX=tox
-
 .PHONY: lint
 lint:
 	$(TOX) -c tox.ini -e lint
 
+.PHONY: dbus-tests
 dbus-tests:
 	py.test-3 ./tests/dbus
+
+.PHONY: fmt
+fmt:
+	yapf --style pep8 --recursive --in-place . check.py setup.py src tests
+
+.PHONY: fmt-travis
+fmt-travis:
+	yapf --style pep8 --recursive --diff . check.py setup.py src tests

--- a/tests/client-dbus/README.rst
+++ b/tests/client-dbus/README.rst
@@ -27,3 +27,7 @@ Contributing
 ------------
 Issues suggesting tests or pull requests that extend the existing test suite
 are welcome.
+
+The code style standard is PEP8.  Travis CI runs a compliance test on
+all pull requests via yapf.  Please auto format code before opening a pull 
+request via "make fmt".

--- a/tests/client-dbus/check.py
+++ b/tests/client-dbus/check.py
@@ -8,14 +8,12 @@ arg_map = {
    "src/stratisd_client_dbus" : [
       "--reports=no",
       "--disable=I",
-      "--disable=bad-continuation",
       "--disable=invalid-name",
       "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
    ],
    "tests" : [
       "--reports=no",
       "--disable=I",
-      "--disable=bad-continuation",
       "--disable=duplicate-code",
       "--disable=invalid-name",
       "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"

--- a/tests/client-dbus/check.py
+++ b/tests/client-dbus/check.py
@@ -5,20 +5,17 @@ import subprocess
 import sys
 
 arg_map = {
-   "src/stratisd_client_dbus" : [
-      "--reports=no",
-      "--disable=I",
-      "--disable=invalid-name",
-      "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
-   ],
-   "tests" : [
-      "--reports=no",
-      "--disable=I",
-      "--disable=duplicate-code",
-      "--disable=invalid-name",
-      "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
-   ]
+    "src/stratisd_client_dbus": [
+        "--reports=no", "--disable=I", "--disable=invalid-name",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
+    ],
+    "tests": [
+        "--reports=no", "--disable=I", "--disable=duplicate-code",
+        "--disable=invalid-name",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
+    ]
 }
+
 
 def get_parser():
     """
@@ -29,12 +26,12 @@ def get_parser():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-       "package",
-       choices=arg_map.keys(),
-       help="designates the package to test"
-    )
+        "package",
+        choices=arg_map.keys(),
+        help="designates the package to test")
     parser.add_argument("--ignore", help="ignore these files")
     return parser
+
 
 def get_command(namespace):
     """
@@ -46,6 +43,7 @@ def get_command(namespace):
     if namespace.ignore:
         cmd.append("--ignore=%s" % namespace.ignore)
     return cmd
+
 
 def main():
     args = get_parser().parse_args()

--- a/tests/client-dbus/requirements.txt
+++ b/tests/client-dbus/requirements.txt
@@ -1,1 +1,2 @@
 tox
+yapf

--- a/tests/client-dbus/setup.py
+++ b/tests/client-dbus/setup.py
@@ -4,8 +4,10 @@ import setuptools
 if sys.version_info[0] < 3:
     from codecs import open
 
+
 def local_file(name):
     return os.path.relpath(os.path.join(os.path.dirname(__file__), name))
+
 
 README = local_file("README.rst")
 
@@ -16,10 +18,10 @@ setuptools.setup(
     description='testing library for stratisd',
     long_description=open(README, encoding='utf-8').read(),
     platforms=['Linux'],
-    install_requires = [
-       'dbus-client-gen>=0.2',
-       'dbus-python-client-gen>=0.6',
+    install_requires=[
+        'dbus-client-gen>=0.2',
+        'dbus-python-client-gen>=0.6',
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),
-    )
+)

--- a/tests/client-dbus/src/stratisd_client_dbus/__init__.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Top-level classes and methods.
 """

--- a/tests/client-dbus/src/stratisd_client_dbus/_connection.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_connection.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Miscellaneous helpful methods.
 """
@@ -38,6 +37,7 @@ class Bus(object):
             Bus._BUS = dbus.SystemBus()
 
         return Bus._BUS
+
 
 def get_object(object_path):
     """

--- a/tests/client-dbus/src/stratisd_client_dbus/_constants.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_constants.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 General constants.
 """

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -11,22 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 XML interface specifications.
 """
 
 SPECS = {
-"org.freedesktop.DBus.ObjectManager" :
-"""
+    "org.freedesktop.DBus.ObjectManager":
+    """
 <interface name="org.freedesktop.DBus.ObjectManager">
 <method name="GetManagedObjects">
 <arg name="objpath_interfaces_and_properties" type="a{oa{sa{sv}}}" direction="out"/>
 </method>
 </interface>
 """,
-"org.storage.stratis1.Manager" :
-"""
+    "org.storage.stratis1.Manager":
+    """
 <interface name="org.storage.stratis1.Manager">
 <method name="ConfigureSimulator">
 <arg name="denominator" type="u" direction="in"/>
@@ -53,8 +52,8 @@ SPECS = {
 </property>
 </interface>
 """,
-"org.storage.stratis1.pool" :
-"""
+    "org.storage.stratis1.pool":
+    """
 <interface name="org.storage.stratis1.pool">
 <method name="AddCacheDevs">
 <arg name="force" type="b" direction="in"/>
@@ -109,8 +108,8 @@ SPECS = {
 </property>
 </interface>
 """,
-"org.storage.stratis1.filesystem" :
-"""
+    "org.storage.stratis1.filesystem":
+    """
 <interface name="org.storage.stratis1.filesystem">
 <method name="SetName">
 <arg name="name" type="s" direction="in"/>
@@ -132,8 +131,8 @@ SPECS = {
 </property>
 </interface>
 """,
-"org.storage.stratis1.blockdev":
-"""
+    "org.storage.stratis1.blockdev":
+    """
 <interface name="org.storage.stratis1.blockdev">
 <method name="SetUserInfo">
 <arg name="id" type="s" direction="in"/>

--- a/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Classes to implement dbus interface.
 """
@@ -24,22 +23,16 @@ from ._data import SPECS
 
 TIME_OUT = 120  # In seconds
 
-ObjectManager = make_class(
-   "ObjectManager",
-   ET.fromstring(SPECS['org.freedesktop.DBus.ObjectManager']),
-   TIME_OUT
-)
-Manager = make_class(
-   "Manager",
-   ET.fromstring(SPECS['org.storage.stratis1.Manager']),
-   TIME_OUT
-)
-Filesystem = make_class(
-   "Filesystem",
-   ET.fromstring(SPECS['org.storage.stratis1.filesystem']),
-   TIME_OUT
-)
-Pool = make_class(
-   "Pool", ET.fromstring(SPECS['org.storage.stratis1.pool']),
-   TIME_OUT
-)
+ObjectManager = make_class("ObjectManager",
+                           ET.fromstring(
+                               SPECS['org.freedesktop.DBus.ObjectManager']),
+                           TIME_OUT)
+Manager = make_class("Manager",
+                     ET.fromstring(SPECS['org.storage.stratis1.Manager']),
+                     TIME_OUT)
+Filesystem = make_class("Filesystem",
+                        ET.fromstring(
+                            SPECS['org.storage.stratis1.filesystem']),
+                        TIME_OUT)
+Pool = make_class("Pool", ET.fromstring(SPECS['org.storage.stratis1.pool']),
+                  TIME_OUT)

--- a/tests/client-dbus/src/stratisd_client_dbus/_managedobjects.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_managedobjects.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Wrapper for GetManagedObjects() result.
 """
@@ -24,14 +23,14 @@ from dbus_client_gen import mo_query_builder
 from ._data import SPECS
 
 pools = mo_query_builder(ET.fromstring(SPECS['org.storage.stratis1.pool']))
-filesystems = mo_query_builder(ET.fromstring(SPECS['org.storage.stratis1.filesystem']))
-blockdevs = mo_query_builder(ET.fromstring(SPECS['org.storage.stratis1.blockdev']))
+filesystems = mo_query_builder(
+    ET.fromstring(SPECS['org.storage.stratis1.filesystem']))
+blockdevs = mo_query_builder(
+    ET.fromstring(SPECS['org.storage.stratis1.blockdev']))
 
-MOPool = managed_object_class(
-   "MOPool",
-   ET.fromstring(SPECS['org.storage.stratis1.pool'])
-)
-MOBlockDev = managed_object_class(
-   "MOBlockDev",
-   ET.fromstring(SPECS['org.storage.stratis1.blockdev'])
-)
+MOPool = managed_object_class("MOPool",
+                              ET.fromstring(
+                                  SPECS['org.storage.stratis1.pool']))
+MOBlockDev = managed_object_class("MOBlockDev",
+                                  ET.fromstring(
+                                      SPECS['org.storage.stratis1.blockdev']))

--- a/tests/client-dbus/src/stratisd_client_dbus/_stratisd_constants.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_stratisd_constants.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Representing stratisd contants.
 """

--- a/tests/client-dbus/tests/dbus/_dm.py
+++ b/tests/client-dbus/tests/dbus/_dm.py
@@ -11,15 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 """
 Functionality pertaining to device mapper
 """
 
 import os
 import subprocess
-
 
 _DM_BIN = os.getenv('STRATIS_DMSETUP_BIN', "/usr/sbin/dmsetup")
 
@@ -40,8 +37,8 @@ def _remove_device(device):
     :param device: The device to remove
     :return: True if device was removed, else False
     """
-    return_code = subprocess.call([_DM_BIN, 'remove', device],
-                                  stderr=subprocess.PIPE)
+    return_code = subprocess.call(
+        [_DM_BIN, 'remove', device], stderr=subprocess.PIPE)
     return return_code == 0
 
 

--- a/tests/client-dbus/tests/dbus/_loopback.py
+++ b/tests/client-dbus/tests/dbus/_loopback.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Class to handle loop back devices.
 """
@@ -56,8 +55,8 @@ class LoopBackDevices(object):
             # Sparse file, so go big (1 TiB)
             bd.truncate(1024**4)
 
-        result = subprocess.check_output([_LOSETUP_BIN, '-f',
-                                          '--show', backing_file])
+        result = subprocess.check_output(
+            [_LOSETUP_BIN, '-f', '--show', backing_file])
         device = str.strip(result.decode("utf-8"))
         token = uuid.uuid4()
         self.devices[token] = (device, backing_file)
@@ -98,8 +97,8 @@ class LoopBackDevices(object):
         if token in self.devices:
             (_, backing_file) = self.devices[token]
 
-            result = subprocess.check_output([_LOSETUP_BIN, '-f', '--show',
-                                    backing_file])
+            result = subprocess.check_output(
+                [_LOSETUP_BIN, '-f', '--show', backing_file])
             device = str.strip(result.decode("utf-8"))
             self.devices[token] = (device, backing_file)
 

--- a/tests/client-dbus/tests/dbus/_misc.py
+++ b/tests/client-dbus/tests/dbus/_misc.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Miscellaneous methods to support testing.
 """
@@ -32,12 +31,9 @@ def _device_list(minimum):
     :param int minimum: the minimum number of devices, must be at least 0
     """
     return strategies.lists(
-       strategies.text(
-          alphabet=string.ascii_letters + "/",
-          min_size=1
-       ),
-       min_size=minimum
-    )
+        strategies.text(alphabet=string.ascii_letters + "/", min_size=1),
+        min_size=minimum)
+
 
 class Service(object):
     """

--- a/tests/client-dbus/tests/dbus/filesystem/test_rename.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_rename.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test renaming a filesystem.
 """
@@ -52,19 +51,15 @@ class SetNameTestCase(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': _DEVICE_STRATEGY.example()
+            })
         self._pool_object = get_object(self._pool_object_path)
         (created, _, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': [self._fs_name]}
-        )
+            self._pool_object, {'specs': [self._fs_name]})
         self._filesystem_object_path = created[0][0]
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -79,10 +74,8 @@ class SetNameTestCase(unittest.TestCase):
         Test rename to same name.
         """
         filesystem = get_object(self._filesystem_object_path)
-        (result, rc, _) = Filesystem.Methods.SetName(
-           filesystem,
-           {'name': self._fs_name}
-        )
+        (result, rc, _) = Filesystem.Methods.SetName(filesystem,
+                                                     {'name': self._fs_name})
 
         self.assertEqual(rc, StratisdErrors.OK)
         self.assertFalse(result)
@@ -92,17 +85,16 @@ class SetNameTestCase(unittest.TestCase):
         Test rename to new name.
         """
         filesystem = get_object(self._filesystem_object_path)
-        (result, rc, _) = Filesystem.Methods.SetName(
-           filesystem,
-           {'name': "new"}
-        )
+        (result, rc, _) = Filesystem.Methods.SetName(filesystem,
+                                                     {'name': "new"})
 
         self.assertEqual(rc, StratisdErrors.OK)
         self.assertTrue(result)
 
         managed_objects = \
            ObjectManager.Methods.GetManagedObjects(self._proxy, {})
-        (fs_object_path, _) = next(filesystems(managed_objects, {'Name': 'new'}))
+        (fs_object_path, _) = next(
+            filesystems(managed_objects, {'Name': 'new'}))
         self.assertEqual(self._filesystem_object_path, fs_object_path)
 
         fs_object_path = \

--- a/tests/client-dbus/tests/dbus/manager/test_create.py
+++ b/tests/client-dbus/tests/dbus/manager/test_create.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'CreatePool'.
 """
@@ -64,14 +63,12 @@ class Create2TestCase(unittest.TestCase):
         """
         devs = _DEVICE_STRATEGY.example()
         ((poolpath, devnodes), rc, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': devs
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': devs
+            })
 
         managed_objects = \
            ObjectManager.Methods.GetManagedObjects(self._proxy, {})
@@ -88,8 +85,7 @@ class Create2TestCase(unittest.TestCase):
             pool_info = MOPool(table)
             self.assertLessEqual(
                 int(pool_info.TotalPhysicalUsed()),
-                int(pool_info.TotalPhysicalSize())
-            )
+                int(pool_info.TotalPhysicalSize()))
         else:
             self.assertIsNone(result)
             self.assertEqual(len(all_pools), 0)
@@ -100,15 +96,14 @@ class Create2TestCase(unittest.TestCase):
         """
         devs = _DEVICE_STRATEGY.example()
         (_, rc, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 1),
-              'force': False,
-              'devices': devs
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 1),
+                'force': False,
+                'devices': devs
+            })
         self.assertEqual(rc, StratisdErrors.ERROR)
+
 
 class Create3TestCase(unittest.TestCase):
     """
@@ -125,14 +120,12 @@ class Create3TestCase(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': _DEVICE_STRATEGY.example()
+            })
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
     def tearDown(self):
@@ -145,17 +138,16 @@ class Create3TestCase(unittest.TestCase):
         """
         Create should fail trying to create new pool with same name as previous.
         """
-        pools1 = pools(ObjectManager.Methods.GetManagedObjects(self._proxy, {}))
+        pools1 = pools(
+            ObjectManager.Methods.GetManagedObjects(self._proxy, {}))
 
         (_, rc, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': _DEVICE_STRATEGY.example()
+            })
         expected_rc = StratisdErrors.ALREADY_EXISTS
         self.assertEqual(rc, expected_rc)
 
@@ -166,6 +158,5 @@ class Create3TestCase(unittest.TestCase):
 
         self.assertIsNotNone(pool)
         self.assertEqual(
-           frozenset(x for (x, y) in pools1),
-           frozenset(x for (x, y) in pools2)
-        )
+            frozenset(x for (x, y) in pools1), frozenset(
+                x for (x, y) in pools2))

--- a/tests/client-dbus/tests/dbus/manager/test_destroy.py
+++ b/tests/client-dbus/tests/dbus/manager/test_destroy.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test DestroyPool.
 """
@@ -33,8 +32,8 @@ from stratisd_client_dbus._constants import TOP_OBJECT
 from .._misc import _device_list
 from .._misc import Service
 
-
 _DEVICE_STRATEGY = _device_list(0)
+
 
 class Destroy1TestCase(unittest.TestCase):
     """
@@ -94,14 +93,12 @@ class Destroy2TestCase(unittest.TestCase):
         self._proxy = get_object(TOP_OBJECT)
         self._devices = _DEVICE_STRATEGY.example()
         Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': self._devices
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': self._devices
+            })
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
     def tearDown(self):
@@ -119,9 +116,8 @@ class Destroy2TestCase(unittest.TestCase):
         (pool1, _) = next(pools(managed_objects, {'Name': self._POOLNAME}))
         blockdevs1 = blockdevs(managed_objects, {'Pool': pool1})
         self.assertEqual(
-           frozenset(MOBlockDev(b).Devnode() for (_, b) in blockdevs1),
-           frozenset(d for d in self._devices)
-        )
+            frozenset(MOBlockDev(b).Devnode() for (_, b) in blockdevs1),
+            frozenset(d for d in self._devices))
 
         (result, rc, _) = \
                 Manager.Methods.DestroyPool(self._proxy, {'pool': pool1})
@@ -155,18 +151,14 @@ class Destroy3TestCase(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': _DEVICE_STRATEGY.example()
+            })
         Pool.Methods.CreateFilesystems(
-           get_object(poolpath),
-           {'specs': [self._VOLNAME]}
-        )
+            get_object(poolpath), {'specs': [self._VOLNAME]})
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
     def tearDown(self):
@@ -209,14 +201,12 @@ class Destroy4TestCase(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': []
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': []
+            })
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
     def tearDown(self):
@@ -243,5 +233,4 @@ class Destroy4TestCase(unittest.TestCase):
         managed_objects = \
            ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         self.assertIsNone(
-           next(pools(managed_objects, {'Name': self._POOLNAME}), None)
-        )
+            next(pools(managed_objects, {'Name': self._POOLNAME}), None))

--- a/tests/client-dbus/tests/dbus/manager/test_object_path.py
+++ b/tests/client-dbus/tests/dbus/manager/test_object_path.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test object path methods.
 """
@@ -22,7 +21,6 @@ from stratisd_client_dbus import get_object
 
 from .._misc import _device_list
 from .._misc import Service
-
 
 _DEVICE_STRATEGY = _device_list(0)
 
@@ -38,7 +36,7 @@ class GetObjectTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1) # wait until the service is available
+        time.sleep(1)  # wait until the service is available
 
     def tearDown(self):
         """

--- a/tests/client-dbus/tests/dbus/manager/test_stratis.py
+++ b/tests/client-dbus/tests/dbus/manager/test_stratis.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'stratisd'.
 """
@@ -60,6 +59,7 @@ class StratisTestCase(unittest.TestCase):
         version = Manager.Properties.Version.Get(get_object(TOP_OBJECT))
         (major, _, _) = version.split(".")
         self.assertEqual(major, "0")
+
 
 class StratisTestCase2(unittest.TestCase):
     """

--- a/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test adding blockdevs to a pool.
 """
@@ -51,14 +50,12 @@ class AddCacheDevsTestCase1(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': []
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': []
+            })
         self._pool_object = get_object(poolpath)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -76,13 +73,10 @@ class AddCacheDevsTestCase1(unittest.TestCase):
            ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         (pool, _) = next(pools(managed_objects, {'Name': self._POOLNAME}))
 
-        (result, rc, _) = Pool.Methods.AddCacheDevs(
-           self._pool_object,
-           {
-              'force': False,
-              'devices': []
-           }
-        )
+        (result, rc, _) = Pool.Methods.AddCacheDevs(self._pool_object, {
+            'force': False,
+            'devices': []
+        })
 
         self.assertEqual(len(result), 0)
         self.assertEqual(rc, StratisdErrors.OK)
@@ -103,13 +97,11 @@ class AddCacheDevsTestCase1(unittest.TestCase):
            ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         (pool, _) = next(pools(managed_objects, {'Name': self._POOLNAME}))
 
-        (result, rc, _) = Pool.Methods.AddCacheDevs(
-           self._pool_object,
-           {
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+        (result, rc,
+         _) = Pool.Methods.AddCacheDevs(self._pool_object, {
+             'force': False,
+             'devices': _DEVICE_STRATEGY.example()
+         })
 
         num_devices_added = len(result)
         managed_objects = \
@@ -135,7 +127,7 @@ class AddCacheDevsTestCase1(unittest.TestCase):
         self.assertEqual(len(list(blockdevs3)), num_devices_added)
 
         # There are no datadevs belonging to this pool
-        blockdevs4 = blockdevs(managed_objects, {'Pool': pool, 'Tier':  0})
+        blockdevs4 = blockdevs(managed_objects, {'Pool': pool, 'Tier': 0})
         self.assertEqual(list(blockdevs4), [])
 
 
@@ -155,14 +147,12 @@ class AddCacheDevsTestCase2(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, devpaths), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': _DEVICE_STRATEGY.example()
+            })
         self._pool_object = get_object(poolpath)
         self._devpaths = frozenset(devpaths)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
@@ -182,17 +172,15 @@ class AddCacheDevsTestCase2(unittest.TestCase):
         (pool, _) = next(pools(managed_objects, {'Name': self._POOLNAME}))
 
         blockdevs1 = blockdevs(managed_objects, {'Pool': pool, 'Tier': 0})
-        self.assertEqual(self._devpaths, frozenset(op for (op, _) in blockdevs1))
+        self.assertEqual(self._devpaths, frozenset(
+            op for (op, _) in blockdevs1))
         blockdevs2 = blockdevs(managed_objects, {'Pool': pool, 'Tier': 1})
         self.assertEqual(list(blockdevs2), [])
 
-        (result, rc, _) = Pool.Methods.AddCacheDevs(
-           self._pool_object,
-           {
-              'force': False,
-              'devices': []
-           }
-        )
+        (result, rc, _) = Pool.Methods.AddCacheDevs(self._pool_object, {
+            'force': False,
+            'devices': []
+        })
 
         self.assertEqual(len(result), 0)
         self.assertEqual(rc, StratisdErrors.OK)
@@ -200,7 +188,8 @@ class AddCacheDevsTestCase2(unittest.TestCase):
         managed_objects = \
            ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         blockdevs3 = blockdevs(managed_objects, {'Pool': pool})
-        self.assertEqual(frozenset(op for (op, _) in blockdevs3), self._devpaths)
+        self.assertEqual(
+            frozenset(op for (op, _) in blockdevs3), self._devpaths)
 
     def testSomeDevs(self):
         """
@@ -211,14 +200,13 @@ class AddCacheDevsTestCase2(unittest.TestCase):
         (pool, _) = next(pools(managed_objects, {'Name': self._POOLNAME}))
 
         blockdevs1 = blockdevs(managed_objects, {'Pool': pool, 'Tier': 0})
-        self.assertEqual(self._devpaths, frozenset(op for (op, _) in blockdevs1))
-        (result, rc, _) = Pool.Methods.AddCacheDevs(
-           self._pool_object,
-           {
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+        self.assertEqual(self._devpaths, frozenset(
+            op for (op, _) in blockdevs1))
+        (result, rc,
+         _) = Pool.Methods.AddCacheDevs(self._pool_object, {
+             'force': False,
+             'devices': _DEVICE_STRATEGY.example()
+         })
 
         num_devices_added = len(result)
         managed_objects = \
@@ -232,11 +220,13 @@ class AddCacheDevsTestCase2(unittest.TestCase):
         blockdev_object_paths = frozenset(result)
 
         # cache blockdevs exported on the D-Bus are exactly those added
-        blockdevs2 = list(blockdevs(managed_objects, {'Pool': pool, 'Tier': 1}))
+        blockdevs2 = list(
+            blockdevs(managed_objects, {
+                'Pool': pool,
+                'Tier': 1
+            }))
         self.assertEqual(
-           frozenset(op for (op, _) in blockdevs2),
-           blockdev_object_paths
-        )
+            frozenset(op for (op, _) in blockdevs2), blockdev_object_paths)
 
         # no duplicates in the object paths
         self.assertEqual(len(blockdevs2), num_devices_added)
@@ -248,4 +238,5 @@ class AddCacheDevsTestCase2(unittest.TestCase):
 
         # The number of datadevs has remained the same
         blockdevs5 = blockdevs(managed_objects, {'Pool': pool, 'Tier': 0})
-        self.assertEqual(frozenset(op for (op, _) in blockdevs5), self._devpaths)
+        self.assertEqual(
+            frozenset(op for (op, _) in blockdevs5), self._devpaths)

--- a/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test adding blockdevs to a pool.
 """
@@ -51,14 +50,12 @@ class AddDataDevsTestCase(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': []
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': []
+            })
         self._pool_object = get_object(poolpath)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -79,13 +76,10 @@ class AddDataDevsTestCase(unittest.TestCase):
         blockdevs1 = blockdevs(managed_objects, {'Pool': pool})
         self.assertEqual(list(blockdevs1), [])
 
-        (result, rc, _) = Pool.Methods.AddDataDevs(
-           self._pool_object,
-           {
-              'force': False,
-              'devices': []
-           }
-        )
+        (result, rc, _) = Pool.Methods.AddDataDevs(self._pool_object, {
+            'force': False,
+            'devices': []
+        })
 
         self.assertEqual(result, [])
         self.assertEqual(rc, StratisdErrors.OK)
@@ -110,13 +104,11 @@ class AddDataDevsTestCase(unittest.TestCase):
         blockdevs1 = blockdevs(managed_objects, {'Pool': pool})
         self.assertEqual(list(blockdevs1), [])
 
-        (result, rc, _) = Pool.Methods.AddDataDevs(
-           self._pool_object,
-           {
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+        (result, rc,
+         _) = Pool.Methods.AddDataDevs(self._pool_object, {
+             'force': False,
+             'devices': _DEVICE_STRATEGY.example()
+         })
 
         num_devices_added = len(result)
         managed_objects = \
@@ -142,5 +134,5 @@ class AddDataDevsTestCase(unittest.TestCase):
         self.assertEqual(len(list(blockdevs3)), num_devices_added)
 
         # There are no cachedevs belonging to this pool
-        blockdevs4 = blockdevs(managed_objects, {'Pool': pool, 'Tier':  1})
+        blockdevs4 = blockdevs(managed_objects, {'Pool': pool, 'Tier': 1})
         self.assertEqual(list(blockdevs4), [])

--- a/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
@@ -11,14 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test creating a filesystem in a pool.
 """
 
 import time
 import unittest
-
 
 from stratisd_client_dbus import Manager
 from stratisd_client_dbus import ObjectManager
@@ -52,14 +50,12 @@ class CreateFSTestCase(unittest.TestCase):
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': self._devs
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': self._devs
+            })
         self._pool_object = get_object(poolpath)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -76,9 +72,7 @@ class CreateFSTestCase(unittest.TestCase):
         number of volumes.
         """
         (result, rc, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': []}
-        )
+            self._pool_object, {'specs': []})
 
         self.assertEqual(len(result), 0)
         self.assertEqual(rc, StratisdErrors.OK)
@@ -95,9 +89,7 @@ class CreateFSTestCase(unittest.TestCase):
         new_name = "name"
 
         (result, rc, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': [new_name, new_name]}
-        )
+            self._pool_object, {'specs': [new_name, new_name]})
 
         self.assertEqual(rc, StratisdErrors.OK)
         self.assertEqual(len(result), 1)
@@ -128,19 +120,15 @@ class CreateFSTestCase1(unittest.TestCase):
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': self._devs
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': self._devs
+            })
         self._pool_object = get_object(poolpath)
-        Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': [self._VOLNAME]}
-        )
+        Pool.Methods.CreateFilesystems(self._pool_object,
+                                       {'specs': [self._VOLNAME]})
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
     def tearDown(self):
@@ -156,9 +144,7 @@ class CreateFSTestCase1(unittest.TestCase):
         fail, and no additional volume should be created.
         """
         (result, rc, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': [self._VOLNAME]}
-        )
+            self._pool_object, {'specs': [self._VOLNAME]})
 
         self.assertEqual(rc, StratisdErrors.ALREADY_EXISTS)
         self.assertEqual(len(result), 0)
@@ -175,9 +161,7 @@ class CreateFSTestCase1(unittest.TestCase):
         new_name = "newname"
 
         (result, rc, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': [new_name]}
-        )
+            self._pool_object, {'specs': [new_name]})
 
         self.assertEqual(rc, StratisdErrors.OK)
         self.assertEqual(len(result), 1)
@@ -197,9 +181,7 @@ class CreateFSTestCase1(unittest.TestCase):
         fail, and no additional volume should be created.
         """
         (result, rc, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': [self._VOLNAME, "newname"]}
-        )
+            self._pool_object, {'specs': [self._VOLNAME, "newname"]})
 
         self.assertEqual(rc, StratisdErrors.ALREADY_EXISTS)
         self.assertEqual(len(result), 0)
@@ -215,9 +197,7 @@ class CreateFSTestCase1(unittest.TestCase):
         multiple volume support is added back - this test should be removed.
         """
         (result, rc, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': ["a", "b"]}
-        )
+            self._pool_object, {'specs': ["a", "b"]})
 
         self.assertEqual(rc, StratisdErrors.ERROR)
         self.assertEqual(len(result), 0)

--- a/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test destroying a filesystem in a pool.
 """
@@ -51,14 +50,12 @@ class DestroyFSTestCase(unittest.TestCase):
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': self._devs
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': self._devs
+            })
         self._pool_object = get_object(poolpath)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -75,9 +72,7 @@ class DestroyFSTestCase(unittest.TestCase):
         number of volumes.
         """
         (result, rc, _) = Pool.Methods.DestroyFilesystems(
-           self._pool_object,
-           {'filesystems': []}
-        )
+            self._pool_object, {'filesystems': []})
 
         self.assertEqual(len(result), 0)
         self.assertEqual(rc, StratisdErrors.OK)
@@ -92,9 +87,7 @@ class DestroyFSTestCase(unittest.TestCase):
         because at the end the filesystem is not there.
         """
         (result, rc, _) = Pool.Methods.DestroyFilesystems(
-           self._pool_object,
-           {'filesystems': ['/']}
-        )
+            self._pool_object, {'filesystems': ['/']})
         self.assertEqual(rc, StratisdErrors.OK)
         self.assertEqual(len(result), 0)
 
@@ -121,19 +114,15 @@ class DestroyFSTestCase1(unittest.TestCase):
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((self._poolpath, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': self._devs
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': self._devs
+            })
         self._pool_object = get_object(self._poolpath)
         (self._filesystems, _, _) = Pool.Methods.CreateFilesystems(
-           self._pool_object,
-           {'specs': [(self._VOLNAME, '', None)]}
-        )
+            self._pool_object, {'specs': [(self._VOLNAME, '', None)]})
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
     def tearDown(self):
@@ -149,9 +138,7 @@ class DestroyFSTestCase1(unittest.TestCase):
         """
         fs_object_path = self._filesystems[0][0]
         (result, rc, _) = Pool.Methods.DestroyFilesystems(
-           self._pool_object,
-           {'filesystems': [fs_object_path]}
-        )
+            self._pool_object, {'filesystems': [fs_object_path]})
 
         self.assertEqual(len(result), 1)
         self.assertEqual(rc, StratisdErrors.OK)
@@ -168,9 +155,7 @@ class DestroyFSTestCase1(unittest.TestCase):
         """
         fs_object_path = self._filesystems[0][0]
         (result, rc, _) = Pool.Methods.DestroyFilesystems(
-           self._pool_object,
-           {'filesystems': [fs_object_path, "/"]}
-        )
+            self._pool_object, {'filesystems': [fs_object_path, "/"]})
 
         self.assertEqual(len(result), 1)
         self.assertEqual(rc, StratisdErrors.OK)

--- a/tests/client-dbus/tests/dbus/pool/test_rename.py
+++ b/tests/client-dbus/tests/dbus/pool/test_rename.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test renaming a pool.
 """
@@ -50,14 +49,12 @@ class SetNameTestCase(unittest.TestCase):
         time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
-           self._proxy,
-           {
-              'name': self._POOLNAME,
-              'redundancy': (True, 0),
-              'force': False,
-              'devices': _DEVICE_STRATEGY.example()
-           }
-        )
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': _DEVICE_STRATEGY.example()
+            })
         self._pool_object = get_object(self._pool_object_path)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -71,10 +68,8 @@ class SetNameTestCase(unittest.TestCase):
         """
         Test rename to same name.
         """
-        (result, rc, _) = Pool.Methods.SetName(
-           self._pool_object,
-           {'name': self._POOLNAME}
-        )
+        (result, rc, _) = Pool.Methods.SetName(self._pool_object,
+                                               {'name': self._POOLNAME})
 
         self.assertEqual(rc, StratisdErrors.OK)
         self.assertFalse(result)
@@ -92,10 +87,8 @@ class SetNameTestCase(unittest.TestCase):
         """
         new_name = "new"
 
-        (result, rc, _) = Pool.Methods.SetName(
-           self._pool_object,
-           {'name': new_name}
-        )
+        (result, rc, _) = Pool.Methods.SetName(self._pool_object,
+                                               {'name': new_name})
 
         self.assertTrue(result)
         self.assertEqual(rc, StratisdErrors.OK)
@@ -103,8 +96,7 @@ class SetNameTestCase(unittest.TestCase):
         managed_objects = \
            ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         self.assertIsNone(
-           next(pools(managed_objects, {'Name': self._POOLNAME}), None)
-        )
+            next(pools(managed_objects, {'Name': self._POOLNAME}), None))
         result = next(pools(managed_objects, {'Name': new_name}), None)
         self.assertIsNotNone(result)
         (pool, _) = result

--- a/tests/client-dbus/tests/dbus/pool/test_udev.py
+++ b/tests/client-dbus/tests/dbus/pool/test_udev.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 """
 Used to test udev "add" event in stratisd
 """
@@ -49,8 +47,9 @@ def rs(l):
         random.choice(string.ascii_uppercase) for _ in range(l)))
 
 
-@unittest.skipIf(os.getenv('STRATIS_DESTRUCTIVE_TEST') is None,
-                 "STRATIS_DESTRUCTIVE_TEST not set")
+@unittest.skipIf(
+    os.getenv('STRATIS_DESTRUCTIVE_TEST') is None,
+    "STRATIS_DESTRUCTIVE_TEST not set")
 class UdevAdd(unittest.TestCase):
     """
     Test udev add event support.
@@ -65,14 +64,12 @@ class UdevAdd(unittest.TestCase):
         :return: Dbus proxy object representing pool.
         """
         ((pool_object_path, _), _, _) = Manager.Methods.CreatePool(
-            get_object(TOP_OBJECT),
-            {
+            get_object(TOP_OBJECT), {
                 'name': name,
                 'redundancy': (True, 0),
                 'force': False,
                 'devices': devices
-            }
-        )
+            })
         return get_object(pool_object_path)
 
     def _device_files(self, tokens):
@@ -114,7 +111,7 @@ class UdevAdd(unittest.TestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(
             get_object(TOP_OBJECT), {})
 
-        selector = {} if name is None else {'Name' : name}
+        selector = {} if name is None else {'Name': name}
         return list(pools(managed_objects, selector))
 
     def _start_service(self):
@@ -126,8 +123,8 @@ class UdevAdd(unittest.TestCase):
 
         if self._service is None:
             dbus_interface_present = False
-            self._service = subprocess.Popen([os.path.join(_STRATISD),
-                                              '--debug'])
+            self._service = subprocess.Popen(
+                [os.path.join(_STRATISD), '--debug'])
 
             limit = time.time() + 10.0
             while time.time() <= limit:
@@ -178,7 +175,9 @@ class UdevAdd(unittest.TestCase):
         time.sleep(1)
 
     # pylint: disable=too-many-locals
-    def _test_driver(self, number_of_pools, dev_count_pool,
+    def _test_driver(self,
+                     number_of_pools,
+                     dev_count_pool,
                      some_existing=False):
         """
         We want to test 1..N number of devices in the following scenarios:
@@ -407,6 +406,7 @@ class UdevAdd(unittest.TestCase):
                     self._lb_mgr.generate_udev_add_event(d)
 
             self._settle()
-            self.assertEqual(len(UdevAdd._get_pools()), existing_pool_count + 1)
+            self.assertEqual(
+                len(UdevAdd._get_pools()), existing_pool_count + 1)
 
         self.assertEqual(len(UdevAdd._get_pools()), num_pools)


### PR DESCRIPTION
Add two targets to the makefile to support PEP8 formatting style:

```
fmt: format the code to PEP8
fmt-travis: check for PEP8 compliance via travis
```

Reformatted code with the format target.  Updated the README.rst to include formatting instructions for pull requests.
