### PR TITLE
Get rid of a bunch of check() functions that aren't used anymore

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -176,9 +176,6 @@ pub trait Engine: Debug {
     /// denominator: the probably of failure is 1/denominator.
     fn configure_simulator(&mut self, denominator: u32) -> EngineResult<()>;
 
-    /// Check pools' current state and take appropriate actions
-    fn check(&mut self) -> ();
-
     /// Get all pools belonging to this engine.
     fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)>;
 

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -66,15 +66,6 @@ macro_rules! rename_pool_pre {
     }
 }
 
-macro_rules! check_engine {
-    ( $s:ident ) => {
-        for (pool_name, _, pool) in &mut $s.pools {
-            // FIXME: It is not really correct to ignore result of pool.check().
-            let _ = pool.check(pool_name);
-        }
-    }
-}
-
 macro_rules! set_blockdev_user_info {
     ( $s:ident; $info:ident ) => {
         if $s.user_info.as_ref().map(|x| &**x) != $info {

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -114,10 +114,6 @@ impl Engine for SimEngine {
         Ok(())
     }
 
-    fn check(&mut self) -> () {
-        check_engine!(self)
-    }
-
     fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)> {
         self.pools
             .iter()

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -51,10 +51,6 @@ impl SimPool {
          })
     }
 
-    pub fn check(&mut self, _name: &Name) -> EngineResult<()> {
-        Ok(())
-    }
-
     pub fn has_filesystems(&self) -> bool {
         !self.filesystems.is_empty()
     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -272,10 +272,6 @@ impl Engine for StratEngine {
         Ok(()) // we're not the simulator and not configurable, so just say ok
     }
 
-    fn check(&mut self) -> () {
-        check_engine!(self);
-    }
-
     fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)> {
         self.pools
             .iter()

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -120,18 +120,6 @@ impl StratPool {
         self.backstore.save_state(data.as_bytes())
     }
 
-    pub fn check(&mut self, name: &Name) -> EngineResult<()> {
-        // FIXME: The context should not be created here as this is not
-        // a public method. Ideally the context should be created in the
-        // invoking method, Engine::check(). However, since we hope that
-        // method will go away entirely, we just fix half of the problem
-        // with this method, and leave the rest alone.
-        if self.thin_pool.check(&DM::new()?, &mut self.backstore)? {
-            self.write_metadata(name)?;
-        }
-        Ok(())
-    }
-
     /// Teardown a pool.
     pub fn teardown(self, dm: &DM) -> EngineResult<()> {
         self.thin_pool.teardown(dm)?;


### PR DESCRIPTION
These function were made dead by PR#703 and previous PRs which introduced
an eventing mechanism supplanting the code that called check() on the
engine every few seconds. They are no longer needed. This change also
eliminates two FIXMEs and the need for some other code improvements having
to do with the instantiation of a devicemapper context.

Signed-off-by: mulhern <amulhern@redhat.com>