### PR TITLE
Add a method to initialize a devicemapper context just once

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -181,7 +181,7 @@ pub trait Engine: Debug {
 
     /// If the engine would like to include an event in the message loop, it
     /// may return an Eventable from this method.
-    fn get_eventable(&self) -> EngineResult<Option<Box<Eventable>>>;
+    fn get_eventable(&self) -> EngineResult<Option<&'static Eventable>>;
 
     /// Notify the engine that an event has occurred on the Eventable.
     fn evented(&mut self) -> EngineResult<()>;

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -121,7 +121,7 @@ impl Engine for SimEngine {
             .collect()
     }
 
-    fn get_eventable(&self) -> EngineResult<Option<Box<Eventable>>> {
+    fn get_eventable(&self) -> EngineResult<Option<&'static Eventable>> {
         Ok(None)
     }
 

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -9,13 +9,14 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 
-use devicemapper::{CacheDev, DM, Device, DmDevice, IEC, LinearDev, MIN_CACHE_BLOCK_SIZE, Sectors};
+use devicemapper::{CacheDev, Device, DmDevice, IEC, LinearDev, MIN_CACHE_BLOCK_SIZE, Sectors};
 
 use super::super::super::engine::BlockDev;
 use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
 
 use super::super::device::wipe_sectors;
+use super::super::dm::get_dm_context;
 use super::super::dmnames::{CacheRole, format_backstore_ids};
 use super::super::serde_structs::{BackstoreSave, Recordable};
 
@@ -47,8 +48,7 @@ impl DataTier {
     ///
     /// Returns the DataTier and the linear DM device that was created during
     /// setup.
-    pub fn setup(dm: &DM,
-                 block_mgr: BlockDevMgr,
+    pub fn setup(block_mgr: BlockDevMgr,
                  segments: &[(DevUuid, Sectors, Sectors)])
                  -> EngineResult<(DataTier, LinearDev)> {
         if block_mgr.avail_space() != Sectors(0) {
@@ -73,7 +73,10 @@ impl DataTier {
             .collect::<EngineResult<Vec<_>>>()?;
 
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::OriginSub);
-        let ld = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&segments))?;
+        let ld = LinearDev::setup(get_dm_context(),
+                                  &dm_name,
+                                  Some(&dm_uuid),
+                                  map_to_dm(&segments))?;
 
         Ok((DataTier {
                 block_mgr,
@@ -88,7 +91,7 @@ impl DataTier {
     /// Returns the DataTier and the linear device that was created.
     ///
     /// WARNING: metadata changing event
-    pub fn new(dm: &DM, mut block_mgr: BlockDevMgr) -> EngineResult<(DataTier, LinearDev)> {
+    pub fn new(mut block_mgr: BlockDevMgr) -> EngineResult<(DataTier, LinearDev)> {
         let avail_space = block_mgr.avail_space();
         let segments = block_mgr
             .alloc_space(&[avail_space])
@@ -98,7 +101,10 @@ impl DataTier {
             .cloned()
             .collect::<Vec<_>>();
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::OriginSub);
-        let ld = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&segments))?;
+        let ld = LinearDev::setup(get_dm_context(),
+                                  &dm_name,
+                                  Some(&dm_uuid),
+                                  map_to_dm(&segments))?;
         Ok((DataTier {
                 block_mgr,
                 segments,
@@ -110,7 +116,6 @@ impl DataTier {
     /// corresponding to the specified paths.
     /// WARNING: metadata changing event
     pub fn add(&mut self,
-               dm: &DM,
                cache: Option<&mut CacheDev>,
                linear: Option<&mut LinearDev>,
                paths: &[&Path],
@@ -139,12 +144,12 @@ impl DataTier {
 
         match (cache, linear) {
             (Some(cache), None) => {
-                cache.set_origin_table(dm, table)?;
-                cache.resume(dm)
+                cache.set_origin_table(get_dm_context(), table)?;
+                cache.resume(get_dm_context())
             }
             (None, Some(linear)) => {
-                linear.set_table(dm, table)?;
-                linear.resume(dm)
+                linear.set_table(get_dm_context(), table)?;
+                linear.resume(get_dm_context())
             }
             _ => panic!("see assertions at top of method"),
         }?;
@@ -226,8 +231,7 @@ impl CacheTier {
     ///
     /// Returns the CacheTier and the cache DM device that was created during
     /// setup.
-    pub fn setup(dm: &DM,
-                 block_mgr: BlockDevMgr,
+    pub fn setup(block_mgr: BlockDevMgr,
                  origin: LinearDev,
                  cache_segments: &[(DevUuid, Sectors, Sectors)],
                  meta_segments: &[(DevUuid, Sectors, Sectors)])
@@ -254,17 +258,23 @@ impl CacheTier {
             .map(&mapper)
             .collect::<EngineResult<Vec<_>>>()?;
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::MetaSub);
-        let meta = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&meta_segments))?;
+        let meta = LinearDev::setup(get_dm_context(),
+                                    &dm_name,
+                                    Some(&dm_uuid),
+                                    map_to_dm(&meta_segments))?;
 
         let cache_segments = cache_segments
             .iter()
             .map(&mapper)
             .collect::<EngineResult<Vec<_>>>()?;
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::CacheSub);
-        let cache = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&cache_segments))?;
+        let cache = LinearDev::setup(get_dm_context(),
+                                     &dm_name,
+                                     Some(&dm_uuid),
+                                     map_to_dm(&cache_segments))?;
 
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::Cache);
-        let cd = CacheDev::setup(dm,
+        let cd = CacheDev::setup(get_dm_context(),
                                  &dm_name,
                                  Some(&dm_uuid),
                                  meta,
@@ -289,7 +299,6 @@ impl CacheTier {
     // Presumably, the size required for the meta sub-device varies directly
     // with the size of cache sub-device.
     pub fn add(&mut self,
-               dm: &DM,
                cache_device: &mut CacheDev,
                paths: &[&Path],
                force: bool)
@@ -307,8 +316,8 @@ impl CacheTier {
         let coalesced = coalesce_blkdevsegs(&self.cache_segments, &segments);
         let table = map_to_dm(&coalesced);
 
-        cache_device.set_cache_table(dm, table)?;
-        cache_device.resume(dm)?;
+        cache_device.set_cache_table(get_dm_context(), table)?;
+        cache_device.resume(get_dm_context())?;
 
         self.cache_segments = coalesced;
 
@@ -320,8 +329,7 @@ impl CacheTier {
     /// Returns the CacheTier and the cache device that was created.
     ///
     /// WARNING: metadata changing event
-    pub fn new(dm: &DM,
-               mut block_mgr: BlockDevMgr,
+    pub fn new(mut block_mgr: BlockDevMgr,
                origin: LinearDev)
                -> EngineResult<(CacheTier, CacheDev)> {
         let avail_space = block_mgr.avail_space();
@@ -340,17 +348,23 @@ impl CacheTier {
         let meta_segments = segments.pop().expect("segments.len() == 1");
 
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::MetaSub);
-        let meta = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&meta_segments))?;
+        let meta = LinearDev::setup(get_dm_context(),
+                                    &dm_name,
+                                    Some(&dm_uuid),
+                                    map_to_dm(&meta_segments))?;
 
         // See comment in ThinPool::new() method
         wipe_sectors(&meta.devnode(), Sectors(0), meta.size())?;
 
 
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::CacheSub);
-        let cache = LinearDev::setup(dm, &dm_name, Some(&dm_uuid), map_to_dm(&cache_segments))?;
+        let cache = LinearDev::setup(get_dm_context(),
+                                     &dm_name,
+                                     Some(&dm_uuid),
+                                     map_to_dm(&cache_segments))?;
 
         let (dm_name, dm_uuid) = format_backstore_ids(block_mgr.pool_uuid(), CacheRole::Cache);
-        let cd = CacheDev::new(dm,
+        let cd = CacheDev::new(get_dm_context(),
                                &dm_name,
                                Some(&dm_uuid),
                                meta,
@@ -417,22 +431,21 @@ pub struct Backstore {
 
 impl Backstore {
     /// Make a Backstore object from blockdevs that already belong to Stratis.
-    pub fn setup(dm: &DM,
-                 pool_uuid: PoolUuid,
+    pub fn setup(pool_uuid: PoolUuid,
                  backstore_save: &BackstoreSave,
                  devnodes: &HashMap<Device, PathBuf>,
                  last_update_time: Option<DateTime<Utc>>)
                  -> EngineResult<Backstore> {
         let (datadevs, cachedevs) = get_blockdevs(pool_uuid, backstore_save, devnodes)?;
         let block_mgr = BlockDevMgr::new(pool_uuid, datadevs, last_update_time);
-        let (data_tier, dm_device) = DataTier::setup(dm, block_mgr, &backstore_save.data_segments)?;
+        let (data_tier, dm_device) = DataTier::setup(block_mgr, &backstore_save.data_segments)?;
 
         let (cache_tier, cache, linear) = if !cachedevs.is_empty() {
             let block_mgr = BlockDevMgr::new(pool_uuid, cachedevs, last_update_time);
             match (&backstore_save.cache_segments, &backstore_save.meta_segments) {
                 (&Some(ref cache_segments), &Some(ref meta_segments)) => {
                     let (cache_tier, cache_device) =
-                        CacheTier::setup(dm, block_mgr, dm_device, cache_segments, meta_segments)?;
+                        CacheTier::setup(block_mgr, dm_device, cache_segments, meta_segments)?;
                     (Some(cache_tier), Some(cache_device), None)
 
                 }
@@ -456,15 +469,13 @@ impl Backstore {
 
     /// Initialize a Backstore object, by initializing the specified devs.
     /// WARNING: metadata changing event
-    pub fn initialize(dm: &DM,
-                      pool_uuid: PoolUuid,
+    pub fn initialize(pool_uuid: PoolUuid,
                       paths: &[&Path],
                       mda_size: Sectors,
                       force: bool)
                       -> EngineResult<Backstore> {
         let (data_tier, dm_device) =
-            DataTier::new(dm,
-                          BlockDevMgr::initialize(pool_uuid, paths, mda_size, force)?)?;
+            DataTier::new(BlockDevMgr::initialize(pool_uuid, paths, mda_size, force)?)?;
         Ok(Backstore {
                data_tier,
                cache_tier: None,
@@ -479,17 +490,13 @@ impl Backstore {
     /// If the cache tier does not already exist, create it.
     ///
     // Postcondition: self.cache.is_some() && self.linear.is_none()
-    fn add_cachedevs(&mut self,
-                     dm: &DM,
-                     paths: &[&Path],
-                     force: bool)
-                     -> EngineResult<Vec<DevUuid>> {
+    fn add_cachedevs(&mut self, paths: &[&Path], force: bool) -> EngineResult<Vec<DevUuid>> {
         match self.cache_tier {
             Some(ref mut cache_tier) => {
                 let mut cache_device = self.cache
                     .as_mut()
                     .expect("cache_tier.is_some() <=> self.cache.is_some()");
-                cache_tier.add(dm, &mut cache_device, paths, force)
+                cache_tier.add(&mut cache_device, paths, force)
             }
             None => {
                 // FIXME: This is obviously a bad idea, but unless the UUID
@@ -504,7 +511,7 @@ impl Backstore {
                 let linear = self.linear
                     .take()
                     .expect("cache_tier.is_none() <=> self.linear.is_some()");
-                let (cache_tier, cache) = CacheTier::new(dm, bdm, linear)?;
+                let (cache_tier, cache) = CacheTier::new(bdm, linear)?;
                 self.cache = Some(cache);
 
                 let uuids = cache_tier
@@ -525,16 +532,15 @@ impl Backstore {
     /// corresponding to the specified paths.
     /// WARNING: metadata changing event
     pub fn add_blockdevs(&mut self,
-                         dm: &DM,
                          paths: &[&Path],
                          tier: BlockDevTier,
                          force: bool)
                          -> EngineResult<Vec<DevUuid>> {
         match tier {
-            BlockDevTier::Cache => self.add_cachedevs(dm, paths, force),
+            BlockDevTier::Cache => self.add_cachedevs(paths, force),
             BlockDevTier::Data => {
                 self.data_tier
-                    .add(dm, self.cache.as_mut(), self.linear.as_mut(), paths, force)
+                    .add(self.cache.as_mut(), self.linear.as_mut(), paths, force)
             }
         }
     }
@@ -587,10 +593,10 @@ impl Backstore {
     }
 
     /// Destroy the entire store.
-    pub fn destroy(self, dm: &DM) -> EngineResult<()> {
+    pub fn destroy(self) -> EngineResult<()> {
         match self.cache {
             Some(cache) => {
-                cache.teardown(dm)?;
+                cache.teardown(get_dm_context())?;
                 self.cache_tier
                     .expect("if dm_device is cache, cache tier exists")
                     .destroy()?;
@@ -598,17 +604,21 @@ impl Backstore {
             None => {
                 self.linear
                     .expect("self.cache.is_none()")
-                    .teardown(dm)?;
+                    .teardown(get_dm_context())?;
             }
         };
         self.data_tier.destroy()
     }
 
     /// Teardown the DM devices in the backstore.
-    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
+    pub fn teardown(self) -> EngineResult<()> {
         match self.cache {
-                Some(cache) => cache.teardown(dm),
-                None => self.linear.expect("self.cache.is_none()").teardown(dm),
+                Some(cache) => cache.teardown(get_dm_context()),
+                None => {
+                    self.linear
+                        .expect("self.cache.is_none()")
+                        .teardown(get_dm_context())
+                }
             }
             .map_err(|e| e.into())
     }
@@ -680,10 +690,9 @@ impl Recordable<BackstoreSave> for Backstore {
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
 
     use devicemapper::{CacheDevStatus, DataBlocks};
-
-    use uuid::Uuid;
 
     use super::super::super::tests::{loopbacked, real};
 
@@ -724,15 +733,13 @@ mod tests {
         let (cachedevpaths, paths) = paths.split_at(1);
         let (datadevpaths, initdatapaths) = paths.split_at(1);
 
-        let dm = DM::new().unwrap();
         let mut backstore =
-            Backstore::initialize(&dm, Uuid::new_v4(), initdatapaths, MIN_MDA_SECTORS, false)
-                .unwrap();
+            Backstore::initialize(Uuid::new_v4(), initdatapaths, MIN_MDA_SECTORS, false).unwrap();
 
         invariant(&backstore);
 
         let cache_uuids = backstore
-            .add_blockdevs(&dm, initcachepaths, BlockDevTier::Cache, false)
+            .add_blockdevs(initcachepaths, BlockDevTier::Cache, false)
             .unwrap();
 
         invariant(&backstore);
@@ -743,7 +750,7 @@ mod tests {
         let cache_status = backstore
             .cache
             .as_ref()
-            .map(|c| c.status(&dm).unwrap())
+            .map(|c| c.status(get_dm_context()).unwrap())
             .unwrap();
 
         match cache_status {
@@ -757,13 +764,13 @@ mod tests {
         }
 
         let data_uuids = backstore
-            .add_blockdevs(&dm, datadevpaths, BlockDevTier::Data, false)
+            .add_blockdevs(datadevpaths, BlockDevTier::Data, false)
             .unwrap();
         invariant(&backstore);
         assert_eq!(data_uuids.len(), datadevpaths.len());
 
         let cache_uuids = backstore
-            .add_blockdevs(&dm, cachedevpaths, BlockDevTier::Cache, false)
+            .add_blockdevs(cachedevpaths, BlockDevTier::Cache, false)
             .unwrap();
         invariant(&backstore);
         assert_eq!(cache_uuids.len(), cachedevpaths.len());
@@ -771,7 +778,7 @@ mod tests {
         let cache_status = backstore
             .cache
             .as_ref()
-            .map(|c| c.status(&dm).unwrap())
+            .map(|c| c.status(get_dm_context()).unwrap())
             .unwrap();
 
         match cache_status {
@@ -784,7 +791,7 @@ mod tests {
             CacheDevStatus::Fail => panic!("cache status should succeed"),
         }
 
-        backstore.destroy(&dm).unwrap();
+        backstore.destroy().unwrap();
     }
 
     #[test]
@@ -812,16 +819,15 @@ mod tests {
 
         let (paths1, paths2) = paths.split_at(paths.len() / 2);
 
-        let dm = DM::new().unwrap();
         let pool_uuid = Uuid::new_v4();
 
-        let mut backstore = Backstore::initialize(&dm, pool_uuid, paths1, MIN_MDA_SECTORS, false)
+        let mut backstore = Backstore::initialize(pool_uuid, paths1, MIN_MDA_SECTORS, false)
             .unwrap();
         invariant(&backstore);
         let old_device = backstore.device();
 
         backstore
-            .add_blockdevs(&dm, paths2, BlockDevTier::Cache, false)
+            .add_blockdevs(paths2, BlockDevTier::Cache, false)
             .unwrap();
         invariant(&backstore);
 
@@ -831,17 +837,17 @@ mod tests {
 
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
-        let backstore = Backstore::setup(&dm, pool_uuid, &backstore_save, &map, None).unwrap();
+        let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
         invariant(&backstore);
 
-        backstore.teardown(&dm).unwrap();
+        backstore.teardown().unwrap();
 
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
-        let backstore = Backstore::setup(&dm, pool_uuid, &backstore_save, &map, None).unwrap();
+        let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
         invariant(&backstore);
 
-        backstore.destroy(&dm).unwrap();
+        backstore.destroy().unwrap();
     }
 
     #[test]

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -4,8 +4,6 @@
 
 // Code to handle cleanup after a failed operation.
 
-use devicemapper::DM;
-
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::structures::Table;
 
@@ -13,10 +11,10 @@ use super::pool::StratPool;
 
 
 /// Teardown pools.
-pub fn teardown_pools(dm: &DM, pools: Table<StratPool>) -> EngineResult<()> {
+pub fn teardown_pools(pools: Table<StratPool>) -> EngineResult<()> {
     let mut untorndown_pools = Vec::new();
     for (_, uuid, pool) in pools {
-        pool.teardown(dm)
+        pool.teardown()
             .unwrap_or_else(|_| untorndown_pools.push(uuid));
     }
     if untorndown_pools.is_empty() {

--- a/src/engine/strat_engine/dm.rs
+++ b/src/engine/strat_engine/dm.rs
@@ -4,9 +4,14 @@
 
 // Get ability to instantiate a devicemapper context.
 
+
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Once, ONCE_INIT};
 
 use devicemapper::DM;
+
+use super::super::engine::Eventable;
+use super::super::errors::EngineResult;
 
 static INIT: Once = ONCE_INIT;
 static mut DM_CONTEXT: Option<DM> = None;
@@ -18,5 +23,18 @@ pub fn get_dm_context() -> &'static DM {
             Some(ref context) => context,
             _ => panic!("DM_CONTEXT.is_some()"),
         }
+    }
+}
+
+
+impl Eventable for DM {
+    /// Get file we'd like to have monitored for activity
+    fn get_pollable_fd(&self) -> RawFd {
+        self.file().as_raw_fd()
+    }
+
+    fn clear_event(&self) -> EngineResult<()> {
+        self.arm_poll()?;
+        Ok(())
     }
 }

--- a/src/engine/strat_engine/dm.rs
+++ b/src/engine/strat_engine/dm.rs
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Get ability to instantiate a devicemapper context.
+
+use std::sync::{Once, ONCE_INIT};
+
+use devicemapper::DM;
+
+static INIT: Once = ONCE_INIT;
+static mut DM_CONTEXT: Option<DM> = None;
+
+pub fn get_dm_context() -> &'static DM {
+    unsafe {
+        INIT.call_once(|| DM_CONTEXT = Some(DM::new().unwrap()));
+        match DM_CONTEXT {
+            Some(ref context) => context,
+            _ => panic!("DM_CONTEXT.is_some()"),
+        }
+    }
+}

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -5,11 +5,10 @@
 extern crate libc;
 
 use std::collections::HashMap;
-use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::panic::catch_unwind;
 
-use devicemapper::{DM, Device, DmNameBuf};
+use devicemapper::{Device, DmNameBuf};
 
 use super::super::engine::{Engine, Eventable, Pool};
 use super::super::errors::{EngineError, EngineResult, ErrorEnum};
@@ -46,17 +45,6 @@ pub struct StratEngine {
     watched_dev_last_event_nrs: HashMap<DmNameBuf, u32>,
 }
 
-impl Eventable for DM {
-    /// Get file we'd like to have monitored for activity
-    fn get_pollable_fd(&self) -> RawFd {
-        self.file().as_raw_fd()
-    }
-
-    fn clear_event(&self) -> EngineResult<()> {
-        self.arm_poll()?;
-        Ok(())
-    }
-}
 
 impl StratEngine {
     /// Setup a StratEngine.

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -284,8 +284,8 @@ impl Engine for StratEngine {
             .collect()
     }
 
-    fn get_eventable(&self) -> EngineResult<Option<Box<Eventable>>> {
-        Ok(Some(Box::new(DM::new()?)))
+    fn get_eventable(&self) -> EngineResult<Option<&'static Eventable>> {
+        Ok(Some(get_dm_context()))
     }
 
     fn evented(&mut self) -> EngineResult<()> {

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -6,6 +6,7 @@ mod backstore;
 mod cleanup;
 mod device;
 mod devlinks;
+mod dm;
 mod dmnames;
 mod engine;
 mod pool;

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -2,12 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::panic::catch_unwind;
 use std::path::PathBuf;
-
-use devicemapper::{DM, DevId, DmFlags, DmResult};
 
 use mnt::get_submounts;
 use nix::mount::{MntFlags, umount2};
+
+use devicemapper::{DevId, DmFlags, DmResult};
+
+use super::super::dm::get_dm_context;
 
 
 mod cleanup_errors {
@@ -22,7 +25,7 @@ mod cleanup_errors {
     }
 }
 
-use self::cleanup_errors::{Error, Result, ResultExt};
+use self::cleanup_errors::{Error, Result};
 
 
 /// Attempt to remove all device mapper devices which match the stratis naming convention.
@@ -30,15 +33,16 @@ use self::cleanup_errors::{Error, Result, ResultExt};
 fn dm_stratis_devices_remove() -> Result<()> {
 
     /// One iteration of removing devicemapper devices
-    fn one_iteration(dm: &DM) -> DmResult<(bool, Vec<String>)> {
+    fn one_iteration() -> DmResult<(bool, Vec<String>)> {
         let mut progress_made = false;
         let mut remain = Vec::new();
 
-        for d in dm.list_devices()?
+        for d in get_dm_context()
+                .list_devices()?
                 .iter()
                 .filter(|d| format!("{}", d.0.as_ref()).starts_with("stratis-1")) {
 
-            match dm.device_remove(&DevId::Name(&d.0), DmFlags::empty()) {
+            match get_dm_context().device_remove(&DevId::Name(&d.0), DmFlags::empty()) {
                 Ok(_) => progress_made = true,
                 Err(_) => remain.push(format!("{}", d.0.as_ref())),
             }
@@ -46,10 +50,12 @@ fn dm_stratis_devices_remove() -> Result<()> {
         Ok((progress_made, remain))
     }
 
-    let dm = DM::new().chain_err(|| "Unable to initialize DM")?;
+    if catch_unwind(get_dm_context).is_err() {
+        return Err("Unable to initialize DM".into());
+    }
 
     loop {
-        let (progress_made, remain) = one_iteration(&dm)
+        let (progress_made, remain) = one_iteration()
             .map_err(|e| {
                 Error::with_chain(e,
                                   "Error while attempting to remove stratis device mapper devices")}

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -4,8 +4,8 @@
 
 use std::path::{Path, PathBuf};
 
-use devicemapper::{Bytes, DM, DmDevice, DmName, DmUuid, IEC, SECTOR_SIZE, Sectors, ThinDev,
-                   ThinDevId, ThinPoolDev, ThinStatus};
+use devicemapper::{Bytes, DmDevice, DmName, DmUuid, IEC, SECTOR_SIZE, Sectors, ThinDev, ThinDevId,
+                   ThinPoolDev, ThinStatus};
 
 use mnt::{MountIter, MountParam};
 use nix::mount::{MsFlags, mount, umount};
@@ -16,6 +16,7 @@ use super::super::super::engine::Filesystem;
 use super::super::super::errors::{EngineError, EngineResult, ErrorEnum};
 use super::super::super::types::{FilesystemUuid, Name};
 
+use super::super::dm::get_dm_context;
 use super::super::serde_structs::FilesystemSave;
 
 use super::util::{create_fs, set_uuid, xfs_growfs};
@@ -58,7 +59,6 @@ impl StratFilesystem {
     /// a unique UUID.
     #[allow(too_many_arguments)]
     pub fn snapshot(&self,
-                    dm: &DM,
                     thin_pool: &ThinPoolDev,
                     snapshot_name: &str,
                     snapshot_dm_name: &DmName,
@@ -69,7 +69,7 @@ impl StratFilesystem {
                     -> EngineResult<StratFilesystem> {
 
         match self.thin_dev
-                  .snapshot(dm,
+                  .snapshot(get_dm_context(),
                             snapshot_dm_name,
                             snapshot_dm_uuid,
                             thin_pool,
@@ -111,15 +111,17 @@ impl StratFilesystem {
 
     /// check if filesystem is getting full and needs to be extended
     /// TODO: deal with the thindev in a Fail state.
-    pub fn check(&mut self, dm: &DM) -> EngineResult<FilesystemStatus> {
-        match self.thin_dev.status(dm)? {
+    pub fn check(&mut self) -> EngineResult<FilesystemStatus> {
+        match self.thin_dev.status(get_dm_context())? {
             ThinStatus::Working(_) => {
                 if let Some(mount_point) = self.get_mount_point()? {
                     let (fs_total_bytes, fs_total_used_bytes) = fs_usage(&mount_point)?;
                     let free_bytes = fs_total_bytes - fs_total_used_bytes;
                     if free_bytes.sectors() < FILESYSTEM_LOWATER {
                         let extend_size = self.extend_size(self.thin_dev.size());
-                        if self.thin_dev.extend(dm, extend_size).is_err() {
+                        if self.thin_dev
+                               .extend(get_dm_context(), extend_size)
+                               .is_err() {
                             return Ok(FilesystemStatus::ThinDevExtendFailed);
                         }
                         if xfs_growfs(&mount_point).is_err() {
@@ -180,14 +182,14 @@ impl StratFilesystem {
     }
 
     /// Tear down the filesystem.
-    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
-        self.thin_dev.teardown(dm)?;
+    pub fn teardown(self) -> EngineResult<()> {
+        self.thin_dev.teardown(get_dm_context())?;
         Ok(())
     }
 
     /// Destroy the filesystem.
-    pub fn destroy(self, dm: &DM, thin_pool: &ThinPoolDev) -> EngineResult<()> {
-        self.thin_dev.destroy(dm, thin_pool)?;
+    pub fn destroy(self, thin_pool: &ThinPoolDev) -> EngineResult<()> {
+        self.thin_dev.destroy(get_dm_context(), thin_pool)?;
         Ok(())
     }
 
@@ -200,13 +202,13 @@ impl StratFilesystem {
         }
     }
 
-    pub fn suspend(&mut self, dm: &DM) -> EngineResult<()> {
-        self.thin_dev.suspend(dm)?;
+    pub fn suspend(&mut self) -> EngineResult<()> {
+        self.thin_dev.suspend(get_dm_context())?;
         Ok(())
     }
 
-    pub fn resume(&mut self, dm: &DM) -> EngineResult<()> {
-        self.thin_dev.resume(dm)?;
+    pub fn resume(&mut self) -> EngineResult<()> {
+        self.thin_dev.resume(get_dm_context())?;
         Ok(())
     }
 }

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -16,11 +16,12 @@ use nix::mount::{MsFlags, mount, umount};
 use nix::unistd::fsync;
 use serde_json;
 
-use devicemapper::{DM, DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
+use devicemapper::{DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
 
 use super::super::super::errors::EngineResult;
 use super::super::super::types::{FilesystemUuid, Name, PoolUuid};
 
+use super::super::dm::get_dm_context;
 use super::super::engine::DEV_PATH;
 use super::super::serde_structs::FilesystemSave;
 
@@ -196,21 +197,21 @@ impl MetadataVol {
     }
 
     /// Tear down a Metadata Volume.
-    pub fn teardown(self, dm: &DM) -> EngineResult<()> {
-        self.dev.teardown(dm)?;
+    pub fn teardown(self) -> EngineResult<()> {
+        self.dev.teardown(get_dm_context())?;
 
         Ok(())
     }
 
     /// Suspend the metadata volume DM devices
-    pub fn suspend(&mut self, dm: &DM) -> EngineResult<()> {
-        self.dev.suspend(dm)?;
+    pub fn suspend(&mut self) -> EngineResult<()> {
+        self.dev.suspend(get_dm_context())?;
         Ok(())
     }
 
     /// Resume the metadata volume DM devices
-    pub fn resume(&mut self, dm: &DM) -> EngineResult<()> {
-        self.dev.resume(dm)?;
+    pub fn resume(&mut self) -> EngineResult<()> {
+        self.dev.resume(get_dm_context())?;
         Ok(())
     }
 
@@ -220,11 +221,8 @@ impl MetadataVol {
     }
 
     /// Set the table of the backing device
-    pub fn set_table(&mut self,
-                     dm: &DM,
-                     table: Vec<TargetLine<LinearDevTargetParams>>)
-                     -> EngineResult<()> {
-        self.dev.set_table(dm, table)?;
+    pub fn set_table(&mut self, table: Vec<TargetLine<LinearDevTargetParams>>) -> EngineResult<()> {
+        self.dev.set_table(get_dm_context(), table)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Initialize the context in StratEngine::initialize().
Obtain it everywhere using the method get_dm_context(). Do not pass it as
an argument in stratisd but do instantiate it when passing to methods in
devicemapper.

Signed-off-by: mulhern <amulhern@redhat.com>