### PR TITLE
Update minimum Rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to `/etc/dbus-1/system.d/`.
 
 
 #### Rust tools
-Stratisd requires Rust 1.17+ and Cargo to build. These may be available via
+Stratisd requires Rust 1.24+ and Cargo to build. These may be available via
 your distribution's package manager. If not, [Rustup](https://www.rustup.rs/)
 is available to install and update the Rust toolchain.
 


### PR DESCRIPTION

Update README.md to reflect the new 1.24 minimum version of Rust.