### PR TITLE
Get rid of two coverage pragmas

### DIFF
--- a/tests/client-dbus/src/stratisd_client_dbus/_connection.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_connection.py
@@ -30,7 +30,7 @@ class Bus(object):
     _BUS = None
 
     @staticmethod
-    def get_bus(): # pragma: no cover
+    def get_bus():
         """
         Get our bus.
         """
@@ -39,7 +39,7 @@ class Bus(object):
 
         return Bus._BUS
 
-def get_object(object_path): # pragma: no cover
+def get_object(object_path):
     """
     Get an object from an object path.
 


### PR DESCRIPTION
We do not run coverage tests on this code anymore, because its no longer
part of a library, so the coverage pragmas are no longer useful.

Signed-off-by: mulhern <amulhern@redhat.com>