### PR TITLE
Get rid of a '.'

### DIFF
--- a/tests/client-dbus/Makefile
+++ b/tests/client-dbus/Makefile
@@ -9,8 +9,8 @@ dbus-tests:
 
 .PHONY: fmt
 fmt:
-	yapf --style pep8 --recursive --in-place . check.py setup.py src tests
+	yapf --style pep8 --recursive --in-place check.py setup.py src tests
 
 .PHONY: fmt-travis
 fmt-travis:
-	yapf --style pep8 --recursive --diff . check.py setup.py src tests
+	yapf --style pep8 --recursive --diff check.py setup.py src tests


### PR DESCRIPTION
In order to avoid trying to format all the Python files in the directory.
We only want to format those that are part of our project.

Signed-off-by: mulhern <amulhern@redhat.com>