### PR TITLE
Move 1 second sleeps after stratisd setup to setUp function

### DIFF
--- a/tests/client-dbus/tests/dbus/_misc.py
+++ b/tests/client-dbus/tests/dbus/_misc.py
@@ -18,6 +18,7 @@ Miscellaneous methods to support testing.
 import os
 import string
 import subprocess
+import time
 
 from hypothesis import strategies
 
@@ -45,6 +46,7 @@ class Service(object):
         Start the stratisd daemon with the simulator.
         """
         self._stratisd = subprocess.Popen([os.path.join(_STRATISD), '--sim'])
+        time.sleep(1)
 
     def tearDown(self):
         """

--- a/tests/client-dbus/tests/dbus/filesystem/test_rename.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_rename.py
@@ -15,7 +15,6 @@
 Test renaming a filesystem.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import Filesystem
@@ -48,7 +47,6 @@ class SetNameTestCase(unittest.TestCase):
         self._fs_name = 'fs'
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
             self._proxy, {

--- a/tests/client-dbus/tests/dbus/manager/test_create.py
+++ b/tests/client-dbus/tests/dbus/manager/test_create.py
@@ -15,7 +15,6 @@
 Test 'CreatePool'.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import MOPool
@@ -45,7 +44,6 @@ class Create2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -117,7 +115,6 @@ class Create3TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.CreatePool(
             self._proxy, {

--- a/tests/client-dbus/tests/dbus/manager/test_destroy.py
+++ b/tests/client-dbus/tests/dbus/manager/test_destroy.py
@@ -15,7 +15,6 @@
 Test DestroyPool.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import Manager
@@ -49,7 +48,6 @@ class Destroy1TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -89,7 +87,6 @@ class Destroy2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         self._devices = _DEVICE_STRATEGY.example()
         Manager.Methods.CreatePool(
@@ -148,7 +145,6 @@ class Destroy3TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
 
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
             self._proxy, {
@@ -198,7 +194,6 @@ class Destroy4TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.CreatePool(
             self._proxy, {

--- a/tests/client-dbus/tests/dbus/manager/test_object_path.py
+++ b/tests/client-dbus/tests/dbus/manager/test_object_path.py
@@ -14,7 +14,6 @@
 """
 Test object path methods.
 """
-import time
 import unittest
 
 from stratisd_client_dbus import get_object
@@ -36,7 +35,6 @@ class GetObjectTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)  # wait until the service is available
 
     def tearDown(self):
         """

--- a/tests/client-dbus/tests/dbus/manager/test_stratis.py
+++ b/tests/client-dbus/tests/dbus/manager/test_stratis.py
@@ -15,7 +15,6 @@
 Test 'stratisd'.
 """
 
-import time
 import unittest
 
 from dbus_python_client_gen import DPClientInvalidArgError
@@ -40,7 +39,6 @@ class StratisTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 
@@ -72,7 +70,6 @@ class StratisTestCase2(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
 

--- a/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
@@ -15,7 +15,6 @@
 Test adding blockdevs to a pool.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import Manager
@@ -47,7 +46,6 @@ class AddCacheDevsTestCase1(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
             self._proxy, {
@@ -144,7 +142,6 @@ class AddCacheDevsTestCase2(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, devpaths), _, _) = Manager.Methods.CreatePool(
             self._proxy, {

--- a/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
@@ -15,7 +15,6 @@
 Test adding blockdevs to a pool.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import Manager
@@ -47,7 +46,6 @@ class AddDataDevsTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
             self._proxy, {

--- a/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
@@ -15,7 +15,6 @@
 Test creating a filesystem in a pool.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import Manager
@@ -46,7 +45,6 @@ class CreateFSTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
@@ -116,7 +114,6 @@ class CreateFSTestCase1(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(

--- a/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
@@ -15,7 +15,6 @@
 Test destroying a filesystem in a pool.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import Manager
@@ -46,7 +45,6 @@ class DestroyFSTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((poolpath, _), _, _) = Manager.Methods.CreatePool(
@@ -110,7 +108,6 @@ class DestroyFSTestCase1(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(2)
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY.example()
         ((self._poolpath, _), _, _) = Manager.Methods.CreatePool(

--- a/tests/client-dbus/tests/dbus/pool/test_rename.py
+++ b/tests/client-dbus/tests/dbus/pool/test_rename.py
@@ -15,7 +15,6 @@
 Test renaming a pool.
 """
 
-import time
 import unittest
 
 from stratisd_client_dbus import Manager
@@ -46,7 +45,6 @@ class SetNameTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         self._proxy = get_object(TOP_OBJECT)
         ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
             self._proxy, {


### PR DESCRIPTION
There is always a sleep of 1, or in one instance 2 seconds after
every invocation of Service.setUp. These all occur in TestCase.setUp
methods. Just do the sleep in Service.setUp for less verbosity.

Signed-off-by: mulhern <amulhern@redhat.com>