### PR TITLE
Make self parameters to Eventable methods non-mut

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -135,12 +135,12 @@ fn run() -> StratisResult<()> {
                  events: libc::POLLIN,
              });
 
-    let mut eventable = engine.borrow_mut().get_eventable()?;
+    let eventable = engine.borrow().get_eventable()?;
 
     // The variable _dbus_client_index_start is only used when dbus support is compiled in, thus
     // we denote the value as not needed to compile when dbus support is not included.
     let (engine_eventable, poll_timeout, _dbus_client_index_start) = match eventable {
-        Some(ref mut evt) => {
+        Some(ref evt) => {
             fds.push(libc::pollfd {
                          fd: evt.get_pollable_fd(),
                          revents: 0,
@@ -201,7 +201,7 @@ fn run() -> StratisResult<()> {
                 fds[FD_INDEX_ENGINE].revents = 0;
 
                 eventable
-                    .as_mut()
+                    .as_ref()
                     .expect("eventable.is_some()")
                     .clear_event()?;
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -181,7 +181,7 @@ pub trait Engine: Debug {
 
     /// If the engine would like to include an event in the message loop, it
     /// may return an Eventable from this method.
-    fn get_eventable(&mut self) -> EngineResult<Option<Box<Eventable>>>;
+    fn get_eventable(&self) -> EngineResult<Option<Box<Eventable>>>;
 
     /// Notify the engine that an event has occurred on the Eventable.
     fn evented(&mut self) -> EngineResult<()>;
@@ -191,9 +191,9 @@ pub trait Engine: Debug {
 /// Engine::get_eventable() and Engine::evented().
 pub trait Eventable {
     /// Get fd the engine would like to monitor for activity
-    fn get_pollable_fd(&mut self) -> RawFd;
+    fn get_pollable_fd(&self) -> RawFd;
 
     /// Assuming level-triggered semantics, clear the event that caused the
     /// Eventable to trigger.
-    fn clear_event(&mut self) -> EngineResult<()>;
+    fn clear_event(&self) -> EngineResult<()>;
 }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -121,7 +121,7 @@ impl Engine for SimEngine {
             .collect()
     }
 
-    fn get_eventable(&mut self) -> EngineResult<Option<Box<Eventable>>> {
+    fn get_eventable(&self) -> EngineResult<Option<Box<Eventable>>> {
         Ok(None)
     }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -46,13 +46,12 @@ pub struct StratEngine {
 
 impl Eventable for DM {
     /// Get file we'd like to have monitored for activity
-    fn get_pollable_fd(&mut self) -> RawFd {
+    fn get_pollable_fd(&self) -> RawFd {
         self.file().as_raw_fd()
     }
 
-    fn clear_event(&mut self) -> EngineResult<()> {
+    fn clear_event(&self) -> EngineResult<()> {
         self.arm_poll()?;
-
         Ok(())
     }
 }
@@ -279,7 +278,7 @@ impl Engine for StratEngine {
             .collect()
     }
 
-    fn get_eventable(&mut self) -> EngineResult<Option<Box<Eventable>>> {
+    fn get_eventable(&self) -> EngineResult<Option<Box<Eventable>>> {
         Ok(Some(Box::new(DM::new()?)))
     }
 


### PR DESCRIPTION
They do not need to take a mutable argument, because the DM context
is never mutated and a DM context is the one thing that implements
Eventable in the stratisd code base.

As a consequence it is possible to make Engine::eventable()
return an immutable object, so do that.

Remove some mut modifiers where the devicemapper context is used as
an Eventable.

Signed-off-by: mulhern <amulhern@redhat.com>