### PR TITLE
fix coalesce_segs to add segments in the right slice

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -99,9 +99,9 @@ fn coalesce_segs(left: &[(Sectors, Sectors)],
     };
 
     if coalesced {
-        segments.extend_from_slice(&left[1..]);
+        segments.extend_from_slice(&right[1..]);
     } else {
-        segments.extend_from_slice(left);
+        segments.extend_from_slice(right);
     }
     segments
 }


### PR DESCRIPTION

This is a step towards fixing #831.  Segments were not being properly coalesced.

The similar method coalesce_blkdevsegs() is correct. 
