### PR TITLE
Reduce number of metadata reads

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -435,7 +435,7 @@ impl Backstore {
                  devnodes: &HashMap<Device, (PathBuf, StratisResult<BDA>)>,
                  last_update_time: Option<DateTime<Utc>>)
                  -> StratisResult<Backstore> {
-        let (datadevs, cachedevs) = get_blockdevs(pool_uuid, backstore_save, devnodes)?;
+        let (datadevs, cachedevs) = get_blockdevs(backstore_save, devnodes)?;
         let block_mgr = BlockDevMgr::new(pool_uuid, datadevs, last_update_time);
         let (data_tier, dm_device) = DataTier::setup(block_mgr, &backstore_save.data_segments)?;
 

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -22,7 +22,7 @@ use super::super::dmnames::{CacheRole, format_backstore_ids};
 use super::super::serde_structs::{BackstoreSave, Recordable};
 
 use super::blockdevmgr::{BlkDevSegment, BlockDevMgr, Segment, coalesce_blkdevsegs, map_to_dm};
-use super::metadata::MIN_MDA_SECTORS;
+use super::metadata::{BDA, MIN_MDA_SECTORS};
 use super::setup::get_blockdevs;
 
 /// Use a cache block size that the kernel docs indicate is the largest
@@ -432,7 +432,7 @@ impl Backstore {
     /// Make a Backstore object from blockdevs that already belong to Stratis.
     pub fn setup(pool_uuid: PoolUuid,
                  backstore_save: &BackstoreSave,
-                 devnodes: &HashMap<Device, PathBuf>,
+                 devnodes: &HashMap<Device, (PathBuf, StratisResult<BDA>)>,
                  last_update_time: Option<DateTime<Utc>>)
                  -> StratisResult<Backstore> {
         let (datadevs, cachedevs) = get_blockdevs(pool_uuid, backstore_save, devnodes)?;

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -663,7 +663,7 @@ mod tests {
 
         assert!(pools
                     .iter()
-                    .map(|(uuid, devs)| get_metadata(*uuid, devs))
+                    .map(|(_, devs)| get_metadata(devs))
                     .all(|x| x.unwrap().is_none()));
     }
 

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -30,7 +30,6 @@ const MDA_RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)
 
 const STRAT_MAGIC: &[u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
 
-
 /// The SyncAll trait unifies the File type with other types that do
 /// not implement sync_all(). The purpose is to allow testing of methods
 /// that sync to a File using other structs that also implement Write, but
@@ -57,7 +56,7 @@ impl<T> SyncAll for Cursor<T>
 }
 
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BDA {
     header: StaticHeader,
     regions: mda::MDARegions,
@@ -182,7 +181,7 @@ impl BDA {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StaticHeader {
     blkdev_size: Sectors,
     pool_uuid: PoolUuid,
@@ -358,7 +357,7 @@ mod mda {
     pub const MIN_MDA_SECTORS: Sectors = Sectors(2032);
 
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct MDARegions {
         // Spec defines 4 regions, but regions 2 & 3 are duplicates of 0 and 1 respectively
         region_size: Sectors,
@@ -552,7 +551,7 @@ mod mda {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct MDAHeader {
         last_updated: DateTime<Utc>,
 

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -13,6 +13,6 @@ mod range_alloc;
 mod setup;
 mod util;
 
-pub use self::metadata::MIN_MDA_SECTORS;
+pub use self::metadata::{BDA, MIN_MDA_SECTORS};
 pub use self::setup::{find_all, get_metadata, is_stratis_device, setup_pool};
 pub use self::backstore::Backstore;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -18,7 +18,7 @@ use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::types::{BlockDevTier, DevUuid, FilesystemUuid, Name, PoolUuid, Redundancy,
                           RenameAction};
 
-use super::backstore::{Backstore, MIN_MDA_SECTORS};
+use super::backstore::{BDA, Backstore, MIN_MDA_SECTORS};
 use super::serde_structs::{PoolSave, Recordable};
 use super::thinpool::{ThinPool, ThinPoolSizeParams};
 
@@ -94,7 +94,7 @@ impl StratPool {
 
     /// Setup a StratPool using its UUID and the list of devnodes it has.
     pub fn setup(uuid: PoolUuid,
-                 devnodes: &HashMap<Device, PathBuf>,
+                 devnodes: &HashMap<Device, (PathBuf, StratisResult<BDA>)>,
                  metadata: &PoolSave)
                  -> StratisResult<(Name, StratPool)> {
         let backstore = Backstore::setup(uuid, &metadata.backstore, devnodes, None)?;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -327,8 +327,8 @@ mod tests {
         assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
         let devnodes2 = pools.get(&uuid2).unwrap();
-        let pool_save1 = get_metadata(uuid1, devnodes1).unwrap().unwrap();
-        let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
+        let pool_save1 = get_metadata(devnodes1).unwrap().unwrap();
+        let pool_save2 = get_metadata(devnodes2).unwrap().unwrap();
         assert_eq!(pool_save1, metadata1);
         assert_eq!(pool_save2, metadata2);
 
@@ -338,8 +338,8 @@ mod tests {
         assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
         let devnodes2 = pools.get(&uuid2).unwrap();
-        let pool_save1 = get_metadata(uuid1, devnodes1).unwrap().unwrap();
-        let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
+        let pool_save1 = get_metadata(devnodes1).unwrap().unwrap();
+        let pool_save2 = get_metadata(devnodes2).unwrap().unwrap();
         assert_eq!(pool_save1, metadata1);
         assert_eq!(pool_save2, metadata2);
     }
@@ -445,10 +445,8 @@ mod tests {
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 1);
         let devices = pools.get(&uuid).unwrap();
-        let (name, pool) = StratPool::setup(uuid,
-                                            &devices,
-                                            &get_metadata(uuid, &devices).unwrap().unwrap())
-                .unwrap();
+        let (name, pool) =
+            StratPool::setup(uuid, &devices, &get_metadata(&devices).unwrap().unwrap()).unwrap();
         invariant(&pool, &name);
 
         let metadata3 = pool.record(&name);


### PR DESCRIPTION
Alternative to #871.

The basic idea is that ```find_all``` or ```block_evaluate``` as the case may be, attempts to load a BDA if it has reason to believe that the device it's working with is a Stratis device. It then stores the result of that attempt as an ```StratisResult<BDA>``` along with the device. Other methods that previously loaded the BDA now get the BDA in the data structure which they take as an argument. These methods themselves return an error if the BDA is an Err(), so their semantics should be more or less the same. There are some TODOs which call out some possible courses of action.