### PR TITLE
Reverse order of arguments to block_evaluate

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -151,8 +151,8 @@ pub trait Engine: Debug {
     /// stratis device.  If all the devices are present in the pool and the pool isn't already
     /// up and running, it will get setup and the pool uuid will be returned.
     fn block_evaluate(&mut self,
-                      dev_node: PathBuf,
-                      device: Device)
+                      device: Device,
+                      dev_node: PathBuf)
                       -> EngineResult<Option<PoolUuid>>;
 
     /// Destroy a pool.

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -63,8 +63,8 @@ impl Engine for SimEngine {
     }
 
     fn block_evaluate(&mut self,
-                      dev_node: PathBuf,
-                      device: Device)
+                      device: Device,
+                      dev_node: PathBuf)
                       -> EngineResult<Option<PoolUuid>> {
         assert_ne!(dev_node, PathBuf::from("/"));
         assert_ne!(libc::dev_t::from(device), 0);

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -139,8 +139,8 @@ impl Engine for StratEngine {
     /// Logs a warning if the block devices appears to be a Stratis block
     /// device and no pool is set up.
     fn block_evaluate(&mut self,
-                      dev_node: PathBuf,
-                      device: Device)
+                      device: Device,
+                      dev_node: PathBuf)
                       -> EngineResult<Option<PoolUuid>> {
         let pool_uuid = if let Some(pool_uuid) = is_stratis_device(&dev_node)? {
             if self.pools.contains_uuid(pool_uuid) {


### PR DESCRIPTION
To match the order in which they appear in the result of find_all or
in incomplete_pools field of StratEngine.

Do the same for handle_udev_add.

Signed-off-by: mulhern <amulhern@redhat.com>