### PR TITLE
Add --target option to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TARGET ?= "x86_64-unknown-linux-gnu"
+
 ${HOME}/.cargo/bin/cargo-fmt:
 	cargo install rustfmt --vers 0.8.3
 
@@ -21,7 +23,9 @@ fmt-travis:
 	cargo fmt -- --write-mode=diff
 
 build:
-	RUSTFLAGS='-D warnings' cargo build --features "dbus_enabled"
+	PKG_CONFIG_ALLOW_CROSS=1 \
+	RUSTFLAGS='-D warnings' \
+	cargo build --features "dbus_enabled" --target $(TARGET)
 
 test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_


### PR DESCRIPTION
Default is x86_64-unknown-linux-gnu.  To build 32 bit stratisd on a
64 bit system:

rustup target add i686-unknown-linux-gnu
dnf install -y dbus-devel.i686 systemd-devel.i686 glibc-devel.i686

TARGET=i686-unknown-linux-gnu make build

Signed-off-by: Todd Gill <tgill@redhat.com>