### PR TITLE
Mark rustfmt as an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
 language: rust
 
 matrix:
+    allow_failures:
+        - rust: stable
+          env: TASK=fmt-travis
     include:
         - rust: stable
           env: TASK=fmt-travis


### PR DESCRIPTION
Failing just because a line is 101 characters is not cool.

This may be fixed by adopting a newer, better rustfmt but for the moment
it doesn't seem right to modify our code because rustfmt 0.8.3 has this
issue.

Signed-off-by: Andy Grover <agrover@redhat.com>