### PR TITLE
Extend a test to verify behavior on non-existent object path

### DIFF
--- a/tests/client-dbus/tests/dbus/manager/test_object_path.py
+++ b/tests/client-dbus/tests/dbus/manager/test_object_path.py
@@ -16,6 +16,12 @@ Test object path methods.
 """
 import unittest
 
+import dbus
+
+from dbus_python_client_gen import DPClientInvocationError
+
+from stratisd_client_dbus import Manager
+from stratisd_client_dbus import ObjectManager
 from stratisd_client_dbus import get_object
 
 from .._misc import _device_list
@@ -46,7 +52,22 @@ class GetObjectTestCase(unittest.TestCase):
         """
         A proxy object is returned from a non-existant path.
         """
-        self.assertIsNotNone(get_object('/this/is/not/an/object/path'))
+        proxy = get_object('/this/is/not/an/object/path')
+        self.assertIsNotNone(proxy)
+
+        with self.assertRaises(DPClientInvocationError) as context:
+            ObjectManager.Methods.GetManagedObjects(proxy, {})
+        cause = context.exception.__cause__
+        self.assertIsInstance(cause, dbus.exceptions.DBusException)
+        self.assertEqual(cause.get_dbus_name(),
+                         'org.freedesktop.DBus.Error.UnknownMethod')
+
+        with self.assertRaises(DPClientInvocationError) as context:
+            Manager.Properties.Version.Get(proxy)
+        cause = context.exception.__cause__
+        self.assertIsInstance(cause, dbus.exceptions.DBusException)
+        self.assertEqual(cause.get_dbus_name(),
+                         'org.freedesktop.DBus.Error.UnknownMethod')
 
     def testInvalid(self):
         """


### PR DESCRIPTION
For greater precision.

Signed-off-by: mulhern <amulhern@redhat.com>