### PR TITLE
Build with dbus by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ quickcheck = "0.6"
 loopdev = "0.2"
 
 [features]
+default = ["dbus_enabled"]
 dbus_enabled = ["dbus"]

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ fmt-travis:
 build:
 	PKG_CONFIG_ALLOW_CROSS=1 \
 	RUSTFLAGS='-D warnings' \
-	cargo build --features "dbus_enabled" --target $(TARGET)
+	cargo build --target $(TARGET)
 
 test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -218,7 +218,7 @@ fn run() -> StratisResult<()> {
                             if let Some(_pool_uuid) = pool_uuid {
                                 #[cfg(feature="dbus_enabled")]
                                 libstratis::dbus_api::register_pool(&mut dbus_conn,
-                                                                    Rc::clone(&engine),
+                                                                    &Rc::clone(&engine),
                                                                     &mut dbus_context,
                                                                     &mut tree,
                                                                     _pool_uuid,

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -221,7 +221,7 @@ pub fn connect<'a>
 
 /// Given the UUID of a pool, register all the pertinent information with dbus.
 pub fn register_pool(c: &Connection,
-                     engine: Rc<RefCell<Engine>>,
+                     engine: &Rc<RefCell<Engine>>,
                      dbus_context: &DbusContext,
                      tree: &mut Tree<MTFn<TData>, TData>,
                      pool_uuid: Uuid,


### PR DESCRIPTION
Hello,
This is super trivial change.

Verified it works as expected by comparing size of the output binary.
`--no-default-features` mentioned in issue was also tested.

Before this change `clippy` was run without `dbus` enabled so it revealed needless pass by value.
It required changing public API so you might want to hold back merging this PR for some time.

While at it noticed 5 warnings and  1 error from `clippy` in the `src/bin/stratisd.rs` (it doesn't have `clippy` enabled).
Looks like oversight to me.

Fixes #739