### PR TITLE
Move general startup tasks into main(), and ensure pidfile is held properly

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -122,13 +122,11 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
     initialize_log(matches.is_present("debug"))
         .expect("This is the first and only invocation of this method; it must succeed.");
 
-    // We must setup a udev listener before we initialize the
-    // engine. It is possible that a device may appear after the engine has read the
-    // /dev directory but before it has completed initialization. Unless the udev
-    // event has been recorded, the engine will be unaware of the existence of the
-    // device.
-    // This is especially important since stratisd is required to be able to run
-    // during early boot.
+    // Setup a udev listener before initializing the engine. A device may
+    // appear after the engine has read the /dev directory but before it has
+    // completed initialization. Unless the udev event has been recorded, the
+    // engine will miss the device.
+    // This is especially important since stratisd must run during early boot.
     let context = libudev::Context::new()?;
     let mut monitor = libudev::Monitor::new(&context)?;
     monitor.match_subsystem_devtype("block", "disk")?;


### PR DESCRIPTION
The previous code would cause the pidfile to be closed immediately when
control returned to run(). Giving it a name prevents this.

I swear this used to work. Did a newer compiler version perhaps change
this behavior?

Signed-off-by: Andy Grover <agrover@redhat.com>