### PR TITLE
Test pool Full -> Good transition

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -801,7 +801,8 @@ mod tests {
 
     #[test]
     pub fn real_test_add_cache_devs() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(4), test_add_cache_devs);
+        real::test_with_spec(real::DeviceLimits::AtLeast(4, None, None),
+                             test_add_cache_devs);
     }
 
     #[test]
@@ -857,7 +858,7 @@ mod tests {
 
     #[test]
     pub fn real_test_setup() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_setup);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None), test_setup);
     }
 
     #[test]

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -506,7 +506,8 @@ mod tests {
 
     #[test]
     pub fn real_test_blockdevmgr_used() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_blockdevmgr_used);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None),
+                             test_blockdevmgr_used);
     }
 
     #[test]
@@ -571,7 +572,8 @@ mod tests {
 
     #[test]
     pub fn real_test_force_flag_dirty() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_force_flag_dirty);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None),
+                             test_force_flag_dirty);
     }
 
     #[test]
@@ -614,7 +616,8 @@ mod tests {
 
     #[test]
     pub fn real_test_force_flag_stratis() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_force_flag_stratis);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None),
+                             test_force_flag_stratis);
     }
 
     #[test]
@@ -674,7 +677,7 @@ mod tests {
 
     #[test]
     pub fn real_test_initialize() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_initialize);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None), test_initialize);
     }
 
     #[test]
@@ -719,7 +722,7 @@ mod tests {
 
     #[test]
     pub fn real_test_ownership() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_ownership);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None), test_ownership);
     }
 
     #[test]

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -13,6 +13,7 @@ mod range_alloc;
 mod setup;
 mod util;
 
+pub use self::device::blkdev_size;
 pub use self::metadata::MIN_MDA_SECTORS;
 pub use self::setup::{find_all, get_metadata, is_stratis_device, setup_pool};
 pub use self::backstore::Backstore;

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -293,7 +293,7 @@ mod test {
 
     #[test]
     pub fn real_test_pool_rename() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_pool_rename);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None), test_pool_rename);
     }
 
     /// Test engine setup.
@@ -347,6 +347,6 @@ mod test {
 
     #[test]
     pub fn real_test_setup() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_setup);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None), test_setup);
     }
 }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -24,7 +24,6 @@ use super::thinpool::{ThinPool, ThinPoolSizeParams};
 
 pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE};
 
-
 /// Check the metadata of an individual pool for consistency.
 pub fn check_metadata(metadata: &PoolSave) -> StratisResult<()> {
     // If the amount allocated from the cache tier is not the same as that
@@ -351,7 +350,8 @@ mod tests {
 
     #[test]
     pub fn real_test_basic_metadata() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_basic_metadata);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None),
+                             test_basic_metadata);
     }
 
     /// Verify that a pool with no devices does not have the minimum amount of
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     pub fn real_test_empty_pool() {
-        real::test_with_spec(real::DeviceLimits::Exactly(0), test_empty_pool);
+        real::test_with_spec(real::DeviceLimits::Exactly(0, None, None), test_empty_pool);
     }
 
     /// Test that adding a cachedev causes metadata to be updated.
@@ -513,6 +513,7 @@ mod tests {
 
     #[test]
     pub fn real_test_add_cachedevs() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_add_cachedevs);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None),
+                             test_add_cachedevs);
     }
 }

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -9,23 +9,30 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{Value, from_reader};
 
-use devicemapper::{Bytes, IEC, Sectors};
+use devicemapper::{Bytes, DevId, Device, devnode_to_devno, DmDevice, DmFlags, DmName, LinearDev,
+                   LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine, IEC};
 
 use super::logger::init_logger;
 use super::util::clean_up;
 
+use super::super::backstore::blkdev_size;
 use super::super::device::wipe_sectors;
+use super::super::dm::get_dm;
 
 pub struct RealTestDev {
     path: PathBuf,
+    linear: Option<LinearDev>,
 }
 
 impl RealTestDev {
     /// Construct a new test device for the given path.
     /// Wipe initial MiB to clear metadata.
-    pub fn new(path: &Path) -> RealTestDev {
+    pub fn new(path: &Path, linear_dev: Option<LinearDev>) -> RealTestDev {
         wipe_sectors(path, Sectors(0), Bytes(IEC::Mi).sectors()).unwrap();
-        RealTestDev { path: PathBuf::from(path) }
+        RealTestDev {
+            path: PathBuf::from(path),
+            linear: linear_dev,
+        }
     }
 
     /// Get the device node of the device.
@@ -37,50 +44,178 @@ impl RealTestDev {
 impl Drop for RealTestDev {
     fn drop(&mut self) {
         wipe_sectors(&self.path, Sectors(0), Bytes(IEC::Mi).sectors()).unwrap();
+        // If the block device is a LinearDev clean up
+        if let Some(ref ld) = self.linear {
+            // LinearDev::teardown() can't be called from a class that implements
+            // drop.  TODO: Is there a better work around?
+            get_dm()
+                .device_remove(&DevId::Name(ld.name()), DmFlags::empty())
+                .unwrap();
+        }
     }
 }
 
 pub enum DeviceLimits {
-    Exactly(usize),
-    AtLeast(usize),
+    Exactly(usize, Option<Sectors>, Option<Sectors>),
+    AtLeast(usize, Option<Sectors>, Option<Sectors>),
     #[allow(dead_code)]
-    Range(usize, usize), // inclusive
+    Range(usize, usize, Option<Sectors>, Option<Sectors>), // inclusive
+}
+
+/// Return true if the given path is >= min_size and <= max_size
+fn size_ok(dev: &Path, min_size: Option<Sectors>, max_size: Option<Sectors>) -> bool {
+    if min_size == None && max_size == None {
+        return true;
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&dev)
+        .unwrap();
+    let blkdev_size = blkdev_size(&file).unwrap().sectors();
+
+    if min_size.unwrap_or(Sectors(0)) > blkdev_size {
+        return false;
+    }
+
+    if max_size.unwrap_or(Sectors(<u64>::max_value())) < blkdev_size {
+        return false;
+    }
+
+    return true;
+}
+
+/// Create LinearDevs of min_size using the space from the path
+fn slice_disk(dev: &Path, min_size: Sectors, count: u64) -> Vec<LinearDev> {
+    let mut start = Sectors(0);
+    let mut lds = vec![];
+
+    for i in 0..count {
+        let params = LinearTargetParams::new(Device::from(devnode_to_devno(dev).unwrap().unwrap()),
+                                             start);
+        let table =
+            vec![TargetLine::new(Sectors(0), min_size, LinearDevTargetParams::Linear(params))];
+        let ld =
+            LinearDev::setup(get_dm(),
+                             DmName::new(&format!("stratis_test_{}", i)).expect("valid format"),
+                             None,
+                             table.clone())
+                    .unwrap();
+        start = start + min_size;
+        lds.push(ld)
+    }
+
+    lds
+}
+
+/// Return how many slices of min_size will fit on the block device
+fn slice_count(dev: &Path, min_size: Sectors) -> u64 {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&dev)
+        .unwrap();
+    blkdev_size(&file).unwrap().sectors() / min_size
+}
+
+/// Create min_count LinearDevs from the paths if possible
+fn slice_devices(devpaths: &[&Path], min_count: usize, min_size: Sectors) -> Vec<RealTestDev> {
+    let mut slices: Vec<RealTestDev> = vec![];
+
+    // Determine how many block devices of min_size can each of the paths provide
+    let path_slice_count = devpaths
+        .to_vec()
+        .iter()
+        .map(|&dev| (dev, slice_count(dev, min_size)))
+        .collect::<Vec<(_, u64)>>();
+
+    // Get the sum of all the block devices for each path
+    let total_possible_slices = path_slice_count
+        .to_vec()
+        .iter()
+        .fold(0u64, |sum, tup| sum + tup.1);
+
+    // If the min_count can be provided, create linear devs to be returned,
+    // Otherwise return an empty vec[].
+    if total_possible_slices >= min_count as u64 {
+        let mut needed_count = 0;
+        let mut avail_slices: u64 = 0;
+
+        // Determine how many of the paths we need to slice into LinearDevs to
+        // meet min_count
+        for path in path_slice_count.iter() {
+            needed_count += 1;
+            avail_slices += path.1;
+            if avail_slices >= min_count as u64 {
+                break;
+            }
+        }
+
+        // Create needed_count LinearDevs
+        let linear_devs: Vec<LinearDev> = path_slice_count[0..needed_count]
+            .to_vec()
+            .iter()
+            .map(|&tup| slice_disk(tup.0, min_size, cmp::min(tup.1, min_count as u64)))
+            .collect::<Vec<Vec<LinearDev>>>()
+            .into_iter()
+            .flat_map(|vec| vec.into_iter())
+            .collect();
+
+        // Wrap the LinearDev in a RealTestDev.  The RealTestDev drop implementation
+        // will cleanup the LinearDev.
+        slices.append(&mut linear_devs
+                               .into_iter()
+                               .map(|ld| RealTestDev::new(&ld.devnode(), Some(ld)))
+                               .collect());
+    }
+    slices
 }
 
 /// Get a list of counts of devices to use for tests.
 /// None of the counts can be greater than avail.
-fn get_device_counts(limits: DeviceLimits, avail: usize) -> Vec<usize> {
+fn get_devices(limits: DeviceLimits, devpaths: &[&Path]) -> Vec<Vec<RealTestDev>> {
     // Convert enum to [lower, Option<upper>) values
-    let (lower, maybe_upper) = match limits {
-        DeviceLimits::Exactly(num) => (num, Some(num + 1)),
-        DeviceLimits::AtLeast(num) => (num, None),
-        DeviceLimits::Range(lower, upper) => {
-            assert!(lower < upper);
-            (lower, Some(upper + 1))
+    let (lower, maybe_upper, min_size, max_size) = match limits {
+        DeviceLimits::Exactly(num, min_size, max_size) => (num, None, min_size, max_size),
+        DeviceLimits::AtLeast(num, min_size, max_size) => (num, None, min_size, max_size),
+        DeviceLimits::Range(lower, upper, min_size, max_size) => {
+            assert!(lower < upper,
+                    "Upper bound of range must be greater than the lower bound");
+            (lower, Some(upper + 1), min_size, max_size)
         }
     };
-
-    let mut counts = vec![];
-
-    // Check these values against available blockdevs
-    if lower > avail {
-        return counts;
+    assert!(min_size.unwrap_or(Sectors(u64::min_value())) <
+            max_size.unwrap_or(Sectors(u64::max_value())),
+            "Minimum device size greater than maximum");
+    let mut devices: Vec<Vec<RealTestDev>> = vec![];
+    let correct_size: Vec<&Path> = devpaths
+        .to_vec()
+        .iter()
+        .cloned()
+        .filter(|dev| size_ok(dev, min_size, max_size))
+        .collect::<Vec<&Path>>();
+    if correct_size.len() <= lower {
+        let slices = slice_devices(devpaths,
+                                   lower,
+                                   min_size.unwrap_or(Bytes(IEC::Gi).sectors()));
+        assert!(slices.len() >= lower,
+                "Test devices supplied do not meet minimum requirements");
+        devices.push(slices);
+    } else {
+        devices.push(correct_size[0..lower]
+                         .to_vec()
+                         .iter()
+                         .map(|x| RealTestDev::new(x, None))
+                         .collect());
+        if maybe_upper.is_some() {
+            devices.push(correct_size[0..(maybe_upper.unwrap() - 1)]
+                             .to_vec()
+                             .iter()
+                             .map(|x| RealTestDev::new(x, None))
+                             .collect());
+        };
     }
-
-    counts.push(lower);
-
-    if lower != avail {
-        match maybe_upper {
-            None => counts.push(avail),
-            Some(upper) => {
-                if lower + 1 < upper {
-                    counts.push(cmp::min(upper - 1, avail))
-                }
-            }
-        }
-    }
-
-    counts
+    devices
 }
 
 /// Run test on real devices, using given constraints. Constraints may result
@@ -103,19 +238,13 @@ pub fn test_with_spec<F>(limits: DeviceLimits, test: F) -> ()
         .map(|x| Path::new(x.as_str().unwrap()))
         .collect();
 
-    let counts = get_device_counts(limits, devpaths.len());
+    let runs = get_devices(limits, &devpaths);
 
-    assert!(!counts.is_empty());
+    assert!(!runs.is_empty());
 
     init_logger();
 
-    let runs = counts
-        .iter()
-        .map(|num| devpaths.iter().take(*num).collect::<Vec<_>>());
-
-    for run_paths in runs {
-        let devices: Vec<_> = run_paths.iter().map(|x| RealTestDev::new(x)).collect();
-
+    for devices in runs {
         clean_up().unwrap();
 
         let result =

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -927,7 +927,8 @@ mod tests {
 
     #[test]
     pub fn real_test_filesystem_snapshot() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_filesystem_snapshot);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None),
+                             test_filesystem_snapshot);
     }
 
     /// Verify that a filesystem rename causes the filesystem metadata to be
@@ -975,7 +976,8 @@ mod tests {
 
     #[test]
     pub fn real_test_filesystem_rename() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_filesystem_rename);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None),
+                             test_filesystem_rename);
     }
 
     /// Verify that setting up a pool when the pool has not been previously torn
@@ -1037,7 +1039,7 @@ mod tests {
 
     #[test]
     pub fn real_test_pool_setup() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_pool_setup);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None), test_pool_setup);
     }
     /// Verify that destroy_filesystems actually deallocates the space
     /// from the thinpool, by attempting to reinstantiate it using the
@@ -1103,7 +1105,8 @@ mod tests {
 
     #[test]
     pub fn real_test_meta_expand() {
-        real::test_with_spec(real::DeviceLimits::Range(2, 3), test_meta_expand);
+        real::test_with_spec(real::DeviceLimits::Range(2, 3, None, None),
+                             test_meta_expand);
     }
 
     /// Verify that the meta device backing a ThinPool is expanded when meta
@@ -1153,7 +1156,8 @@ mod tests {
 
     #[test]
     pub fn real_test_thindev_destroy() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_thindev_destroy);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None),
+                             test_thindev_destroy);
     }
 
     /// Verify that the physical space allocated to a pool is expanded when
@@ -1208,7 +1212,8 @@ mod tests {
 
     #[test]
     pub fn real_test_thinpool_expand() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_thinpool_expand);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None),
+                             test_thinpool_expand);
     }
 
     /// Verify that the logical space allocated to a filesystem is expanded when
@@ -1283,7 +1288,7 @@ mod tests {
 
     #[test]
     pub fn real_test_xfs_expand() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_xfs_expand);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None), test_xfs_expand);
     }
 
     /// Just suspend and resume the device and make sure it doesn't crash.
@@ -1319,7 +1324,8 @@ mod tests {
 
     #[test]
     pub fn real_test_suspend_resume() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(1), test_suspend_resume);
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None),
+                             test_suspend_resume);
     }
 
     /// Set up thinpool and backstore. Set up filesystem and write to it.
@@ -1414,6 +1420,6 @@ mod tests {
 
     #[test]
     pub fn real_test_set_device() {
-        real::test_with_spec(real::DeviceLimits::AtLeast(2), test_set_device);
+        real::test_with_spec(real::DeviceLimits::AtLeast(2, None, None), test_set_device);
     }
 }

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -818,8 +818,9 @@ fn attempt_thin_repair(pool_uuid: PoolUuid,
 
 #[cfg(test)]
 mod tests {
-    use std::fs::OpenOptions;
+    use std::fs::{File, OpenOptions};
     use std::io::{Read, Write};
+    use std::iter::FromIterator;
     use std::path::Path;
 
     use nix::mount::{MsFlags, mount, umount};
@@ -836,6 +837,101 @@ mod tests {
     use super::super::filesystem::{FILESYSTEM_LOWATER, fs_usage};
 
     use super::*;
+
+    const BYTES_PER_WRITE: usize = 2 * IEC::Ki as usize * SECTOR_SIZE as usize;
+
+    /// Verify that a full pool extends properly when additional space is added.
+    fn test_full_pool(paths: &[&Path]) {
+        let pool_uuid = Uuid::new_v4();
+        devlinks::setup_dev_path().unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        let first_path = Vec::from_iter(paths[0..1].iter().cloned());
+        let remaining_paths = Vec::from_iter(paths[1..paths.len()].iter().cloned());
+        let mut backstore = Backstore::initialize(pool_uuid, &first_path, MIN_MDA_SECTORS, false)
+            .unwrap();
+        let mut pool = ThinPool::new(pool_uuid,
+                                     &ThinPoolSizeParams::default(),
+                                     DATA_BLOCK_SIZE,
+                                     DATA_LOWATER,
+                                     &mut backstore)
+                .unwrap();
+
+        let pool_name = "stratis_test_pool";
+        devlinks::pool_added(&pool_name).unwrap();
+        let fs_uuid = pool.create_filesystem(pool_name, "stratis_test_filesystem", None)
+            .unwrap();
+        let write_buf = &[8u8; BYTES_PER_WRITE];
+        let source_tmp_dir = tempfile::Builder::new()
+            .prefix("stratis_testing")
+            .tempdir()
+            .unwrap();
+        {
+            // to allow mutable borrow of pool
+            let (_, filesystem) = pool.get_filesystem_by_uuid(fs_uuid).unwrap();
+            mount(Some(&filesystem.devnode()),
+                  source_tmp_dir.path(),
+                  Some("xfs"),
+                  MsFlags::empty(),
+                  None as Option<&str>)
+                    .unwrap();
+            let file_path = source_tmp_dir.path().join("stratis_test.txt");
+            let mut f: File = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(file_path)
+                .unwrap();
+            // Write the write_buf until the pool is full
+            loop {
+                let status: dm::ThinPoolStatus = pool.thin_pool.status(get_dm()).unwrap();
+                match status {
+                    dm::ThinPoolStatus::Working(ref _status) => {
+                        f.write_all(write_buf).unwrap();
+                        if let Err(_e) = f.sync_data() {
+                            break;
+                        }
+                    }
+                    dm::ThinPoolStatus::Fail => panic!("ThinPoolStatus::Fail  Expected working."),
+                }
+            }
+        }
+        match pool.thin_pool.status(get_dm()).unwrap() {
+            dm::ThinPoolStatus::Working(ref status) => {
+                assert!(
+                    status.summary == ThinPoolStatusSummary::OutOfSpace,
+                    "Expected full pool",
+                );
+            }
+            dm::ThinPoolStatus::Fail => panic!("ThinPoolStatus::Fail  Expected working/full."),
+        };
+        // Add block devices to the pool and run check() to extend
+        backstore
+            .add_blockdevs(&remaining_paths, BlockDevTier::Data, true)
+            .unwrap();
+        pool.check(&mut backstore).unwrap();
+        // Verify the pool is back in a Good state
+        match pool.thin_pool.status(get_dm()).unwrap() {
+            dm::ThinPoolStatus::Working(ref status) => {
+                assert!(
+                    status.summary == ThinPoolStatusSummary::Good,
+                    "Expected pool to be restored to good state",
+                );
+            }
+            dm::ThinPoolStatus::Fail => panic!("ThinPoolStatus::Fail.  Expected working/good."),
+        };
+    }
+
+    #[test]
+    pub fn loop_test_full_pool() {
+        loopbacked::test_with_spec(loopbacked::DeviceLimits::Exactly(2), test_full_pool);
+    }
+
+    #[test]
+    pub fn real_test_full_pool() {
+        real::test_with_spec(real::DeviceLimits::Exactly(2,
+                                                         Some(Bytes(IEC::Gi).sectors()),
+                                                         Some(Bytes(IEC::Gi * 4).sectors())),
+                             test_full_pool);
+    }
 
     /// Verify a snapshot has the same files and same contents as the origin.
     fn test_filesystem_snapshot(paths: &[&Path]) {


### PR DESCRIPTION
Extend the test framework to allow unit tests to request a size range for the test devices.  If the range is not available - the supplied devices may be sliced up into DM linear devs to satisfy the request.

Add a test case that uses the test framework extension to test that once a pool has gone into the "full" state, it can be transitioned back to good when block devices are added.
