### PR TITLE
Allow failures for lint task on the Python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ addons:
 language: rust
 
 matrix:
+    allow_failures:
+        - env: TASK=lint
     include:
         - rust: stable
           env: TASK=fmt-travis TARGET=x86_64-unknown-linux-gnu


### PR DESCRIPTION
This is, of course, temporary, until we get the lint task running again.

Related: #923 