### PR TITLE
metadata: Use sync_all() instead of flush()

### DIFF
--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -4,6 +4,8 @@
 
 // Utilities to support Stratis.
 
+use std::fs::File;
+use std::io::Cursor;
 use std::path::Path;
 
 use libudev;
@@ -35,4 +37,22 @@ pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
         });
 
     result
+}
+
+/// Lets functions that take file-like types ensure that changes are
+/// flushed/synced, since flush() doesn't actually do anything.
+pub trait SyncAll {
+    fn sync_all(&mut self) -> StratisResult<()>;
+}
+
+impl SyncAll for File {
+    fn sync_all(&mut self) -> StratisResult<()> {
+        File::sync_all(self).map_err(|e| e.into())
+    }
+}
+
+impl<T> SyncAll for Cursor<T> {
+    fn sync_all(&mut self) -> StratisResult<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
Apparently flush() does nothing, so use sync_all() instead to ensure
data is saved.

Since we also want our functions to be generic so we can mock using Cursor,
Add trait SyncAll, which allows Cursor to still work with the new method
call (sync_all() on a Cursor is no-op.)

There were also a couple spots that were taking a reference that didn't
need to, that needed to be corrected to get this working.

fixes #892

Signed-off-by: Andy Grover <agrover@redhat.com>