### PR TITLE
Leverage the udev db

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -743,6 +743,7 @@ mod tests {
 
     use devicemapper::{CacheDevStatus, DataBlocks};
 
+    use super::super::super::cmd;
     use super::super::super::tests::{loopbacked, real};
 
     use super::super::setup::find_all;
@@ -897,6 +898,7 @@ mod tests {
 
         let backstore_save = backstore.record();
 
+        cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
         let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
@@ -904,6 +906,7 @@ mod tests {
 
         backstore.teardown().unwrap();
 
+        cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
         let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -19,13 +19,12 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{DevUuid, PoolUuid};
 
-use super::super::engine::DevOwnership;
 use super::super::serde_structs::{BlockDevSave, Recordable};
 
 use super::blockdev::StratBlockDev;
 use super::cleanup::wipe_blockdevs;
-use super::device::{blkdev_size, resolve_devices};
-use super::metadata::{validate_mda_size, StaticHeader, BDA, MIN_MDA_SECTORS};
+use super::device::{blkdev_size, identify, resolve_devices, DevOwnership};
+use super::metadata::{validate_mda_size, BDA, MIN_MDA_SECTORS};
 use super::util::hw_lookup;
 
 const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
@@ -351,12 +350,12 @@ fn initialize(
     /// Get device information, returns an error if problem with obtaining
     /// that information.
     /// Returns a tuple with the device's path, its size in bytes,
-    /// its ownership as determined by calling determine_ownership(),
+    /// its signature as determined by calling device::identify(),
     /// and an open File handle, all of which are needed later.
     fn dev_info(devnode: &Path) -> StratisResult<(&Path, Bytes, DevOwnership, File)> {
-        let mut f = OpenOptions::new().read(true).write(true).open(&devnode)?;
+        let f = OpenOptions::new().read(true).write(true).open(&devnode)?;
         let dev_size = blkdev_size(&f)?;
-        let ownership = StaticHeader::determine_ownership(&mut f)?;
+        let ownership = identify(devnode)?;
 
         Ok((devnode, dev_size, ownership, f))
     }
@@ -376,7 +375,7 @@ fn initialize(
     {
         let mut add_devs = Vec::new();
         for (dev, dev_result) in dev_infos {
-            let (devnode, dev_size, ownership, f) = dev_result?;
+            let (devnode, dev_size, ownership, mut f) = dev_result?;
             if dev_size < MIN_DEV_SIZE {
                 let error_message = format!(
                     "{} too small, minimum {} bytes",
@@ -387,11 +386,12 @@ fn initialize(
             };
             match ownership {
                 DevOwnership::Unowned => add_devs.push((dev, (devnode, dev_size, f))),
-                DevOwnership::Theirs => {
+                DevOwnership::Theirs(signature) => {
                     if !force {
                         let err_str = format!(
-                            "Device {} appears to belong to another application",
-                            devnode.display()
+                            "Device {} has an existing signature {}",
+                            devnode.display(),
+                            signature
                         );
                         return Err(StratisError::Engine(ErrorEnum::Invalid, err_str));
                     } else {
@@ -467,15 +467,31 @@ mod tests {
     use rand;
     use uuid::Uuid;
 
-    use devicemapper::SECTOR_SIZE;
-
-    use super::super::super::device::write_sectors;
     use super::super::super::tests::{loopbacked, real};
 
-    use super::super::metadata::{BDA_STATIC_HDR_SECTORS, MIN_MDA_SECTORS};
+    use super::super::metadata::{StaticHeader, MIN_MDA_SECTORS};
     use super::super::setup::{find_all, get_metadata};
 
+    use super::super::super::cmd;
+
     use super::*;
+
+    /// Returns true if two usages have the same type.  This is needed because
+    /// if Usage::Theirs(String::from("foo") != Usage::Theirs(String::from("bar").
+    /// TODO: See if there is a better way to solve this.
+    fn usage_equal(left: &DevOwnership, right: &DevOwnership) -> bool {
+        if left == right {
+            true
+        } else {
+            match left {
+                &DevOwnership::Theirs(_) => match right {
+                    &DevOwnership::Theirs(_) => true,
+                    _ => false,
+                },
+                _ => false,
+            }
+        }
+    }
 
     /// Verify that initially,
     /// current_capacity() - metadata_size() = avail_space().
@@ -522,47 +538,38 @@ mod tests {
     }
 
     /// Verify that it is impossible to initialize a set of disks of which
-    /// even one is dirty, i.e, has some data written within BDA_STATIC_HDR_SECTORS
-    /// of start of disk. Choose the dirty disk randomly. This means that even
-    /// if our code is broken with respect to this property, this test might
-    /// sometimes succeed.
-    /// FIXME: Consider enriching device specs so that this test will fail
-    /// consistently.
-    /// Verify that force flag allows all dirty disks to be initialized.
+    /// even one of them has a signature.  Choose the dirty disk randomly.
+    /// Verify that force flag allows initialization in the presence of
+    /// one device with a signature.
     fn test_force_flag_dirty(paths: &[&Path]) -> () {
         let index = rand::random::<u8>() as usize % paths.len();
-        write_sectors(
-            paths[index],
-            Sectors(index as u64 % *BDA_STATIC_HDR_SECTORS),
-            Sectors(1),
-            &[1u8; SECTOR_SIZE],
-        ).unwrap();
+
+        cmd::create_ext3_fs(paths[index]).unwrap();
+        cmd::udev_settle().unwrap();
 
         let pool_uuid = Uuid::new_v4();
         assert!(BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).is_err());
         assert!(paths.iter().enumerate().all(|(i, path)| {
-            StaticHeader::determine_ownership(&mut OpenOptions::new()
-                .read(true)
-                .open(path)
-                .unwrap())
-                .unwrap() == if i == index {
-                DevOwnership::Theirs
+            let tmp = if i == index {
+                DevOwnership::Theirs(String::from(""))
             } else {
                 DevOwnership::Unowned
-            }
+            };
+
+            usage_equal(&identify(path).unwrap(), &tmp)
         }));
 
         assert!(BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, true).is_ok());
+        cmd::udev_settle().unwrap();
+
         assert!(paths.iter().all(|path| {
-            match StaticHeader::determine_ownership(&mut OpenOptions::new()
+            let (t_pool_uuid, _) = StaticHeader::device_identifiers(&mut OpenOptions::new()
                 .read(true)
                 .open(path)
                 .unwrap())
                 .unwrap()
-            {
-                DevOwnership::Ours(uuid, _) => pool_uuid == uuid,
-                _ => false,
-            }
+                .unwrap();
+            pool_uuid == t_pool_uuid
         }));
     }
 
@@ -604,6 +611,8 @@ mod tests {
         let uuid2 = Uuid::new_v4();
 
         let mut bd_mgr = BlockDevMgr::initialize(uuid, paths1, MIN_MDA_SECTORS, false).unwrap();
+        cmd::udev_settle().unwrap();
+
         assert!(BlockDevMgr::initialize(uuid2, paths1, MIN_MDA_SECTORS, false).is_err());
         // FIXME: this should succeed, but currently it fails, to be extra safe.
         // See: https://github.com/stratis-storage/stratisd/pull/292
@@ -614,6 +623,8 @@ mod tests {
         assert_eq!(bd_mgr.block_devs.len(), original_length);
 
         BlockDevMgr::initialize(uuid, paths2, MIN_MDA_SECTORS, false).unwrap();
+        cmd::udev_settle().unwrap();
+
         assert!(bd_mgr.add(paths2, false).is_err());
     }
 
@@ -659,6 +670,7 @@ mod tests {
         let uuid1 = Uuid::new_v4();
         BlockDevMgr::initialize(uuid1, paths1, MIN_MDA_SECTORS, false).unwrap();
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 1);
         assert!(pools.contains_key(&uuid1));
@@ -668,6 +680,7 @@ mod tests {
         let uuid2 = Uuid::new_v4();
         BlockDevMgr::initialize(uuid2, paths2, MIN_MDA_SECTORS, false).unwrap();
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 2);
 
@@ -708,24 +721,26 @@ mod tests {
         let pool_uuid = Uuid::new_v4();
         let bd_mgr = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
 
+        cmd::udev_settle().unwrap();
+
         assert!(paths.iter().all(|path| {
-            match StaticHeader::determine_ownership(&mut OpenOptions::new()
+            let (t_pool_uuid, _) = StaticHeader::device_identifiers(&mut OpenOptions::new()
                 .read(true)
                 .open(path)
                 .unwrap())
                 .unwrap()
-            {
-                DevOwnership::Ours(uuid, _) => uuid == pool_uuid,
-                _ => false,
-            }
+                .unwrap();
+            pool_uuid == t_pool_uuid
         }));
+
         bd_mgr.destroy_all().unwrap();
         assert!(paths.iter().all(|path| {
-            StaticHeader::determine_ownership(&mut OpenOptions::new()
+            let id = StaticHeader::device_identifiers(&mut OpenOptions::new()
                 .read(true)
                 .open(path)
                 .unwrap())
-                .unwrap() == DevOwnership::Unowned
+                .unwrap();
+            id.is_none()
         }));
     }
 

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -5,13 +5,16 @@
 // Functions for dealing with devices.
 
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::os::unix::prelude::AsRawFd;
 use std::path::Path;
 
 use devicemapper::{devnode_to_devno, Bytes, Device};
-
 use stratis::{ErrorEnum, StratisError, StratisResult};
+
+use super::super::super::types::{DevUuid, PoolUuid};
+use super::metadata::StaticHeader;
+use super::util::get_udev_block_device;
 
 ioctl!(read blkgetsize64 with 0x12, 114; u64);
 
@@ -42,4 +45,153 @@ pub fn resolve_devices<'a>(paths: &'a [&Path]) -> StratisResult<HashMap<Device, 
         }
     }
     Ok(map)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DevOwnership {
+    Ours(PoolUuid, DevUuid),
+    Unowned,
+    Theirs(String), // String is something useful to give back to end user about what's on device
+}
+
+/// Returns true if a device has no signature, yes this is a bit convoluted.  Logic gleaned from
+/// blivet library.
+fn empty(device: &HashMap<String, String>) -> bool {
+    !((device.contains_key("ID_PART_TABLE_TYPE") && !device.contains_key("ID_PART_ENTRY_DISK"))
+        || device.contains_key("ID_FS_USAGE"))
+}
+
+/// Generate some kind of human readable text about what's on a device.
+fn signature(device: &HashMap<String, String>) -> String {
+    if empty(device) {
+        String::from("empty")
+    } else {
+        device
+            .iter()
+            .filter(|&(k, _)| k.contains("ID_FS_") || k.contains("ID_PART_TABLE_"))
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<String>>()
+            .join(" ")
+    }
+}
+
+/// Determine what a block device is used for.
+pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
+    if let Some(device) = get_udev_block_device(devnode)? {
+        if empty(&device) {
+            // The device is either really empty or we are running on a distribution that hasn't
+            // picked up the latest libblkid, lets read down to the device and find out for sure.
+            // TODO: At some point in the future we can remove this and just return Unowned.
+            if let Some((pool_uuid, device_uuid)) = StaticHeader::device_identifiers(
+                &mut OpenOptions::new().read(true).open(&devnode)?,
+            )? {
+                Ok(DevOwnership::Ours(pool_uuid, device_uuid))
+            } else {
+                Ok(DevOwnership::Unowned)
+            }
+        } else if device.contains_key("ID_FS_TYPE")
+            && device.get("ID_FS_TYPE").unwrap() == "stratis"
+        {
+            // Device is ours, but we don't get everything we need from udev db, lets go to disk.
+            if let Some((pool_uuid, device_uuid)) = StaticHeader::device_identifiers(
+                &mut OpenOptions::new().read(true).open(&devnode)?,
+            )? {
+                Ok(DevOwnership::Ours(pool_uuid, device_uuid))
+            } else {
+                // In this case the udev db says it's ours, but our check says otherwise.  We should
+                // trust ourselves.  Should we raise an error here?
+                Ok(DevOwnership::Theirs(String::from(
+                    "Udev db says stratis, disk meta says no",
+                )))
+            }
+        } else {
+            Ok(DevOwnership::Theirs(signature(&device)))
+        }
+    } else {
+        Err(StratisError::Engine(
+            ErrorEnum::NotFound,
+            String::from(format!(
+                "We expected to find the block device {:?} in the udev db",
+                devnode
+            )),
+        ))
+    }
+}
+
+/// Determine if devnode is a Stratis device. Return the device's Stratis
+/// pool UUID if it belongs to Stratis.
+pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<PoolUuid>> {
+    match identify(devnode)? {
+        DevOwnership::Ours(pool_uuid, _) => Ok(Some(pool_uuid)),
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use super::super::super::cmd::{udev_settle, create_ext3_fs};
+    use super::super::super::tests::{loopbacked, real};
+
+    use super::super::device;
+
+    /// Verify that the device is not stratis by creating a device with XFS fs.
+    fn test_other_ownership(paths: &[&Path]) {
+        create_ext3_fs(paths[0]).unwrap();
+
+        udev_settle().unwrap();
+
+        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+
+        assert!(match device::identify(paths[0]).unwrap() {
+            device::DevOwnership::Theirs(identity) => {
+                assert!(identity.contains("ID_FS_USAGE=filesystem"));
+                assert!(identity.contains("ID_FS_TYPE=ext3"));
+                assert!(identity.contains("ID_FS_UUID"));
+                true
+            }
+            _ => false,
+        });
+    }
+
+    /// Test a blank device and ensure it comes up as device::Usage::Unowned
+    fn test_empty(paths: &[&Path]) {
+        udev_settle().unwrap();
+
+        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+
+        assert!(match device::identify(paths[0]).unwrap() {
+            device::DevOwnership::Unowned => true,
+            _ => false,
+        });
+
+        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+    }
+
+    #[test]
+    pub fn loop_test_device_other_ownership() {
+        loopbacked::test_with_spec(
+            loopbacked::DeviceLimits::Range(1, 3, None),
+            test_other_ownership,
+        );
+    }
+
+    #[test]
+    pub fn real_test_device_other_ownership() {
+        real::test_with_spec(
+            real::DeviceLimits::AtLeast(1, None, None),
+            test_other_ownership,
+        );
+    }
+
+    #[test]
+    pub fn loop_test_device_empty() {
+        loopbacked::test_with_spec(loopbacked::DeviceLimits::Range(1, 3, None), test_empty);
+    }
+
+    #[test]
+    pub fn real_test_device_empty() {
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None), test_empty);
+    }
 }

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -17,7 +17,6 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::super::types::{DevUuid, PoolUuid};
 
 use super::super::device::SyncAll;
-use super::super::engine::DevOwnership;
 
 pub use self::mda::{validate_mda_size, MIN_MDA_SECTORS};
 
@@ -319,9 +318,8 @@ impl StaticHeader {
         }
     }
 
-    /// Determine the ownership of a device.
-    /// If the device is owned by Stratis, return its device UUID.
-    pub fn determine_ownership<F>(f: &mut F) -> StratisResult<DevOwnership>
+    /// Retrieve the device and pool UUIDs from a stratis device.
+    pub fn device_identifiers<F>(f: &mut F) -> StratisResult<Option<((PoolUuid, DevUuid))>>
     where
         F: Read + Seek + SyncAll,
     {
@@ -330,15 +328,8 @@ impl StaticHeader {
         // it must also have correct CRC, no weird stuff in fields,
         // etc!
         match StaticHeader::setup(f) {
-            Ok(Some(sh)) => Ok(DevOwnership::Ours(sh.pool_uuid, sh.dev_uuid)),
-            Ok(None) => {
-                let buf = BDA::read(f)?;
-                if buf.iter().any(|x| *x != 0) {
-                    Ok(DevOwnership::Theirs)
-                } else {
-                    Ok(DevOwnership::Unowned)
-                }
-            }
+            Ok(Some(sh)) => Ok(Some((sh.pool_uuid, sh.dev_uuid))),
+            Ok(None) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -884,8 +875,6 @@ mod tests {
     use quickcheck::{QuickCheck, TestResult};
     use uuid::Uuid;
 
-    use super::super::super::engine::DevOwnership;
-
     use super::*;
 
     /// Return a static header with random block device and MDA size.
@@ -905,49 +894,20 @@ mod tests {
     }
 
     #[test]
-    /// Verify that the file is theirs, if there are any non-zero bits in BDA.
-    /// Unowned if all bits are 0.
-    fn test_other_ownership() {
-        fn property(offset: u8, length: u8, value: u8) -> TestResult {
-            if value == 0 || length == 0 {
-                return TestResult::discard();
-            }
-            let mut buf = Cursor::new(vec![0; _BDA_STATIC_HDR_SIZE]);
-            match StaticHeader::determine_ownership(&mut buf).unwrap() {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
-            }
-
-            let data = vec![value; length as usize];
-            buf.seek(SeekFrom::Start(offset as u64)).unwrap();
-            buf.write(&data).unwrap();
-            match StaticHeader::determine_ownership(&mut buf).unwrap() {
-                DevOwnership::Theirs => {}
-                _ => return TestResult::failed(),
-            }
-            TestResult::passed()
-        }
-        QuickCheck::new()
-            .tests(10)
-            .quickcheck(property as fn(u8, u8, u8) -> TestResult);
-    }
-
-    #[test]
     /// Construct an arbitrary StaticHeader object.
-    /// Verify that the "file" is unowned.
+    /// Verify that the "memory buffer" is unowned.
     /// Initialize a BDA.
-    /// Verify that Stratis owns the file.
+    /// Verify that Stratis buffer validates.
     /// Wipe the BDA.
-    /// Verify that the file is again unowned.
+    /// Verify that the buffer is again unowned.
     fn prop_test_ownership() {
         fn test_ownership(blkdev_size: u64, mda_size_factor: u32) -> TestResult {
             let sh = random_static_header(blkdev_size, mda_size_factor);
             let buf_size = *sh.mda_size.bytes() as usize + _BDA_STATIC_HDR_SIZE;
             let mut buf = Cursor::new(vec![0; buf_size]);
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
+            let ownership = StaticHeader::device_identifiers(&mut buf).unwrap();
+            if ownership.is_some() {
+                return TestResult::failed();
             }
 
             BDA::initialize(
@@ -958,21 +918,18 @@ mod tests {
                 sh.blkdev_size,
                 Utc::now().timestamp() as u64,
             ).unwrap();
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Ours(pool_uuid, dev_uuid) => {
-                    if sh.pool_uuid != pool_uuid || sh.dev_uuid != dev_uuid {
-                        return TestResult::failed();
-                    }
+            if let Some((t_p, t_d)) = StaticHeader::device_identifiers(&mut buf).unwrap() {
+                if t_p != sh.pool_uuid || t_d != sh.dev_uuid {
+                    return TestResult::failed();
                 }
-                _ => return TestResult::failed(),
+            } else {
+                return TestResult::failed();
             }
 
             BDA::wipe(&mut buf).unwrap();
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
+            let ownership = StaticHeader::device_identifiers(&mut buf).unwrap();
+            if ownership.is_some() {
+                return TestResult::failed();
             }
 
             TestResult::passed()

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -7,14 +7,14 @@ mod backstore;
 mod blockdev;
 mod blockdevmgr;
 mod cleanup;
-mod device;
+pub mod device;
 mod metadata;
 mod range_alloc;
 mod setup;
 mod util;
 
 pub use self::backstore::Backstore;
-#[cfg(test)]
 pub use self::device::blkdev_size;
+pub use self::device::is_stratis_device;
 pub use self::metadata::MIN_MDA_SECTORS;
-pub use self::setup::{find_all, get_metadata, is_stratis_device, setup_pool};
+pub use self::setup::{find_all, get_metadata, setup_pool};

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -6,11 +6,9 @@
 // Initial setup steps are steps that do not alter the environment.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::{read_dir, OpenOptions};
-use std::io::ErrorKind;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 
-use nix::errno::Errno;
 use serde_json;
 
 use devicemapper::{devnode_to_devno, Device};
@@ -20,57 +18,13 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::super::structures::Table;
 use super::super::super::types::{Name, PoolUuid};
 
-use super::super::engine::DevOwnership;
 use super::super::pool::{check_metadata, StratPool};
 use super::super::serde_structs::{BackstoreSave, PoolSave};
 
 use super::blockdev::StratBlockDev;
-use super::device::blkdev_size;
-use super::metadata::{StaticHeader, BDA};
-
-/// Determine if devnode is a Stratis device. Return the device's Stratis
-/// pool UUID if it belongs to Stratis.
-pub fn is_stratis_device(devnode: &PathBuf) -> StratisResult<Option<PoolUuid>> {
-    match OpenOptions::new().read(true).open(&devnode) {
-        Ok(mut f) => {
-            if let DevOwnership::Ours(pool_uuid, _) = StaticHeader::determine_ownership(&mut f)? {
-                Ok(Some(pool_uuid))
-            } else {
-                Ok(None)
-            }
-        }
-        Err(err) => {
-            // There are some reasons for OpenOptions::open() to return an error
-            // which are not reasons for this method to return an error.
-            // Try to distinguish. Non-error conditions are:
-            //
-            // 1. ENXIO: The device does not exist anymore. This means that the device
-            // was volatile for some reason; in that case it can not belong to
-            // Stratis so it is safe to ignore it.
-            //
-            // 2. ENOMEDIUM: The device has no medium. An example of this case is an
-            // empty optical drive.
-            //
-            // Note that it is better to be conservative and return with an
-            // error in any case where failure to read the device could result
-            // in bad data for Stratis. Additional exceptions may be added,
-            // but only with a complete justification.
-            match err.kind() {
-                ErrorKind::NotFound => Ok(None),
-                _ => {
-                    if let Some(errno) = err.raw_os_error() {
-                        match Errno::from_i32(errno) {
-                            Errno::ENXIO | Errno::ENOMEDIUM => Ok(None),
-                            _ => Err(StratisError::Io(err)),
-                        }
-                    } else {
-                        Err(StratisError::Io(err))
-                    }
-                }
-            }
-        }
-    }
-}
+use super::device::{blkdev_size, is_stratis_device};
+use super::metadata::BDA;
+use super::util::get_stratis_block_devices;
 
 /// Setup a pool from constituent devices in the context of some already
 /// setup pools. Return an error on anything that prevents the pool
@@ -135,28 +89,20 @@ pub fn setup_pool(
 /// Returns a map of pool uuids to a map of devices to devnodes for each pool.
 pub fn find_all() -> StratisResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> {
     let mut pool_map = HashMap::new();
-    let mut devno_set = HashSet::new();
-    for dir_e in read_dir("/dev")? {
-        let dir_e = dir_e?;
-        let devnode = dir_e.path();
 
+    for devnode in get_stratis_block_devices()? {
         match devnode_to_devno(&devnode)? {
             None => continue,
             Some(devno) => {
-                if devno_set.insert(devno) {
-                    is_stratis_device(&devnode)?.and_then(|pool_uuid| {
-                        pool_map
-                            .entry(pool_uuid)
-                            .or_insert_with(HashMap::new)
-                            .insert(Device::from(devno), devnode)
-                    });
-                } else {
-                    continue;
-                }
+                is_stratis_device(&devnode)?.and_then(|pool_uuid| {
+                    pool_map
+                        .entry(pool_uuid)
+                        .or_insert_with(HashMap::new)
+                        .insert(Device::from(devno), devnode)
+                });
             }
         }
     }
-
     Ok(pool_map)
 }
 

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -3,36 +3,90 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Utilities to support Stratis.
-
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use libudev;
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use super::device::is_stratis_device;
+use stratis::StratisResult;
 
-/// Lookup the WWN from the udev db using the device node eg. /dev/sda
-pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
-    #![allow(let_and_return)]
+/// Takes a libudev device entry and returns the properties as a HashMap.
+fn device_as_map(device: &libudev::Device) -> HashMap<String, String> {
+    let rc: HashMap<_, _> = device
+        .properties()
+        .map(|i| {
+            (
+                String::from(i.name().to_str().expect("Unix is utf-8")),
+                String::from(i.value().to_str().expect("Unix is utf-8")),
+            )
+        })
+        .collect();
+    rc
+}
+
+/// Common function used to retrieve the udev db entry for a block device as a HashMap when found
+pub fn get_udev_block_device(
+    dev_node_search: &Path,
+) -> StratisResult<Option<HashMap<String, String>>> {
     let context = libudev::Context::new()?;
     let mut enumerator = libudev::Enumerator::new(&context)?;
     enumerator.match_subsystem("block")?;
-    enumerator.match_property("DEVTYPE", "disk")?;
 
     let result = enumerator
         .scan_devices()?
         .find(|x| x.devnode().map_or(false, |d| dev_node_search == d))
-        .map_or(Ok(None), |dev| {
-            dev.property_value("ID_WWN").map_or(Ok(None), |i| {
-                i.to_str()
-                    .ok_or_else(|| {
-                        StratisError::Engine(
-                            ErrorEnum::Error,
-                            format!("Unable to convert {:?} to str", i),
-                        )
-                    })
-                    .map(|i| Some(String::from(i)))
-            })
-        });
+        .map_or(None, |dev| Some(device_as_map(&dev)));
+    Ok(result)
+}
 
-    result
+/// Lookup the WWN from the udev db using the device node eg. /dev/sda
+pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
+    let dev = get_udev_block_device(dev_node_search)?;
+    Ok(dev.map_or(None, |dev| {
+        dev.get("ID_WWN").map_or(None, |i| Some(i.clone()))
+    }))
+}
+
+/// Collect paths for all the devices that appear to be empty from a udev db perspective.
+fn get_all_empty_devices() -> StratisResult<Vec<PathBuf>> {
+    let context = libudev::Context::new()?;
+    let mut enumerator = libudev::Enumerator::new(&context)?;
+    enumerator.match_subsystem("block")?;
+
+    Ok(enumerator
+        .scan_devices()?
+        .filter(|dev| {
+            !((dev.property_value("ID_PART_TABLE_TYPE").is_some()
+                && !dev.property_value("ID_PART_ENTRY_DISK").is_some())
+                || dev.property_value("ID_FS_USAGE").is_some())
+        })
+        .map(|i| i.devnode().expect("block devices have devnode").into())
+        .collect())
+}
+
+/// Retrieve all the block devices on the system that have a Stratis signature.
+pub fn get_stratis_block_devices() -> StratisResult<Vec<PathBuf>> {
+    let context = libudev::Context::new()?;
+    let mut enumerator = libudev::Enumerator::new(&context)?;
+    enumerator.match_subsystem("block")?;
+    enumerator.match_property("ID_FS_TYPE", "stratis")?;
+
+    let devices: Vec<PathBuf> = enumerator
+        .scan_devices()?
+        .map(|x| x.devnode().expect("block devices have devnode").into())
+        .collect();
+
+    if devices.len() == 0 {
+        // Either we don't have any stratis devices or we are using a distribution that doesn't
+        // have a version of libblkid that supports stratis, lets make sure.
+        // TODO: At some point in the future we can remove this and just return the devices.
+
+        Ok(get_all_empty_devices()?
+            .into_iter()
+            .filter(|x| is_stratis_device(&x).ok().is_some())
+            .collect())
+    } else {
+        Ok(devices)
+    }
 }

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -158,3 +158,20 @@ pub fn thin_repair(meta_dev: &Path, new_meta_dev: &Path) -> StratisResult<()> {
         &format!("thin_repair of thin pool meta device {:?} failed", meta_dev),
     )
 }
+
+/// Call udevadm settle
+#[cfg(test)]
+pub fn udev_settle() -> StratisResult<()> {
+    execute_cmd(
+        Command::new("udevadm").arg("settle"),
+        &format!("udevadm settle failed"),
+    )
+}
+
+#[cfg(test)]
+pub fn create_ext3_fs(devnode: &Path) -> StratisResult<()> {
+    execute_cmd(
+        Command::new("mkfs.ext3").arg(&devnode),
+        &format!("Failed to create new ext3 filesystem at {:?}", devnode),
+    )
+}

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -11,9 +11,10 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::engine::{Engine, Eventable, Pool};
 use super::super::structures::Table;
-use super::super::types::{DevUuid, Name, PoolUuid, Redundancy, RenameAction};
+use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
 
-use super::backstore::{find_all, is_stratis_device, setup_pool};
+use super::backstore::device::is_stratis_device;
+use super::backstore::{find_all, setup_pool};
 #[cfg(test)]
 use super::cleanup::teardown_pools;
 use super::cmd::verify_binaries;
@@ -23,13 +24,6 @@ use super::pool::StratPool;
 
 pub const DEV_PATH: &str = "/dev/stratis";
 const REQUIRED_DM_MINOR_VERSION: u32 = 37;
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum DevOwnership {
-    Ours(PoolUuid, DevUuid),
-    Unowned,
-    Theirs,
-}
 
 #[derive(Debug)]
 pub struct StratEngine {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -315,6 +315,7 @@ mod tests {
     use super::super::super::types::Redundancy;
 
     use super::super::backstore::{find_all, get_metadata};
+    use super::super::cmd;
     use super::super::devlinks;
     use super::super::tests::{loopbacked, real};
 
@@ -350,6 +351,7 @@ mod tests {
 
         let metadata2 = pool2.record(name2);
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
@@ -361,6 +363,8 @@ mod tests {
 
         pool1.teardown().unwrap();
         pool2.teardown().unwrap();
+
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
@@ -479,6 +483,7 @@ mod tests {
 
         pool.teardown().unwrap();
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 1);
         let devices = pools.get(&uuid).unwrap();


### PR DESCRIPTION
With the addition of Stratis support to libblkid, the udev db has
the basic information needed for stratisd.  This change leverages
the udev db where appropriate, to limit when we go to disk to
read up the meta data.

Signed-off-by: Tony Asleson <tasleson@redhat.com>