### PR TITLE
Have method in StratEngine implementation return StratBlockDevs

### DIFF
--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -17,7 +17,6 @@ use devicemapper::{Bytes, Device, IEC, LinearDevTargetParams, LinearTargetParams
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::engine::BlockDev;
 use super::super::super::types::{DevUuid, PoolUuid};
 
 use super::super::engine::DevOwnership;
@@ -297,25 +296,19 @@ impl BlockDevMgr {
     }
 
     /// Get references to managed blockdevs.
-    pub fn blockdevs(&self) -> Vec<(DevUuid, &BlockDev)> {
+    pub fn blockdevs(&self) -> Vec<(DevUuid, &StratBlockDev)> {
         self.block_devs
             .iter()
-            .map(|bd| (bd.uuid(), bd as &BlockDev))
+            .map(|bd| (bd.uuid(), bd))
             .collect()
     }
 
-    pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<&BlockDev> {
-        self.block_devs
-            .iter()
-            .find(|bd| bd.uuid() == uuid)
-            .map(|bd| bd as &BlockDev)
+    pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<&StratBlockDev> {
+        self.block_devs.iter().find(|bd| bd.uuid() == uuid)
     }
 
-    pub fn get_mut_blockdev_by_uuid(&mut self, uuid: DevUuid) -> Option<&mut BlockDev> {
-        self.block_devs
-            .iter_mut()
-            .find(|bd| bd.uuid() == uuid)
-            .map(|bd| bd as &mut BlockDev)
+    pub fn get_mut_blockdev_by_uuid(&mut self, uuid: DevUuid) -> Option<&mut StratBlockDev> {
+        self.block_devs.iter_mut().find(|bd| bd.uuid() == uuid)
     }
 
     // SIZE methods

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -260,15 +260,23 @@ impl Pool for StratPool {
     }
 
     fn blockdevs(&self) -> Vec<(DevUuid, &BlockDev)> {
-        self.backstore.blockdevs()
+        self.backstore
+            .blockdevs()
+            .iter()
+            .map(|&(u, b)| (u, b as &BlockDev))
+            .collect()
     }
 
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)> {
-        self.backstore.get_blockdev_by_uuid(uuid)
+        self.backstore
+            .get_blockdev_by_uuid(uuid)
+            .map(|(t, b)| (t, b as &BlockDev))
     }
 
     fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut BlockDev)> {
-        self.backstore.get_mut_blockdev_by_uuid(uuid)
+        self.backstore
+            .get_mut_blockdev_by_uuid(uuid)
+            .map(|(t, b)| (t, b as &mut BlockDev))
     }
 
     fn save_state(&mut self, pool_name: &str) -> StratisResult<()> {


### PR DESCRIPTION
Previously, these methods returned BlockDevs. At the internal implementation
level, it makes more sense to return objects of the concrete type, rather
than trait objects.

This means that, instead of being cast to BlockDev at the lowest level, these
references are cast to BlockDev at the highest level, i.e., in the impl
of the Pool trait for StratPool.

Signed-off-by: mulhern <amulhern@redhat.com>