### PR TITLE
Revert "Update formatting for newest version of yapf"

### DIFF
--- a/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
@@ -23,14 +23,16 @@ from ._data import SPECS
 
 TIME_OUT = 120  # In seconds
 
-ObjectManager = make_class(
-    "ObjectManager",
-    ET.fromstring(SPECS['org.freedesktop.DBus.ObjectManager']), TIME_OUT)
+ObjectManager = make_class("ObjectManager",
+                           ET.fromstring(
+                               SPECS['org.freedesktop.DBus.ObjectManager']),
+                           TIME_OUT)
 Manager = make_class("Manager",
                      ET.fromstring(SPECS['org.storage.stratis1.Manager']),
                      TIME_OUT)
-Filesystem = make_class(
-    "Filesystem", ET.fromstring(SPECS['org.storage.stratis1.filesystem']),
-    TIME_OUT)
+Filesystem = make_class("Filesystem",
+                        ET.fromstring(
+                            SPECS['org.storage.stratis1.filesystem']),
+                        TIME_OUT)
 Pool = make_class("Pool", ET.fromstring(SPECS['org.storage.stratis1.pool']),
                   TIME_OUT)

--- a/tests/client-dbus/src/stratisd_client_dbus/_managedobjects.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_managedobjects.py
@@ -28,7 +28,9 @@ filesystems = mo_query_builder(
 blockdevs = mo_query_builder(
     ET.fromstring(SPECS['org.storage.stratis1.blockdev']))
 
-MOPool = managed_object_class(
-    "MOPool", ET.fromstring(SPECS['org.storage.stratis1.pool']))
-MOBlockDev = managed_object_class(
-    "MOBlockDev", ET.fromstring(SPECS['org.storage.stratis1.blockdev']))
+MOPool = managed_object_class("MOPool",
+                              ET.fromstring(
+                                  SPECS['org.storage.stratis1.pool']))
+MOBlockDev = managed_object_class("MOBlockDev",
+                                  ET.fromstring(
+                                      SPECS['org.storage.stratis1.blockdev']))


### PR DESCRIPTION
This reverts commit a797c05c7ab6eb57c46375b1bbada87ba3429d01.

The reason for reverting this change is that pyup has only updated yapf to
0.21.0, not 0.22.0.