### PR TITLE
Change SyncAll::sync_all() to return io::Result

### DIFF
--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fs::File;
-use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 use std::str::from_utf8;
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -36,13 +36,13 @@ const STRAT_MAGIC: &[u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
 /// that sync to a File using other structs that also implement Write, but
 /// do not implement sync_all, e.g., the Cursor type.
 pub trait SyncAll: Write {
-    fn sync_all(&mut self) -> StratisResult<()>;
+    fn sync_all(&mut self) -> io::Result<()>;
 }
 
 impl SyncAll for File {
     /// Invokes File::sync_all() thereby syncing all the data
-    fn sync_all(&mut self) -> StratisResult<()> {
-        File::sync_all(self).map_err(|e| e.into())
+    fn sync_all(&mut self) -> io::Result<()> {
+        File::sync_all(self)
     }
 }
 
@@ -51,7 +51,7 @@ impl<T> SyncAll for Cursor<T>
 {
     /// A no-op. No data need be synced, because it is already in the Cursor
     /// inner value, which has type T.
-    fn sync_all(&mut self) -> StratisResult<()> {
+    fn sync_all(&mut self) -> io::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
It doesn't need to handle the wider possibilities of StratisResult, and
makes it easier to bind with other I/O calls, see next commit for an
example.

Signed-off-by: Andy Grover <agrover@redhat.com>