### PR TITLE
Remove some remaining flush() calls in favor of sync_all()

### DIFF
--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -413,7 +413,7 @@ mod mda {
                 f.write_all(&hdr_buf)?;
             }
 
-            f.flush()?;
+            f.sync_all()?;
 
             Ok(MDARegions {
                 region_size,
@@ -505,7 +505,7 @@ mod mda {
                 )))?;
                 f.write_all(&hdr_buf)?;
                 f.write_all(data)?;
-                f.flush()?;
+                f.sync_all()?;
 
                 Ok(())
             };

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::File;
-use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom};
 use std::str::from_utf8;
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -17,6 +16,7 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{DevUuid, PoolUuid};
 
+use super::super::device::SyncAll;
 use super::super::engine::DevOwnership;
 
 pub use self::mda::{validate_mda_size, MIN_MDA_SECTORS};
@@ -29,32 +29,6 @@ const BDA_STATIC_HDR_SIZE: Bytes = Bytes(_BDA_STATIC_HDR_SIZE as u64);
 const MDA_RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)); // = 3 MiB
 
 const STRAT_MAGIC: &[u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
-
-/// The SyncAll trait unifies the File type with other types that do
-/// not implement sync_all(). The purpose is to allow testing of methods
-/// that sync to a File using other structs that also implement Write, but
-/// do not implement sync_all, e.g., the Cursor type.
-pub trait SyncAll: Write {
-    fn sync_all(&mut self) -> io::Result<()>;
-}
-
-impl SyncAll for File {
-    /// Invokes File::sync_all() thereby syncing all the data
-    fn sync_all(&mut self) -> io::Result<()> {
-        File::sync_all(self)
-    }
-}
-
-impl<T> SyncAll for Cursor<T>
-where
-    Cursor<T>: Write,
-{
-    /// A no-op. No data need be synced, because it is already in the Cursor
-    /// inner value, which has type T.
-    fn sync_all(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
 
 #[derive(Debug)]
 pub struct BDA {
@@ -829,7 +803,7 @@ mod mda {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use std::io::{Cursor, Write};
 
     use devicemapper::{Bytes, Sectors, IEC};
     use quickcheck::{QuickCheck, TestResult};

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -14,5 +14,5 @@ mod setup;
 mod util;
 
 pub use self::backstore::Backstore;
-pub use self::metadata::{SyncAll, MIN_MDA_SECTORS};
+pub use self::metadata::MIN_MDA_SECTORS;
 pub use self::setup::{find_all, get_metadata, is_stratis_device, setup_pool};

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -14,5 +14,5 @@ mod setup;
 mod util;
 
 pub use self::backstore::Backstore;
-pub use self::metadata::MIN_MDA_SECTORS;
+pub use self::metadata::{SyncAll, MIN_MDA_SECTORS};
 pub use self::setup::{find_all, get_metadata, is_stratis_device, setup_pool};

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -5,12 +5,23 @@
 // Functions for dealing with devices.
 
 use std::fs::OpenOptions;
-use std::io::{BufWriter, Seek, SeekFrom, Write};
+use std::io::{self, BufWriter, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
 use stratis::StratisResult;
+
+use super::backstore::SyncAll;
+
+impl<T> SyncAll for BufWriter<T>
+where
+    T: SyncAll,
+{
+    fn sync_all(&mut self) -> io::Result<()> {
+        self.get_mut().sync_all()
+    }
+}
 
 /// Write buf at offset length times.
 pub fn write_sectors<P: AsRef<Path>>(
@@ -27,7 +38,7 @@ pub fn write_sectors<P: AsRef<Path>>(
         f.write_all(buf)?;
     }
 
-    f.flush()?;
+    f.sync_all()?;
     Ok(())
 }
 

--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -47,7 +47,7 @@ impl LoopTestDev {
         // TODO: see https://github.com/nix-rust/nix/issues/596
         f.seek(SeekFrom::Start(IEC::Gi)).unwrap();
         f.write(&[0]).unwrap();
-        f.flush().unwrap();
+        f.sync_all().unwrap();
 
         let ld = lc.next_free().unwrap();
         ld.attach_file(path).unwrap();

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -8,12 +8,10 @@ use std::convert::From;
 use std::fs::{create_dir, read_dir, remove_dir, remove_file, rename, OpenOptions};
 use std::io::ErrorKind;
 use std::io::prelude::*;
-use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use nix;
 use nix::mount::{mount, umount, MsFlags};
-use nix::unistd::fsync;
 use serde_json;
 
 use devicemapper::{DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
@@ -150,8 +148,7 @@ impl MetadataVol {
             f.write_all(data.as_bytes())?;
 
             // Try really hard to make sure it goes to disk
-            f.flush()?;
-            fsync(f.as_raw_fd())?;
+            f.sync_all()?;
         }
 
         rename(temp_path, path)?;

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -934,7 +934,7 @@ mod tests {
                     .open(file_path)
                     .unwrap();
                 f.write_all(write_buf).unwrap();
-                f.flush().unwrap();
+                f.sync_all().unwrap();
             }
         }
 


### PR DESCRIPTION
flush() does nothing, so we should sync_all() any time we want to ensure
something is saved to permanent media.

Make SyncAll public from mod metadata.

Implement SyncAll for BufWriter.

Don't need nix call to fsync() in MDV code any more, that's what sync_all
does.

fixes #953

Signed-off-by: Andy Grover <agrover@redhat.com>