### PR TITLE
fix travis fmt by pinning to 1.26.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ fmt:
 	cargo fmt
 
 fmt-travis:
+	rustup default 1.26.0
 	rustup component add rustfmt-preview
 	cargo fmt -- --write-mode=diff
 


### PR DESCRIPTION
Signed-off-by: Andy Grover <agrover@redhat.com>