### PR TITLE
Re-work dbus permissions

### DIFF
--- a/stratisd.conf
+++ b/stratisd.conf
@@ -4,10 +4,50 @@
 <busconfig>
 <policy user="root">
   <allow own="org.storage.stratis1"/>
+  <allow send_destination="org.storage.stratis1"/>
 </policy>
 <policy context="default">
-  <allow send_destination="org.storage.stratis1"/>
-  <allow own_prefix="org.storage.stratis1.Manager"/>
-  <allow send_interface="org.storage.stratis1"/>
+  <deny own="org.storage.stratis1"/>
+  <deny send_destination="org.storage.stratis1"/>
+
+  <allow send_destination="org.storage.stratis1"
+         send_interface="org.freedesktop.DBus.ObjectManager"/>
+
+  <allow send_destination="org.storage.stratis1"
+         send_interface="org.freedesktop.DBus.Introspectable"/>
+
+  <allow send_destination="org.storage.stratis1"
+         send_interface="org.freedesktop.DBus.Properties"
+         send_member="Get"/>
+
+  <allow send_destination="org.storage.stratis1"
+         send_interface="org.freedesktop.DBus.Properties"
+         send_member="GetAll"/>
+
+  <allow send_destination="org.storage.stratis1.pool"
+         send_interface="org.freedesktop.DBus.Properties"
+         send_member="Get"/>
+
+  <allow send_destination="org.storage.stratis1.pool"
+         send_interface="org.freedesktop.DBus.Properties"
+         send_member="GetAll"/>
+
+  <allow send_destination="org.storage.stratis1.filesystem"
+         send_interface="org.freedesktop.DBus.Properties"
+         send_member="Get"/>
+
+  <allow send_destination="org.storage.stratis1.filesystem"
+         send_interface="org.freedesktop.DBus.Properties"
+         send_member="GetAll"/>
+
+  <allow send_destination="org.storage.stratis1.blockdev"
+         send_interface="org.freedesktop.DBus.Properties"
+         send_member="Get"/>
+
+  <allow send_destination="org.storage.stratis1.blockdev"
+        send_interface="org.freedesktop.DBus.Properties"
+        send_member="GetAll"/>
+
 </policy>
+
 </busconfig>


### PR DESCRIPTION
Change the permissions so root can do anything and non-root user
can use the following interfaces:

org.freedesktop.DBus.ObjectManager
org.freedesktop.DBus.Introspectable
org.freedesktop.DBus.Properties

On each of the provided interfaces by stratisd.  This change
allows the stratis CLI or any dbus client to query the system, but
not make changes.

Signed-off-by: Tony Asleson <tasleson@redhat.com>