### PR TITLE
Improvement to stratisd run() method

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -180,6 +180,18 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
     let (dbus_conn, mut tree, base_object_path, dbus_context) =
         libstratis::dbus_api::connect(Rc::clone(&engine))?;
 
+    #[cfg(feature = "dbus_enabled")]
+    for (_, pool_uuid, pool) in engine.borrow().pools() {
+        libstratis::dbus_api::register_pool(
+            &dbus_conn,
+            &dbus_context,
+            &mut tree,
+            pool_uuid,
+            pool,
+            &base_object_path,
+        )?;
+    }
+
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -214,22 +214,10 @@ pub fn connect<'a>(
     dbus::Error,
 > {
     let c = Connection::get_private(BusType::System)?;
-
-    let local_engine = Rc::clone(&engine);
-
-    let (mut tree, object_path) = get_base_tree(DbusContext::new(engine));
+    let (tree, object_path) = get_base_tree(DbusContext::new(engine));
     let dbus_context = tree.get_data().clone();
-
-    // This should never panic as register_pool_dbus does not borrow the engine.
-    for (_, pool_uuid, pool) in local_engine.borrow().pools() {
-        register_pool_dbus(&dbus_context, pool_uuid, pool, &object_path);
-    }
-
     tree.set_registered(&c, true)?;
     c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32)?;
-
-    process_deferred_actions(&c, &mut tree, &mut dbus_context.actions.borrow_mut())?;
-
     Ok((c, tree, object_path, dbus_context))
 }
 


### PR DESCRIPTION
This moves registering pools out of the dbus layer and into bin/stratisd.rs, completely. Previously, in one case the pools were registered in the run() method in stratisd.rs , and in the other they were registered as a side-effect of calling the dbus-api connect() method. This way, the code is more uniform.