### PR TITLE
Expect the pool to be available if it was just added

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -199,10 +199,16 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
                         #[cfg(feature = "dbus_enabled")]
                         libstratis::dbus_api::register_pool(
                             &dbus_conn,
-                            &Rc::clone(&engine),
                             &dbus_context,
                             &mut tree,
                             _pool_uuid,
+                            engine
+                                .borrow()
+                                .get_pool(_pool_uuid)
+                                .expect(
+                                    "block_evaluate() returned a pool UUID, pool must be available",
+                                )
+                                .1,
                             &base_object_path,
                         )?;
                     }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -236,17 +236,14 @@ pub fn connect<'a>(
 /// Given the UUID of a pool, register all the pertinent information with dbus.
 pub fn register_pool(
     c: &Connection,
-    engine: &Rc<RefCell<Engine>>,
     dbus_context: &DbusContext,
     tree: &mut Tree<MTFn<TData>, TData>,
     pool_uuid: Uuid,
+    pool: &Pool,
     object_path: &dbus::Path<'static>,
 ) -> Result<(), dbus::Error> {
-    if let Some((_, pool)) = engine.borrow().get_pool(pool_uuid) {
-        register_pool_dbus(dbus_context, pool_uuid, pool, object_path);
-        return process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut());
-    }
-    Ok(())
+    register_pool_dbus(dbus_context, pool_uuid, pool, object_path);
+    process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut())
 }
 
 /// Update the dbus tree with deferred adds and removes.


### PR DESCRIPTION
block_evaluate() only returns a pool UUID if the engine has the pool.
Also, just pass the pool to register_pool.

Signed-off-by: mulhern <amulhern@redhat.com>