### PR TITLE
Do not set revents to 0 when handling engine events

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -232,7 +232,6 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
         match eventable {
             Some(ref evt) => {
                 if fds[FD_INDEX_ENGINE].revents != 0 {
-                    fds[FD_INDEX_ENGINE].revents = 0;
                     evt.clear_event()?;
                     engine.borrow_mut().evented()?;
                 }


### PR DESCRIPTION
Expect the kernel to do the correct thing, as with D-Bus and udev
revents.

Signed-off-by: mulhern <amulhern@redhat.com>