### PR TITLE
Make clippy mandatory again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ addons:
 language: rust
 
 matrix:
-    allow_failures:
-        - env: TASK=clippy TARGET=x86_64-unknown-linux-gnu
     include:
         - rust: stable
           env: TASK=fmt-travis TARGET=x86_64-unknown-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,7 @@ stratisd.8.gz: stratisd.8
 	gzip --stdout docs/stratisd.8 > docs/stratisd.8.gz
 
 clippy:
-	cargo install clippy
-	RUSTFLAGS='-D warnings' cargo clippy
+	! cargo install clippy || RUSTFLAGS='-D warnings' cargo clippy
 
 uml-graphs: ${HOME}/.cargo/bin/cargo-script
 	PATH=${HOME}/.cargo/bin:${PATH} cargo script scripts/uml_graphs.rs

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -38,8 +38,8 @@ impl From<DbusErrorEnum> for u16 {
 }
 
 impl DbusErrorEnum {
-    pub fn get_error_string(&self) -> &str {
-        match *self {
+    pub fn get_error_string(self) -> &'static str {
+        match self {
             DbusErrorEnum::OK => "Ok",
             DbusErrorEnum::ERROR => "A general error happened",
             DbusErrorEnum::ALREADY_EXISTS => "Already exists",

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -252,6 +252,7 @@ impl StaticHeader {
     where
         F: Read + Seek + SyncAll,
     {
+        #![allow(collapsible_if)]
         let buf = BDA::read(f)?;
         let buf_loc_1 = &buf[SECTOR_SIZE..2 * SECTOR_SIZE];
         let buf_loc_2 = &buf[9 * SECTOR_SIZE..10 * SECTOR_SIZE];


### PR DESCRIPTION
Make clippy a mandatory part of Travis by causing the Travis task to succeed if compiling clippy fails.

Resolves: #925.