### PR TITLE
Add a Travis task for compilation w/out defaults enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
         - rust: stable
           env: TASK=build TARGET=x86_64-unknown-linux-gnu
         - rust: stable
+          env: TASK=build-no-default TARGET=x86_64-unknown-linux-gnu
+        - rust: stable
           env: TASK=build TARGET=x86_64-unknown-linux-gnu
           install:
             - rustup default 1.26.0

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ build:
 	RUSTFLAGS='-D warnings' \
 	cargo build --target $(TARGET)
 
+build-no-default:
+	PKG_CONFIG_ALLOW_CROSS=1 \
+	RUSTFLAGS='-D warnings' \
+	cargo build --no-default-features --target $(TARGET)
+
 test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_
 


### PR DESCRIPTION
We should always be certain that stratisd compiles w/out defaults enabled.

Related: #735.