### PR TITLE
RFC: Leverage conditional compilation for full runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ loopdev = "0.2"
 either = "1.1.0"
 
 [features]
-default = ["dbus_enabled"]
-dbus_enabled = ["dbus"]
+default = ["full_runtime"]
+full_runtime = ["dbus"]

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -47,6 +47,7 @@ pub trait Pool: Debug {
     /// Returns an error if any of the specified names are already in use
     /// for filesystems in this pool. If the same name is passed multiple
     /// times, the size associated with the last item is used.
+    #[cfg(feature = "full_runtime")]
     fn create_filesystems<'a, 'b>(
         &'a mut self,
         pool_name: &str,
@@ -94,6 +95,7 @@ pub trait Pool: Debug {
 
     /// Snapshot filesystem
     /// Create a CoW snapshot of the origin
+    #[cfg(feature = "full_runtime")]
     fn snapshot_filesystem(
         &mut self,
         pool_name: &str,
@@ -145,6 +147,7 @@ pub trait Engine: Debug {
     /// Returns the UUID of the newly created pool.
     /// Returns an error if the redundancy code does not correspond to a
     /// supported redundancy.
+    #[cfg(feature = "full_runtime")]
     fn create_pool(
         &mut self,
         name: &str,
@@ -191,6 +194,7 @@ pub trait Engine: Debug {
     fn get_eventable(&self) -> Option<&'static Eventable>;
 
     /// Notify the engine that an event has occurred on the Eventable.
+    #[cfg(feature = "full_runtime")]
     fn evented(&mut self) -> StratisResult<()>;
 }
 

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+#[cfg(feature = "full_runtime")]
 macro_rules! calculate_redundancy {
     ($redundancy:ident) => {
         match $redundancy {

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -5,10 +5,19 @@
 extern crate libc;
 
 use std::cell::RefCell;
+
+#[cfg(feature = "full_runtime")]
 use std::collections::HashSet;
+
+#[cfg(feature = "full_runtime")]
 use std::collections::hash_map::RandomState;
+
+#[cfg(feature = "full_runtime")]
 use std::iter::FromIterator;
-use std::path::{Path, PathBuf};
+
+#[cfg(feature = "full_runtime")]
+use std::path::Path;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use devicemapper::Device;
@@ -17,7 +26,9 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::engine::{Engine, Eventable, Pool};
 use super::super::structures::Table;
-use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
+#[cfg(feature = "full_runtime")]
+use super::super::types::Redundancy;
+use super::super::types::{Name, PoolUuid, RenameAction};
 
 use super::pool::SimPool;
 use super::randomization::Randomizer;
@@ -31,6 +42,7 @@ pub struct SimEngine {
 impl SimEngine {}
 
 impl Engine for SimEngine {
+    #[cfg(feature = "full_runtime")]
     fn create_pool(
         &mut self,
         name: &str,
@@ -125,6 +137,7 @@ impl Engine for SimEngine {
         None
     }
 
+    #[cfg(feature = "full_runtime")]
     fn evented(&mut self) -> StratisResult<()> {
         Ok(())
     }

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "full_runtime")]
 use rand;
 
 use std::path::PathBuf;
@@ -14,6 +15,7 @@ pub struct SimFilesystem {
 }
 
 impl SimFilesystem {
+    #[cfg(feature = "full_runtime")]
     pub fn new() -> SimFilesystem {
         SimFilesystem {
             rand: rand::random::<u32>(),

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::vec::Vec;
 
+#[cfg(feature = "full_runtime")]
 use uuid::Uuid;
 
 use devicemapper::{Sectors, IEC};
@@ -18,8 +19,9 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::structures::Table;
-use super::super::types::{BlockDevTier, DevUuid, FilesystemUuid, Name, PoolUuid, Redundancy,
-                          RenameAction};
+#[cfg(feature = "full_runtime")]
+use super::super::types::PoolUuid;
+use super::super::types::{BlockDevTier, DevUuid, FilesystemUuid, Name, Redundancy, RenameAction};
 
 use super::blockdev::SimDev;
 use super::filesystem::SimFilesystem;
@@ -35,6 +37,7 @@ pub struct SimPool {
 }
 
 impl SimPool {
+    #[cfg(feature = "full_runtime")]
     pub fn new(
         rdm: &Rc<RefCell<Randomizer>>,
         paths: &[&Path],
@@ -72,6 +75,7 @@ impl SimPool {
 }
 
 impl Pool for SimPool {
+    #[cfg(feature = "full_runtime")]
     fn create_filesystems<'a, 'b>(
         &'a mut self,
         _pool_name: &str,
@@ -159,6 +163,7 @@ impl Pool for SimPool {
         Ok(RenameAction::Renamed)
     }
 
+    #[cfg(feature = "full_runtime")]
     fn snapshot_filesystem(
         &mut self,
         _pool_name: &str,

--- a/src/engine/sim_engine/randomization.rs
+++ b/src/engine/sim_engine/randomization.rs
@@ -4,9 +4,11 @@
 
 use std::fmt;
 
+#[cfg(feature = "full_runtime")]
 use rand::{thread_rng, Rng, ThreadRng};
 
 pub struct Randomizer {
+    #[cfg(feature = "full_runtime")]
     rng: ThreadRng,
     denominator: u32,
 }
@@ -14,6 +16,7 @@ pub struct Randomizer {
 impl Default for Randomizer {
     fn default() -> Randomizer {
         Randomizer {
+            #[cfg(feature = "full_runtime")]
             rng: thread_rng(),
             denominator: 0u32,
         }
@@ -31,6 +34,7 @@ impl fmt::Debug for Randomizer {
 impl Randomizer {
     /// Throw a denominator sided die, returning true if 1 comes up
     /// If denominator is 0, return false
+    #[cfg(feature = "full_runtime")]
     pub fn throw_die(&mut self) -> bool {
         if self.denominator == 0 {
             false

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -100,6 +100,7 @@ impl DataTier {
     /// Returns the DataTier and the linear device that was created.
     ///
     /// WARNING: metadata changing event
+    #[cfg(feature = "full_runtime")]
     pub fn new(mut block_mgr: BlockDevMgr) -> StratisResult<(DataTier, LinearDev)> {
         let avail_space = block_mgr.avail_space();
         let segments = block_mgr
@@ -507,6 +508,7 @@ impl Backstore {
 
     /// Initialize a Backstore object, by initializing the specified devs.
     /// WARNING: metadata changing event
+    #[cfg(feature = "full_runtime")]
     pub fn initialize(
         pool_uuid: PoolUuid,
         paths: &[&Path],
@@ -592,6 +594,7 @@ impl Backstore {
     /// WARNING: All this must change when it becomes possible to return
     /// sectors to the store.
     /// WARNING: metadata changing event
+    #[cfg(feature = "full_runtime")]
     pub fn alloc_space(&mut self, sizes: &[Sectors]) -> Option<Vec<Vec<(Sectors, Sectors)>>> {
         if self.available() < sizes.iter().cloned().sum() {
             return None;
@@ -626,6 +629,7 @@ impl Backstore {
     }
 
     /// The available number of Sectors.
+    #[cfg(feature = "full_runtime")]
     pub fn available(&self) -> Sectors {
         self.data_tier.capacity() - self.next
     }

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[cfg(feature = "full_runtime")]
 use uuid::Uuid;
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
@@ -37,18 +38,24 @@ fn find_binary(name: &str) -> Option<PathBuf> {
 // These are the external binaries that stratisd relies on.
 // Any change in this list requires a corresponding change to BINARIES,
 // and vice-versa.
+#[cfg(feature = "full_runtime")]
 const MKFS_XFS: &str = "mkfs.xfs";
 const THIN_CHECK: &str = "thin_check";
 const THIN_REPAIR: &str = "thin_repair";
+#[cfg(feature = "full_runtime")]
 const XFS_ADMIN: &str = "xfs_admin";
+#[cfg(feature = "full_runtime")]
 const XFS_GROWFS: &str = "xfs_growfs";
 
 lazy_static! {
     static ref BINARIES: HashMap<String, Option<PathBuf>> = [
+        #[cfg(feature = "full_runtime")]
         (MKFS_XFS.to_string(), find_binary(MKFS_XFS)),
         (THIN_CHECK.to_string(), find_binary(THIN_CHECK)),
         (THIN_REPAIR.to_string(), find_binary(THIN_REPAIR)),
+        #[cfg(feature = "full_runtime")]
         (XFS_ADMIN.to_string(), find_binary(XFS_ADMIN)),
+        #[cfg(feature = "full_runtime")]
         (XFS_GROWFS.to_string(), find_binary(XFS_GROWFS))
     ].iter()
         .cloned()
@@ -103,6 +110,7 @@ fn get_executable(name: &str) -> StratisResult<PathBuf> {
 }
 
 /// Create a filesystem on devnode.
+#[cfg(feature = "full_runtime")]
 pub fn create_fs(devnode: &Path, uuid: Uuid) -> StratisResult<()> {
     execute_cmd(
         Command::new(get_executable(MKFS_XFS)?.as_os_str())
@@ -117,6 +125,7 @@ pub fn create_fs(devnode: &Path, uuid: Uuid) -> StratisResult<()> {
 
 /// Use the xfs_growfs command to expand a filesystem mounted at the given
 /// mount point.
+#[cfg(feature = "full_runtime")]
 pub fn xfs_growfs(mount_point: &Path) -> StratisResult<()> {
     execute_cmd(
         Command::new(get_executable(XFS_GROWFS)?.as_os_str())
@@ -127,6 +136,7 @@ pub fn xfs_growfs(mount_point: &Path) -> StratisResult<()> {
 }
 
 /// Set a new UUID for filesystem on the devnode.
+#[cfg(feature = "full_runtime")]
 pub fn set_uuid(devnode: &Path, uuid: Uuid) -> StratisResult<()> {
     execute_cmd(
         Command::new(get_executable(XFS_ADMIN)?.as_os_str())

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "full_runtime")]
+use std::path::Path;
+use std::path::PathBuf;
 
 use devicemapper::{Device, DmNameBuf};
 
@@ -11,7 +13,9 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::engine::{Engine, Eventable, Pool};
 use super::super::structures::Table;
-use super::super::types::{DevUuid, Name, PoolUuid, Redundancy, RenameAction};
+#[cfg(feature = "full_runtime")]
+use super::super::types::Redundancy;
+use super::super::types::{DevUuid, Name, PoolUuid, RenameAction};
 
 use super::backstore::{find_all, is_stratis_device, setup_pool};
 #[cfg(test)]
@@ -103,6 +107,7 @@ impl StratEngine {
 }
 
 impl Engine for StratEngine {
+    #[cfg(feature = "full_runtime")]
     fn create_pool(
         &mut self,
         name: &str,
@@ -231,6 +236,7 @@ impl Engine for StratEngine {
         Some(get_dm())
     }
 
+    #[cfg(feature = "full_runtime")]
     fn evented(&mut self) -> StratisResult<()> {
         let device_list: HashMap<_, _> = get_dm()
             .list_devices()?

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -3,14 +3,19 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::collections::HashMap;
+#[cfg(feature = "full_runtime")]
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use std::vec::Vec;
 
 use serde_json;
+
+#[cfg(feature = "full_runtime")]
 use uuid::Uuid;
 
-use devicemapper::{Device, DmName, DmNameBuf, Sectors};
+use devicemapper::{Device, Sectors};
+#[cfg(feature = "full_runtime")]
+use devicemapper::{DmName, DmNameBuf};
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
@@ -18,11 +23,18 @@ use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::types::{BlockDevTier, DevUuid, FilesystemUuid, Name, PoolUuid, Redundancy,
                           RenameAction};
 
-use super::backstore::{Backstore, MIN_MDA_SECTORS};
-use super::serde_structs::{PoolSave, Recordable};
-use super::thinpool::{ThinPool, ThinPoolSizeParams};
+use super::backstore::Backstore;
+#[cfg(feature = "full_runtime")]
+use super::backstore::MIN_MDA_SECTORS;
 
-pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER, INITIAL_DATA_SIZE};
+use super::serde_structs::{PoolSave, Recordable};
+use super::thinpool::ThinPool;
+#[cfg(feature = "full_runtime")]
+use super::thinpool::ThinPoolSizeParams;
+
+#[cfg(feature = "full_runtime")]
+pub use super::thinpool::INITIAL_DATA_SIZE;
+pub use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER};
 
 /// Check the metadata of an individual pool for consistency.
 pub fn check_metadata(metadata: &PoolSave) -> StratisResult<()> {
@@ -59,6 +71,7 @@ impl StratPool {
     /// Initialize a Stratis Pool.
     /// 1. Initialize the block devices specified by paths.
     /// 2. Set up thinpool device to back filesystems.
+    #[cfg(feature = "full_runtime")]
     pub fn initialize(
         name: &str,
         paths: &[&Path],
@@ -138,6 +151,7 @@ impl StratPool {
     }
 
     /// The names of DM devices belonging to this pool that may generate events
+    #[cfg(feature = "full_runtime")]
     pub fn get_eventing_dev_names(&self) -> Vec<DmNameBuf> {
         self.thin_pool.get_eventing_dev_names()
     }
@@ -145,6 +159,7 @@ impl StratPool {
     /// Called when a DM device in this pool has generated an event.
     // TODO: Just check the device that evented. Currently checks
     // everything.
+    #[cfg(feature = "full_runtime")]
     pub fn event_on(&mut self, pool_name: &Name, dm_name: &DmName) -> StratisResult<()> {
         assert!(
             self.thin_pool
@@ -169,6 +184,7 @@ impl StratPool {
 }
 
 impl Pool for StratPool {
+    #[cfg(feature = "full_runtime")]
     fn create_filesystems<'a, 'b>(
         &'a mut self,
         pool_name: &str,
@@ -238,6 +254,7 @@ impl Pool for StratPool {
         self.thin_pool.rename_filesystem(pool_name, uuid, new_name)
     }
 
+    #[cfg(feature = "full_runtime")]
     fn snapshot_filesystem(
         &mut self,
         pool_name: &str,

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -20,6 +20,7 @@ use stratis::StratisResult;
 
 use super::super::super::types::{FilesystemUuid, Name, PoolUuid};
 
+#[cfg(feature = "full_runtime")]
 use super::super::cmd::create_fs;
 use super::super::dm::get_dm;
 use super::super::engine::DEV_PATH;
@@ -89,6 +90,7 @@ impl<'a> Drop for MountedMDV<'a> {
 
 impl MetadataVol {
     /// Initialize a new Metadata Volume.
+    #[cfg(feature = "full_runtime")]
     pub fn initialize(pool_uuid: PoolUuid, dev: LinearDev) -> StratisResult<MetadataVol> {
         create_fs(&dev.devnode(), pool_uuid)?;
         MetadataVol::setup(pool_uuid, dev)

--- a/src/engine/strat_engine/thinpool/mod.rs
+++ b/src/engine/strat_engine/thinpool/mod.rs
@@ -8,5 +8,6 @@ mod thinids;
 #[allow(module_inception)]
 mod thinpool;
 
-pub use self::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE, DATA_LOWATER,
-                         INITIAL_DATA_SIZE};
+pub use self::thinpool::{ThinPool, DATA_BLOCK_SIZE, DATA_LOWATER};
+#[cfg(feature = "full_runtime")]
+pub use self::thinpool::{ThinPoolSizeParams, INITIAL_DATA_SIZE};

--- a/src/engine/strat_engine/thinpool/thinids.rs
+++ b/src/engine/strat_engine/thinpool/thinids.rs
@@ -6,6 +6,7 @@
 
 use devicemapper::ThinDevId;
 
+#[cfg(feature = "full_runtime")]
 use stratis::StratisResult;
 
 #[derive(Debug)]
@@ -28,6 +29,7 @@ impl ThinDevIdPool {
     /// Returns an error if no thindev id can be constructed.
     // TODO: Improve this so that it is guaranteed only to fail if every 24 bit
     // number has been used.
+    #[cfg(feature = "full_runtime")]
     pub fn new_id(&mut self) -> StratisResult<ThinDevId> {
         let next_id = ThinDevId::new_u64(u64::from(self.next_id))?;
         self.next_id += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate chrono;
 extern crate crc;
 extern crate uuid;
 
-#[cfg(feature = "dbus_enabled")]
+#[cfg(feature = "full_runtime")]
 extern crate dbus;
 
 extern crate mnt;
@@ -35,7 +35,7 @@ extern crate lazy_static;
 
 pub mod engine;
 
-#[cfg(feature = "dbus_enabled")]
+#[cfg(feature = "full_runtime")]
 pub mod dbus_api;
 
 pub mod stratis;

--- a/src/stratis/errors.rs
+++ b/src/stratis/errors.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::str;
 use std::{fmt, io};
 
-#[cfg(feature = "dbus_enabled")]
+#[cfg(feature = "full_runtime")]
 use dbus;
 use libudev;
 use nix;
@@ -38,7 +38,7 @@ pub enum StratisError {
     Serde(serde_json::error::Error),
     DM(devicemapper::DmError),
 
-    #[cfg(feature = "dbus_enabled")]
+    #[cfg(feature = "full_runtime")]
     Dbus(dbus::Error),
     Udev(libudev::Error),
 }
@@ -55,7 +55,7 @@ impl fmt::Display for StratisError {
             StratisError::Serde(ref err) => write!(f, "Serde error: {}", err),
             StratisError::DM(ref err) => write!(f, "DM error: {}", err),
 
-            #[cfg(feature = "dbus_enabled")]
+            #[cfg(feature = "full_runtime")]
             StratisError::Dbus(ref err) => {
                 write!(f, "Dbus error: {}", err.message().unwrap_or("Unknown"))
             }
@@ -76,7 +76,7 @@ impl Error for StratisError {
             StratisError::Serde(ref err) => err.description(),
             StratisError::DM(ref err) => err.description(),
 
-            #[cfg(feature = "dbus_enabled")]
+            #[cfg(feature = "full_runtime")]
             StratisError::Dbus(ref err) => err.message().unwrap_or("D-Bus Error"),
             StratisError::Udev(ref err) => Error::description(err),
         }
@@ -92,7 +92,7 @@ impl Error for StratisError {
             StratisError::Serde(ref err) => Some(err),
             StratisError::DM(ref err) => Some(err),
 
-            #[cfg(feature = "dbus_enabled")]
+            #[cfg(feature = "full_runtime")]
             StratisError::Dbus(ref err) => Some(err),
             StratisError::Udev(ref err) => Some(err),
         }
@@ -135,7 +135,7 @@ impl From<devicemapper::DmError> for StratisError {
     }
 }
 
-#[cfg(feature = "dbus_enabled")]
+#[cfg(feature = "full_runtime")]
 impl From<dbus::Error> for StratisError {
     fn from(err: dbus::Error) -> StratisError {
         StratisError::Dbus(err)


### PR DESCRIPTION
I renamed the `dbus_enabled` feature to `full_runtime` and prefixed the external executables and functions that aren't in the initrd.  After doing this I just let the compiler flag everything that wouldn't compile or wasn't needed anymore until things compiled clean.  I'm not saying we want to utilize this approach as it's ugly, but I did find it very informative.  For example we basically need to disable the events coming out of `dm` as those code paths utilize binaries that aren't in the initrd.

I'm not really sure how we could restructure the code at the moment so that things could be placed into different modules to make this all much cleaner. 

This was an attempt at an answer for https://github.com/stratis-storage/stratisd/issues/987

**Note: The release code size difference between with/without `full_runtime` is 662440 bytes.**  (3914600 vs. 3252160)

