### PR TITLE
Leverage the udev db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "libdbus-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -165,11 +165,6 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "error-chain"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "error-chain"
@@ -238,10 +233,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libdbus-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -317,16 +312,6 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "metadeps"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -584,11 +569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,7 +661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
-"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -692,14 +671,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
-"checksum libdbus-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e98e3259797bbd8ad6db7f0bd3b0f223a4e5f3bd0b4059c1b60e68f4fc1925f9"
+"checksum libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8720f9274907052cb50313f91201597868da9d625f8dd125f2aca5bddb7e83a1"
 "checksum libudev 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea626d3bdf40a1c5aee3bcd4f40826970cae8d80a8fec934c82a63840094dcfe"
 "checksum libudev-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "249a1e347fa266dc3184ebc9b4dc57108a30feda16ec0b821e94b42be20b9355"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum loopdev 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdea9df4e03f31dc3816fc81d563a3caa9433f7845d87d41e86bd69186be3a"
 "checksum macro-attr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00e51c6f0e2bf862b01b3d784fc32b02feb248a69062c51fb0b6d14cd526cc2a"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
-"checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
 "checksum mnt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1587ebb20a5b04738f16cffa7e2526f1b8496b84f92920facd518362ff1559eb"
 "checksum newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 "checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
@@ -731,7 +709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
-"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #![cfg_attr(not(feature = "clippy"), allow(unknown_lints))]
+#![cfg_attr(not(feature = "clippy"), allow(unit_arg))]
 #![allow(doc_markdown)]
 
 extern crate devicemapper;

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -743,6 +743,7 @@ mod tests {
 
     use devicemapper::{CacheDevStatus, DataBlocks};
 
+    use super::super::super::cmd;
     use super::super::super::tests::{loopbacked, real};
 
     use super::super::setup::find_all;
@@ -897,6 +898,7 @@ mod tests {
 
         let backstore_save = backstore.record();
 
+        cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
         let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
@@ -904,6 +906,7 @@ mod tests {
 
         backstore.teardown().unwrap();
 
+        cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
         let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -19,13 +19,12 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{DevUuid, PoolUuid};
 
-use super::super::engine::DevOwnership;
 use super::super::serde_structs::{BlockDevSave, Recordable};
 
 use super::blockdev::StratBlockDev;
 use super::cleanup::wipe_blockdevs;
-use super::device::{blkdev_size, resolve_devices};
-use super::metadata::{validate_mda_size, StaticHeader, BDA, MIN_MDA_SECTORS};
+use super::device::{blkdev_size, identify, resolve_devices, DevOwnership};
+use super::metadata::{validate_mda_size, BDA, MIN_MDA_SECTORS};
 use super::util::hw_lookup;
 
 const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
@@ -351,12 +350,12 @@ fn initialize(
     /// Get device information, returns an error if problem with obtaining
     /// that information.
     /// Returns a tuple with the device's path, its size in bytes,
-    /// its ownership as determined by calling determine_ownership(),
+    /// its signature as determined by calling device::identify(),
     /// and an open File handle, all of which are needed later.
     fn dev_info(devnode: &Path) -> StratisResult<(&Path, Bytes, DevOwnership, File)> {
-        let mut f = OpenOptions::new().read(true).write(true).open(&devnode)?;
+        let f = OpenOptions::new().read(true).write(true).open(&devnode)?;
         let dev_size = blkdev_size(&f)?;
-        let ownership = StaticHeader::determine_ownership(&mut f)?;
+        let ownership = identify(devnode)?;
 
         Ok((devnode, dev_size, ownership, f))
     }
@@ -376,7 +375,7 @@ fn initialize(
     {
         let mut add_devs = Vec::new();
         for (dev, dev_result) in dev_infos {
-            let (devnode, dev_size, ownership, f) = dev_result?;
+            let (devnode, dev_size, ownership, mut f) = dev_result?;
             if dev_size < MIN_DEV_SIZE {
                 let error_message = format!(
                     "{} too small, minimum {} bytes",
@@ -387,11 +386,12 @@ fn initialize(
             };
             match ownership {
                 DevOwnership::Unowned => add_devs.push((dev, (devnode, dev_size, f))),
-                DevOwnership::Theirs => {
+                DevOwnership::Theirs(signature) => {
                     if !force {
                         let err_str = format!(
-                            "Device {} appears to belong to another application",
-                            devnode.display()
+                            "Device {} has an existing signature {}",
+                            devnode.display(),
+                            signature
                         );
                         return Err(StratisError::Engine(ErrorEnum::Invalid, err_str));
                     } else {
@@ -467,15 +467,31 @@ mod tests {
     use rand;
     use uuid::Uuid;
 
-    use devicemapper::SECTOR_SIZE;
-
-    use super::super::super::device::write_sectors;
     use super::super::super::tests::{loopbacked, real};
 
-    use super::super::metadata::{BDA_STATIC_HDR_SECTORS, MIN_MDA_SECTORS};
+    use super::super::metadata::{StaticHeader, MIN_MDA_SECTORS};
     use super::super::setup::{find_all, get_metadata};
 
+    use super::super::super::cmd;
+
     use super::*;
+
+    /// Returns true if two usages have the same type.  This is needed because
+    /// if Usage::Theirs(String::from("foo") != Usage::Theirs(String::from("bar").
+    /// TODO: See if there is a better way to solve this.
+    fn usage_equal(left: &DevOwnership, right: &DevOwnership) -> bool {
+        if left == right {
+            true
+        } else {
+            match left {
+                &DevOwnership::Theirs(_) => match right {
+                    &DevOwnership::Theirs(_) => true,
+                    _ => false,
+                },
+                _ => false,
+            }
+        }
+    }
 
     /// Verify that initially,
     /// current_capacity() - metadata_size() = avail_space().
@@ -522,47 +538,38 @@ mod tests {
     }
 
     /// Verify that it is impossible to initialize a set of disks of which
-    /// even one is dirty, i.e, has some data written within BDA_STATIC_HDR_SECTORS
-    /// of start of disk. Choose the dirty disk randomly. This means that even
-    /// if our code is broken with respect to this property, this test might
-    /// sometimes succeed.
-    /// FIXME: Consider enriching device specs so that this test will fail
-    /// consistently.
-    /// Verify that force flag allows all dirty disks to be initialized.
+    /// even one of them has a signature.  Choose the dirty disk randomly.
+    /// Verify that force flag allows initialization in the presence of
+    /// one device with a signature.
     fn test_force_flag_dirty(paths: &[&Path]) -> () {
         let index = rand::random::<u8>() as usize % paths.len();
-        write_sectors(
-            paths[index],
-            Sectors(index as u64 % *BDA_STATIC_HDR_SECTORS),
-            Sectors(1),
-            &[1u8; SECTOR_SIZE],
-        ).unwrap();
+
+        cmd::create_ext3_fs(paths[index]).unwrap();
+        cmd::udev_settle().unwrap();
 
         let pool_uuid = Uuid::new_v4();
         assert!(BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).is_err());
         assert!(paths.iter().enumerate().all(|(i, path)| {
-            StaticHeader::determine_ownership(&mut OpenOptions::new()
-                .read(true)
-                .open(path)
-                .unwrap())
-                .unwrap() == if i == index {
-                DevOwnership::Theirs
+            let tmp = if i == index {
+                DevOwnership::Theirs(String::from(""))
             } else {
                 DevOwnership::Unowned
-            }
+            };
+
+            usage_equal(&identify(path).unwrap(), &tmp)
         }));
 
         assert!(BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, true).is_ok());
+        cmd::udev_settle().unwrap();
+
         assert!(paths.iter().all(|path| {
-            match StaticHeader::determine_ownership(&mut OpenOptions::new()
+            let (t_pool_uuid, _) = StaticHeader::device_identifiers(&mut OpenOptions::new()
                 .read(true)
                 .open(path)
                 .unwrap())
                 .unwrap()
-            {
-                DevOwnership::Ours(uuid, _) => pool_uuid == uuid,
-                _ => false,
-            }
+                .unwrap();
+            pool_uuid == t_pool_uuid
         }));
     }
 
@@ -604,6 +611,8 @@ mod tests {
         let uuid2 = Uuid::new_v4();
 
         let mut bd_mgr = BlockDevMgr::initialize(uuid, paths1, MIN_MDA_SECTORS, false).unwrap();
+        cmd::udev_settle().unwrap();
+
         assert!(BlockDevMgr::initialize(uuid2, paths1, MIN_MDA_SECTORS, false).is_err());
         // FIXME: this should succeed, but currently it fails, to be extra safe.
         // See: https://github.com/stratis-storage/stratisd/pull/292
@@ -614,6 +623,8 @@ mod tests {
         assert_eq!(bd_mgr.block_devs.len(), original_length);
 
         BlockDevMgr::initialize(uuid, paths2, MIN_MDA_SECTORS, false).unwrap();
+        cmd::udev_settle().unwrap();
+
         assert!(bd_mgr.add(paths2, false).is_err());
     }
 
@@ -659,6 +670,7 @@ mod tests {
         let uuid1 = Uuid::new_v4();
         BlockDevMgr::initialize(uuid1, paths1, MIN_MDA_SECTORS, false).unwrap();
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 1);
         assert!(pools.contains_key(&uuid1));
@@ -668,6 +680,7 @@ mod tests {
         let uuid2 = Uuid::new_v4();
         BlockDevMgr::initialize(uuid2, paths2, MIN_MDA_SECTORS, false).unwrap();
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 2);
 
@@ -708,24 +721,26 @@ mod tests {
         let pool_uuid = Uuid::new_v4();
         let bd_mgr = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
 
+        cmd::udev_settle().unwrap();
+
         assert!(paths.iter().all(|path| {
-            match StaticHeader::determine_ownership(&mut OpenOptions::new()
+            let (t_pool_uuid, _) = StaticHeader::device_identifiers(&mut OpenOptions::new()
                 .read(true)
                 .open(path)
                 .unwrap())
                 .unwrap()
-            {
-                DevOwnership::Ours(uuid, _) => uuid == pool_uuid,
-                _ => false,
-            }
+                .unwrap();
+            pool_uuid == t_pool_uuid
         }));
+
         bd_mgr.destroy_all().unwrap();
         assert!(paths.iter().all(|path| {
-            StaticHeader::determine_ownership(&mut OpenOptions::new()
+            let id = StaticHeader::device_identifiers(&mut OpenOptions::new()
                 .read(true)
                 .open(path)
                 .unwrap())
-                .unwrap() == DevOwnership::Unowned
+                .unwrap();
+            id.is_none()
         }));
     }
 

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -5,13 +5,16 @@
 // Functions for dealing with devices.
 
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::os::unix::prelude::AsRawFd;
 use std::path::Path;
 
 use devicemapper::{devnode_to_devno, Bytes, Device};
-
 use stratis::{ErrorEnum, StratisError, StratisResult};
+
+use super::super::super::types::{DevUuid, PoolUuid};
+use super::metadata::StaticHeader;
+use super::util::get_udev_block_device;
 
 ioctl!(read blkgetsize64 with 0x12, 114; u64);
 
@@ -42,4 +45,160 @@ pub fn resolve_devices<'a>(paths: &'a [&Path]) -> StratisResult<HashMap<Device, 
         }
     }
     Ok(map)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DevOwnership {
+    Ours(PoolUuid, DevUuid),
+    Unowned,
+    Theirs(String), // String is something useful to give back to end user about what's on device
+}
+
+/// Returns true if a device has no signature, yes this is a bit convoluted.  Logic gleaned from
+/// blivet library.
+fn empty(device: &HashMap<String, String>) -> bool {
+    if (device.contains_key("ID_PART_TABLE_TYPE") && !device.contains_key("ID_PART_ENTRY_DISK"))
+        || device.contains_key("ID_FS_USAGE")
+    {
+        false
+    } else {
+        true
+    }
+}
+
+/// Generate some kind of human readable text about what's on a device.
+fn signature(device: &HashMap<String, String>) -> String {
+    if empty(device) {
+        String::from("empty")
+    } else {
+        device
+            .iter()
+            .filter(|&(k, _)| k.contains("ID_FS_") || k.contains("ID_PART_TABLE_"))
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<String>>()
+            .join(" ")
+    }
+}
+
+/// Determine what a block device is used for.
+pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
+    let rc = if let Some(device) = get_udev_block_device(devnode)? {
+        if empty(&device) {
+            // The device is either really empty or we are running on a distribution that hasn't
+            // picked up the latest libblkid, lets read down to the device and find out for sure.
+            // TODO: At some point in the future we can remove this and just return Unowned.
+            if let Some((pool_uuid, device_uuid)) = StaticHeader::device_identifiers(
+                &mut OpenOptions::new().read(true).open(&devnode)?,
+            )? {
+                Ok(DevOwnership::Ours(pool_uuid, device_uuid))
+            } else {
+                Ok(DevOwnership::Unowned)
+            }
+        } else if device.contains_key("ID_FS_TYPE")
+            && device.get("ID_FS_TYPE").unwrap() == "stratis"
+        {
+            // Device is ours, but we don't get everything we need from udev db, lets go to disk.
+            if let Some((pool_uuid, device_uuid)) = StaticHeader::device_identifiers(
+                &mut OpenOptions::new().read(true).open(&devnode)?,
+            )? {
+                Ok(DevOwnership::Ours(pool_uuid, device_uuid))
+            } else {
+                // In this case the udev db says it's ours, but our check says otherwise.  We should
+                // trust ourselves.  Should we raise an error here?
+                Ok(DevOwnership::Theirs(String::from(
+                    "Udev db says stratis, disk meta says no",
+                )))
+            }
+        } else {
+            Ok(DevOwnership::Theirs(signature(&device)))
+        }
+    } else {
+        Err(StratisError::Engine(
+            ErrorEnum::NotFound,
+            String::from(format!(
+                "We expected to find the block device {:?} \
+                 in the udev db",
+                devnode
+            )),
+        ))
+    };
+    rc
+}
+
+/// Determine if devnode is a Stratis device. Return the device's Stratis
+/// pool UUID if it belongs to Stratis.
+pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<PoolUuid>> {
+    match identify(devnode)? {
+        DevOwnership::Ours(pool_uuid, _) => Ok(Some(pool_uuid)),
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use super::super::super::cmd::{udev_settle, create_ext3_fs};
+    use super::super::super::tests::{loopbacked, real};
+
+    use super::super::device;
+
+    /// Verify that the device is not stratis by creating a device with XFS fs.
+    fn test_other_ownership(paths: &[&Path]) {
+        create_ext3_fs(paths[0]).unwrap();
+
+        udev_settle().unwrap();
+
+        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+
+        assert!(match device::identify(paths[0]).unwrap() {
+            device::DevOwnership::Theirs(identity) => {
+                assert!(identity.contains("ID_FS_USAGE=filesystem"));
+                assert!(identity.contains("ID_FS_TYPE=ext3"));
+                assert!(identity.contains("ID_FS_UUID"));
+                true
+            }
+            _ => false,
+        });
+    }
+
+    /// Test a blank device and ensure it comes up as device::Usage::Unowned
+    fn test_empty(paths: &[&Path]) {
+        udev_settle().unwrap();
+
+        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+
+        assert!(match device::identify(paths[0]).unwrap() {
+            device::DevOwnership::Unowned => true,
+            _ => false,
+        });
+
+        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+    }
+
+    #[test]
+    pub fn loop_test_device_other_ownership() {
+        loopbacked::test_with_spec(
+            loopbacked::DeviceLimits::Range(1, 3, None),
+            test_other_ownership,
+        );
+    }
+
+    #[test]
+    pub fn real_test_device_other_ownership() {
+        real::test_with_spec(
+            real::DeviceLimits::AtLeast(1, None, None),
+            test_other_ownership,
+        );
+    }
+
+    #[test]
+    pub fn loop_test_device_empty() {
+        loopbacked::test_with_spec(loopbacked::DeviceLimits::Range(1, 3, None), test_empty);
+    }
+
+    #[test]
+    pub fn real_test_device_empty() {
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None), test_empty);
+    }
 }

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -127,6 +127,8 @@ pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<PoolUuid>> {
 }
 
 #[cfg(test)]
+// rustfmt bug requires this?
+#[cfg_attr(rustfmt, rustfmt_skip)]
 mod test {
     use std::path::Path;
 

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -17,7 +17,6 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::super::types::{DevUuid, PoolUuid};
 
 use super::super::device::SyncAll;
-use super::super::engine::DevOwnership;
 
 pub use self::mda::{validate_mda_size, MIN_MDA_SECTORS};
 
@@ -320,9 +319,8 @@ impl StaticHeader {
         }
     }
 
-    /// Determine the ownership of a device.
-    /// If the device is owned by Stratis, return its device UUID.
-    pub fn determine_ownership<F>(f: &mut F) -> StratisResult<DevOwnership>
+    /// Retrieve the device and pool UUIDs from a stratis device.
+    pub fn device_identifiers<F>(f: &mut F) -> StratisResult<Option<((PoolUuid, DevUuid))>>
     where
         F: Read + Seek + SyncAll,
     {
@@ -331,15 +329,8 @@ impl StaticHeader {
         // it must also have correct CRC, no weird stuff in fields,
         // etc!
         match StaticHeader::setup(f) {
-            Ok(Some(sh)) => Ok(DevOwnership::Ours(sh.pool_uuid, sh.dev_uuid)),
-            Ok(None) => {
-                let buf = BDA::read(f)?;
-                if buf.iter().any(|x| *x != 0) {
-                    Ok(DevOwnership::Theirs)
-                } else {
-                    Ok(DevOwnership::Unowned)
-                }
-            }
+            Ok(Some(sh)) => Ok(Some((sh.pool_uuid, sh.dev_uuid))),
+            Ok(None) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -885,8 +876,6 @@ mod tests {
     use quickcheck::{QuickCheck, TestResult};
     use uuid::Uuid;
 
-    use super::super::super::engine::DevOwnership;
-
     use super::*;
 
     /// Return a static header with random block device and MDA size.
@@ -906,49 +895,20 @@ mod tests {
     }
 
     #[test]
-    /// Verify that the file is theirs, if there are any non-zero bits in BDA.
-    /// Unowned if all bits are 0.
-    fn test_other_ownership() {
-        fn property(offset: u8, length: u8, value: u8) -> TestResult {
-            if value == 0 || length == 0 {
-                return TestResult::discard();
-            }
-            let mut buf = Cursor::new(vec![0; _BDA_STATIC_HDR_SIZE]);
-            match StaticHeader::determine_ownership(&mut buf).unwrap() {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
-            }
-
-            let data = vec![value; length as usize];
-            buf.seek(SeekFrom::Start(offset as u64)).unwrap();
-            buf.write(&data).unwrap();
-            match StaticHeader::determine_ownership(&mut buf).unwrap() {
-                DevOwnership::Theirs => {}
-                _ => return TestResult::failed(),
-            }
-            TestResult::passed()
-        }
-        QuickCheck::new()
-            .tests(10)
-            .quickcheck(property as fn(u8, u8, u8) -> TestResult);
-    }
-
-    #[test]
     /// Construct an arbitrary StaticHeader object.
-    /// Verify that the "file" is unowned.
+    /// Verify that the "memory buffer" is unowned.
     /// Initialize a BDA.
-    /// Verify that Stratis owns the file.
+    /// Verify that Stratis buffer validates.
     /// Wipe the BDA.
-    /// Verify that the file is again unowned.
+    /// Verify that the buffer is again unowned.
     fn prop_test_ownership() {
         fn test_ownership(blkdev_size: u64, mda_size_factor: u32) -> TestResult {
             let sh = random_static_header(blkdev_size, mda_size_factor);
             let buf_size = *sh.mda_size.bytes() as usize + _BDA_STATIC_HDR_SIZE;
             let mut buf = Cursor::new(vec![0; buf_size]);
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
+            let ownership = StaticHeader::device_identifiers(&mut buf).unwrap();
+            if ownership.is_some() {
+                return TestResult::failed();
             }
 
             BDA::initialize(
@@ -959,21 +919,18 @@ mod tests {
                 sh.blkdev_size,
                 Utc::now().timestamp() as u64,
             ).unwrap();
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Ours(pool_uuid, dev_uuid) => {
-                    if sh.pool_uuid != pool_uuid || sh.dev_uuid != dev_uuid {
-                        return TestResult::failed();
-                    }
+            if let Some((t_p, t_d)) = StaticHeader::device_identifiers(&mut buf).unwrap() {
+                if t_p != sh.pool_uuid || t_d != sh.dev_uuid {
+                    return TestResult::failed();
                 }
-                _ => return TestResult::failed(),
+            } else {
+                return TestResult::failed();
             }
 
             BDA::wipe(&mut buf).unwrap();
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
+            let ownership = StaticHeader::device_identifiers(&mut buf).unwrap();
+            if ownership.is_some() {
+                return TestResult::failed();
             }
 
             TestResult::passed()

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -265,14 +265,12 @@ impl StaticHeader {
                     (Some(loc_1), Some(loc_2)) => {
                         if loc_1 == loc_2 {
                             Ok(Some(loc_1))
+                        } else if loc_1.initialization_time > loc_2.initialization_time {
+                            BDA::write(f, buf_loc_1, MetadataLocation::Second)?;
+                            Ok(Some(loc_1))
                         } else {
-                            if loc_1.initialization_time > loc_2.initialization_time {
-                                BDA::write(f, buf_loc_1, MetadataLocation::Second)?;
-                                Ok(Some(loc_1))
-                            } else {
-                                BDA::write(f, buf_loc_2, MetadataLocation::First)?;
-                                Ok(Some(loc_2))
-                            }
+                            BDA::write(f, buf_loc_2, MetadataLocation::First)?;
+                            Ok(Some(loc_2))
                         }
                     }
                     (None, None) => Ok(None),

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -7,14 +7,14 @@ mod backstore;
 mod blockdev;
 mod blockdevmgr;
 mod cleanup;
-mod device;
+pub mod device;
 mod metadata;
 mod range_alloc;
 mod setup;
 mod util;
 
 pub use self::backstore::Backstore;
-#[cfg(test)]
 pub use self::device::blkdev_size;
+pub use self::device::is_stratis_device;
 pub use self::metadata::MIN_MDA_SECTORS;
-pub use self::setup::{find_all, get_metadata, is_stratis_device, setup_pool};
+pub use self::setup::{find_all, get_metadata, setup_pool};

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -6,11 +6,9 @@
 // Initial setup steps are steps that do not alter the environment.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::{read_dir, OpenOptions};
-use std::io::ErrorKind;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 
-use nix::errno::Errno;
 use serde_json;
 
 use devicemapper::{devnode_to_devno, Device};
@@ -20,57 +18,13 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::super::structures::Table;
 use super::super::super::types::{Name, PoolUuid};
 
-use super::super::engine::DevOwnership;
 use super::super::pool::{check_metadata, StratPool};
 use super::super::serde_structs::{BackstoreSave, PoolSave};
 
 use super::blockdev::StratBlockDev;
-use super::device::blkdev_size;
-use super::metadata::{StaticHeader, BDA};
-
-/// Determine if devnode is a Stratis device. Return the device's Stratis
-/// pool UUID if it belongs to Stratis.
-pub fn is_stratis_device(devnode: &PathBuf) -> StratisResult<Option<PoolUuid>> {
-    match OpenOptions::new().read(true).open(&devnode) {
-        Ok(mut f) => {
-            if let DevOwnership::Ours(pool_uuid, _) = StaticHeader::determine_ownership(&mut f)? {
-                Ok(Some(pool_uuid))
-            } else {
-                Ok(None)
-            }
-        }
-        Err(err) => {
-            // There are some reasons for OpenOptions::open() to return an error
-            // which are not reasons for this method to return an error.
-            // Try to distinguish. Non-error conditions are:
-            //
-            // 1. ENXIO: The device does not exist anymore. This means that the device
-            // was volatile for some reason; in that case it can not belong to
-            // Stratis so it is safe to ignore it.
-            //
-            // 2. ENOMEDIUM: The device has no medium. An example of this case is an
-            // empty optical drive.
-            //
-            // Note that it is better to be conservative and return with an
-            // error in any case where failure to read the device could result
-            // in bad data for Stratis. Additional exceptions may be added,
-            // but only with a complete justification.
-            match err.kind() {
-                ErrorKind::NotFound => Ok(None),
-                _ => {
-                    if let Some(errno) = err.raw_os_error() {
-                        match Errno::from_i32(errno) {
-                            Errno::ENXIO | Errno::ENOMEDIUM => Ok(None),
-                            _ => Err(StratisError::Io(err)),
-                        }
-                    } else {
-                        Err(StratisError::Io(err))
-                    }
-                }
-            }
-        }
-    }
-}
+use super::device::{blkdev_size, is_stratis_device};
+use super::metadata::BDA;
+use super::util::get_stratis_block_devices;
 
 /// Setup a pool from constituent devices in the context of some already
 /// setup pools. Return an error on anything that prevents the pool
@@ -135,28 +89,20 @@ pub fn setup_pool(
 /// Returns a map of pool uuids to a map of devices to devnodes for each pool.
 pub fn find_all() -> StratisResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> {
     let mut pool_map = HashMap::new();
-    let mut devno_set = HashSet::new();
-    for dir_e in read_dir("/dev")? {
-        let dir_e = dir_e?;
-        let devnode = dir_e.path();
 
+    for devnode in get_stratis_block_devices()? {
         match devnode_to_devno(&devnode)? {
             None => continue,
             Some(devno) => {
-                if devno_set.insert(devno) {
-                    is_stratis_device(&devnode)?.and_then(|pool_uuid| {
-                        pool_map
-                            .entry(pool_uuid)
-                            .or_insert_with(HashMap::new)
-                            .insert(Device::from(devno), devnode)
-                    });
-                } else {
-                    continue;
-                }
+                is_stratis_device(&devnode)?.and_then(|pool_uuid| {
+                    pool_map
+                        .entry(pool_uuid)
+                        .or_insert_with(HashMap::new)
+                        .insert(Device::from(devno), devnode)
+                });
             }
         }
     }
-
     Ok(pool_map)
 }
 

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -3,36 +3,90 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Utilities to support Stratis.
-
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use libudev;
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use super::device::is_stratis_device;
+use stratis::StratisResult;
 
-/// Lookup the WWN from the udev db using the device node eg. /dev/sda
-pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
-    #![allow(let_and_return)]
+/// Takes a libudev device entry and returns the properties as a HashMap.
+fn device_as_map(device: &libudev::Device) -> HashMap<String, String> {
+    let rc: HashMap<_, _> = device
+        .properties()
+        .map(|i| {
+            (
+                String::from(i.name().to_str().expect("Unix is utf-8")),
+                String::from(i.value().to_str().expect("Unix is utf-8")),
+            )
+        })
+        .collect();
+    rc
+}
+
+/// Common function used to retrieve the udev db entry for a block device as a HashMap when found
+pub fn get_udev_block_device(
+    dev_node_search: &Path,
+) -> StratisResult<Option<HashMap<String, String>>> {
     let context = libudev::Context::new()?;
     let mut enumerator = libudev::Enumerator::new(&context)?;
     enumerator.match_subsystem("block")?;
-    enumerator.match_property("DEVTYPE", "disk")?;
 
     let result = enumerator
         .scan_devices()?
         .find(|x| x.devnode().map_or(false, |d| dev_node_search == d))
-        .map_or(Ok(None), |dev| {
-            dev.property_value("ID_WWN").map_or(Ok(None), |i| {
-                i.to_str()
-                    .ok_or_else(|| {
-                        StratisError::Engine(
-                            ErrorEnum::Error,
-                            format!("Unable to convert {:?} to str", i),
-                        )
-                    })
-                    .map(|i| Some(String::from(i)))
-            })
-        });
+        .map_or(None, |dev| Some(device_as_map(&dev)));
+    Ok(result)
+}
 
-    result
+/// Lookup the WWN from the udev db using the device node eg. /dev/sda
+pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
+    let dev = get_udev_block_device(dev_node_search)?;
+    Ok(dev.map_or(None, |dev| {
+        dev.get("ID_WWN").map_or(None, |i| Some(i.clone()))
+    }))
+}
+
+/// Collect paths for all the devices that appear to be empty from a udev db perspective.
+fn get_all_empty_devices() -> StratisResult<Vec<PathBuf>> {
+    let context = libudev::Context::new()?;
+    let mut enumerator = libudev::Enumerator::new(&context)?;
+    enumerator.match_subsystem("block")?;
+
+    Ok(enumerator
+        .scan_devices()?
+        .filter(|dev| {
+            !((dev.property_value("ID_PART_TABLE_TYPE").is_some()
+                && !dev.property_value("ID_PART_ENTRY_DISK").is_some())
+                || dev.property_value("ID_FS_USAGE").is_some())
+        })
+        .map(|i| i.devnode().expect("block devices have devnode").into())
+        .collect())
+}
+
+/// Retrieve all the block devices on the system that have a Stratis signature.
+pub fn get_stratis_block_devices() -> StratisResult<Vec<PathBuf>> {
+    let context = libudev::Context::new()?;
+    let mut enumerator = libudev::Enumerator::new(&context)?;
+    enumerator.match_subsystem("block")?;
+    enumerator.match_property("ID_FS_TYPE", "stratis")?;
+
+    let devices: Vec<PathBuf> = enumerator
+        .scan_devices()?
+        .map(|x| x.devnode().expect("block devices have devnode").into())
+        .collect();
+
+    if devices.len() == 0 {
+        // Either we don't have any stratis devices or we are using a distribution that doesn't
+        // have a version of libblkid that supports stratis, lets make sure.
+        // TODO: At some point in the future we can remove this and just return the devices.
+
+        Ok(get_all_empty_devices()?
+            .into_iter()
+            .filter(|x| is_stratis_device(&x).ok().is_some())
+            .collect())
+    } else {
+        Ok(devices)
+    }
 }

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -49,7 +49,7 @@ lazy_static! {
         (THIN_CHECK.to_string(), find_binary(THIN_CHECK)),
         (THIN_REPAIR.to_string(), find_binary(THIN_REPAIR)),
         (XFS_ADMIN.to_string(), find_binary(XFS_ADMIN)),
-        (XFS_GROWFS.to_string(), find_binary(XFS_GROWFS))
+        (XFS_GROWFS.to_string(), find_binary(XFS_GROWFS)),
     ].iter()
         .cloned()
         .collect();
@@ -158,16 +158,10 @@ pub fn thin_repair(meta_dev: &Path, new_meta_dev: &Path) -> StratisResult<()> {
 /// Call udevadm settle
 #[cfg(test)]
 pub fn udev_settle() -> StratisResult<()> {
-    execute_cmd(
-        Command::new("udevadm").arg("settle"),
-        &format!("udevadm settle failed"),
-    )
+    execute_cmd(Command::new("udevadm").arg("settle"))
 }
 
 #[cfg(test)]
 pub fn create_ext3_fs(devnode: &Path) -> StratisResult<()> {
-    execute_cmd(
-        Command::new("mkfs.ext3").arg(&devnode),
-        &format!("Failed to create new ext3 filesystem at {:?}", devnode),
-    )
+    execute_cmd(Command::new("mkfs.ext3").arg(&devnode))
 }

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -154,3 +154,20 @@ pub fn thin_repair(meta_dev: &Path, new_meta_dev: &Path) -> StratisResult<()> {
             .arg(new_meta_dev),
     )
 }
+
+/// Call udevadm settle
+#[cfg(test)]
+pub fn udev_settle() -> StratisResult<()> {
+    execute_cmd(
+        Command::new("udevadm").arg("settle"),
+        &format!("udevadm settle failed"),
+    )
+}
+
+#[cfg(test)]
+pub fn create_ext3_fs(devnode: &Path) -> StratisResult<()> {
+    execute_cmd(
+        Command::new("mkfs.ext3").arg(&devnode),
+        &format!("Failed to create new ext3 filesystem at {:?}", devnode),
+    )
+}

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -11,9 +11,10 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::engine::{Engine, Eventable, Pool};
 use super::super::structures::Table;
-use super::super::types::{DevUuid, Name, PoolUuid, Redundancy, RenameAction};
+use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
 
-use super::backstore::{find_all, is_stratis_device, setup_pool};
+use super::backstore::device::is_stratis_device;
+use super::backstore::{find_all, setup_pool};
 #[cfg(test)]
 use super::cleanup::teardown_pools;
 use super::cmd::verify_binaries;
@@ -23,13 +24,6 @@ use super::pool::StratPool;
 
 pub const DEV_PATH: &str = "/dev/stratis";
 const REQUIRED_DM_MINOR_VERSION: u32 = 37;
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum DevOwnership {
-    Ours(PoolUuid, DevUuid),
-    Unowned,
-    Theirs,
-}
 
 #[derive(Debug)]
 pub struct StratEngine {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -315,6 +315,7 @@ mod tests {
     use super::super::super::types::Redundancy;
 
     use super::super::backstore::{find_all, get_metadata};
+    use super::super::cmd;
     use super::super::devlinks;
     use super::super::tests::{loopbacked, real};
 
@@ -350,6 +351,7 @@ mod tests {
 
         let metadata2 = pool2.record(name2);
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
@@ -361,6 +363,8 @@ mod tests {
 
         pool1.teardown().unwrap();
         pool2.teardown().unwrap();
+
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 2);
         let devnodes1 = pools.get(&uuid1).unwrap();
@@ -479,6 +483,7 @@ mod tests {
 
         pool.teardown().unwrap();
 
+        cmd::udev_settle().unwrap();
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 1);
         let devices = pools.get(&uuid).unwrap();

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -11,6 +11,7 @@ use devicemapper::{DevId, DmOptions};
 
 use super::super::dm::{get_dm, get_dm_init};
 
+#[allow(renamed_and_removed_lints)]
 mod cleanup_errors {
     use mnt;
     use nix;


### PR DESCRIPTION
With the addition of Stratis support to libblkid, the udev db has
the basic information needed for stratisd.  This change leverages
the udev db where appropriate, to limit when we go to disk to
read up the meta data.

Signed-off-by: Tony Asleson <tasleson@redhat.com>