### PR TITLE
Remove rustfmt skip

### DIFF
--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -127,12 +127,12 @@ pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<PoolUuid>> {
 }
 
 #[cfg(test)]
-// rustfmt bug requires this?
-#[cfg_attr(rustfmt, rustfmt_skip)]
 mod test {
     use std::path::Path;
 
-    use super::super::super::cmd::{create_ext3_fs, udev_settle};
+    // Current version of rustfmt alphabetizes this one line incorrectly.
+    // https://github.com/rust-lang-nursery/rustfmt/issues/2800
+    use super::super::super::cmd::{udev_settle, create_ext3_fs};
     use super::super::super::tests::{loopbacked, real};
 
     use super::super::device;


### PR DESCRIPTION
Better just to accept this wierdness than to prevent rustfmt from formatting
the whole module.

Signed-off-by: mulhern <amulhern@redhat.com>