### PR TITLE
Master udev intermediate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ matrix:
           env: TASK=fmt-travis
 
 branches:
-    only: master
+    only:
+        - master
+        - fixup-branch
 
 script: make -f Makefile $TASK

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -38,7 +38,7 @@ use dbus::WatchEvent;
 
 use devicemapper::Device;
 
-use libstratis::engine::{Engine, SimEngine, StratEngine};
+use libstratis::engine::{get_udev_init, Engine, SimEngine, StratEngine};
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
@@ -126,7 +126,7 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
     // completed initialization. Unless the udev event has been recorded, the
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.
-    let context = libudev::Context::new()?;
+    let context = get_udev_init()?;
     let mut monitor = libudev::Monitor::new(&context)?;
     monitor.match_subsystem_devtype("block", "disk")?;
     let mut udev = monitor.listen()?;

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -38,7 +38,7 @@ use dbus::WatchEvent;
 
 use devicemapper::Device;
 
-use libstratis::engine::{get_udev_init, Engine, SimEngine, StratEngine};
+use libstratis::engine::{get_device_devnode, get_udev_init, Engine, SimEngine, StratEngine};
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
@@ -68,14 +68,10 @@ fn initialize_log(debug: bool) -> Result<(), SetLoggerError> {
 /// devicemapper::Device.
 fn handle_udev_add(event: &libudev::Event) -> Option<(Device, PathBuf)> {
     if event.event_type() == libudev::EventType::Add {
-        let device = event.device();
-        return device.devnode().and_then(|devnode| {
-            device
-                .devnum()
-                .and_then(|devnum| Some((Device::from(devnum), PathBuf::from(devnode))))
-        });
+        get_device_devnode(event.device())
+    } else {
+        None
     }
-    None
 }
 
 /// To ensure only one instance of stratisd runs at a time, acquire an

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -21,6 +21,7 @@ pub use self::types::PoolUuid;
 pub use self::types::Redundancy;
 pub use self::types::RenameAction;
 
+pub use self::udev::get_device_devnode;
 pub use self::udev::get_udev_init;
 
 #[macro_use]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -21,6 +21,8 @@ pub use self::types::PoolUuid;
 pub use self::types::Redundancy;
 pub use self::types::RenameAction;
 
+pub use self::udev::get_udev_init;
+
 #[macro_use]
 mod macros;
 
@@ -30,3 +32,4 @@ mod sim_engine;
 mod strat_engine;
 mod structures;
 mod types;
+mod udev;

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -26,7 +26,7 @@ use super::blockdev::StratBlockDev;
 use super::cleanup::wipe_blockdevs;
 use super::device::{blkdev_size, resolve_devices};
 use super::metadata::{validate_mda_size, StaticHeader, BDA, MIN_MDA_SECTORS};
-use super::util::hw_lookup;
+use super::udev::hw_lookup;
 
 const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
 const MAX_NUM_TO_WRITE: usize = 10;

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -19,13 +19,12 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{DevUuid, PoolUuid};
 
-use super::super::engine::DevOwnership;
 use super::super::serde_structs::{BlockDevSave, Recordable};
 
 use super::blockdev::StratBlockDev;
 use super::cleanup::wipe_blockdevs;
-use super::device::{blkdev_size, resolve_devices};
-use super::metadata::{validate_mda_size, StaticHeader, BDA, MIN_MDA_SECTORS};
+use super::device::{blkdev_size, identify, resolve_devices, DevOwnership};
+use super::metadata::{validate_mda_size, BDA, MIN_MDA_SECTORS};
 use super::udev::{get_udev_property, udev_block_device_apply};
 
 const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
@@ -351,12 +350,13 @@ fn initialize(
     /// Get device information, returns an error if problem with obtaining
     /// that information.
     /// Returns a tuple with the device's path, its size in bytes,
-    /// its ownership as determined by calling determine_ownership(),
+    /// its ownership as determined by calling identify(),
     /// and an open File handle, all of which are needed later.
     fn dev_info(devnode: &Path) -> StratisResult<(&Path, Bytes, DevOwnership, File)> {
-        let mut f = OpenOptions::new().read(true).write(true).open(&devnode)?;
+        let ownership = identify(devnode)?;
+
+        let f = OpenOptions::new().read(true).write(true).open(&devnode)?;
         let dev_size = blkdev_size(&f)?;
-        let ownership = StaticHeader::determine_ownership(&mut f)?;
 
         Ok((devnode, dev_size, ownership, f))
     }
@@ -387,11 +387,17 @@ fn initialize(
             };
             match ownership {
                 DevOwnership::Unowned => add_devs.push((dev, (devnode, dev_size, f))),
-                DevOwnership::Theirs => {
+                DevOwnership::Contradiction =>
+                {
+                    return Err(StratisError::Engine(ErrorEnum::Invalid,
+                        "udev has identified this device as a Stratis device, but no Stratis header was found on the device".into()))
+                }
+                DevOwnership::Theirs(whose) => {
                     if !force {
                         let err_str = format!(
-                            "Device {} appears to belong to another application",
-                            devnode.display()
+                            "Device {} appears to belong to another application, reason: {}",
+                            devnode.display(),
+                            whose
                         );
                         return Err(StratisError::Engine(ErrorEnum::Invalid, err_str));
                     } else {
@@ -473,7 +479,7 @@ mod tests {
     use super::super::super::device::write_sectors;
     use super::super::super::tests::{loopbacked, real};
 
-    use super::super::metadata::{BDA_STATIC_HDR_SECTORS, MIN_MDA_SECTORS};
+    use super::super::metadata::{device_identifiers, BDA_STATIC_HDR_SECTORS, MIN_MDA_SECTORS};
     use super::super::setup::{find_all, get_metadata};
 
     use super::*;
@@ -542,28 +548,27 @@ mod tests {
         let pool_uuid = Uuid::new_v4();
         assert!(BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).is_err());
         assert!(paths.iter().enumerate().all(|(i, path)| {
-            StaticHeader::determine_ownership(&mut OpenOptions::new()
-                .read(true)
-                .open(path)
-                .unwrap())
-                .unwrap() == if i == index {
-                DevOwnership::Theirs
+            let real_ownership = identify(&path).unwrap();
+            if i == index {
+                match real_ownership {
+                    DevOwnership::Theirs(_) => true,
+                    _ => false,
+                }
             } else {
-                DevOwnership::Unowned
+                match real_ownership {
+                    DevOwnership::Unowned => true,
+                    _ => false,
+                }
             }
         }));
 
         assert!(BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, true).is_ok());
         assert!(paths.iter().all(|path| {
-            match StaticHeader::determine_ownership(&mut OpenOptions::new()
-                .read(true)
-                .open(path)
-                .unwrap())
-                .unwrap()
-            {
-                DevOwnership::Ours(uuid, _) => pool_uuid == uuid,
-                _ => false,
-            }
+            let (t_pool_uuid, _) =
+                device_identifiers(&mut OpenOptions::new().read(true).open(path).unwrap())
+                    .unwrap()
+                    .unwrap();
+            pool_uuid == t_pool_uuid
         }));
     }
 
@@ -710,23 +715,17 @@ mod tests {
         let bd_mgr = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
 
         assert!(paths.iter().all(|path| {
-            match StaticHeader::determine_ownership(&mut OpenOptions::new()
-                .read(true)
-                .open(path)
-                .unwrap())
-                .unwrap()
-            {
-                DevOwnership::Ours(uuid, _) => uuid == pool_uuid,
-                _ => false,
-            }
+            let (t_pool_uuid, _) =
+                device_identifiers(&mut OpenOptions::new().read(true).open(path).unwrap())
+                    .unwrap()
+                    .unwrap();
+            pool_uuid == t_pool_uuid
         }));
         bd_mgr.destroy_all().unwrap();
         assert!(paths.iter().all(|path| {
-            StaticHeader::determine_ownership(&mut OpenOptions::new()
-                .read(true)
-                .open(path)
-                .unwrap())
-                .unwrap() == DevOwnership::Unowned
+            device_identifiers(&mut OpenOptions::new().read(true).open(path).unwrap())
+                .unwrap()
+                .is_none()
         }));
     }
 

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -5,13 +5,21 @@
 // Functions for dealing with devices.
 
 use std::collections::HashMap;
-use std::fs::File;
+use std::fmt::{self, Display};
+use std::fs::{File, OpenOptions};
 use std::os::unix::prelude::AsRawFd;
 use std::path::Path;
+
+use libudev;
 
 use devicemapper::{devnode_to_devno, Bytes, Device};
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
+
+use super::super::super::types::{DevUuid, PoolUuid};
+
+use super::metadata::device_identifiers;
+use super::udev::{get_udev_property, udev_block_device_apply, unclaimed};
 
 ioctl!(read blkgetsize64 with 0x12, 114; u64);
 
@@ -42,4 +50,114 @@ pub fn resolve_devices<'a>(paths: &'a [&Path]) -> StratisResult<HashMap<Device, 
         }
     }
     Ok(map)
+}
+
+/// Something to identify a device that is not a StratisDevice.
+/// This type is extremely rudimentary and may have to be modified as Stratis's
+/// notion of how to obtain a signature for a deivce that is not Stratis's
+/// changes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TheirsReason {
+    /// Udev identifies device as belonging to another.
+    Udev {
+        id_part_table_type: Option<String>,
+        id_fs_type: Option<String>,
+    },
+}
+
+impl Display for TheirsReason {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TheirsReason::Udev {
+                id_part_table_type,
+                id_fs_type,
+            } => write!(
+                f,
+                "ID_PART_TABLE_TYPE: {}, ID_FS_TYPE: {}",
+                match id_part_table_type {
+                    Some(val) => val,
+                    None => "not available",
+                },
+                match id_fs_type {
+                    Some(val) => val,
+                    None => "not found",
+                }
+            ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DevOwnership {
+    Contradiction,
+    Ours(PoolUuid, DevUuid),
+    Unowned,
+    Theirs(TheirsReason),
+}
+
+/// Identify a device node using a combination of udev information and
+/// Stratis signature information.
+/// Return an error if the device is not in the udev database.
+/// Return an error if the necessary udev information can not be read.
+pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
+    /// A helper function. None if the device is unclaimed, the value of
+    /// ID_FS_TYPE, which may yet be None, if it is.
+    #[allow(option_option)]
+    fn udev_info(device: &libudev::Device) -> StratisResult<Option<Option<String>>> {
+        if unclaimed(device) {
+            Ok(None)
+        } else {
+            Ok(Some(get_udev_property(device, "ID_FS_TYPE")?))
+        }
+    }
+
+    match udev_block_device_apply(devnode, udev_info)? {
+        Some(Ok(Some(Some(value)))) => {
+            if value == "stratis" {
+                if let Some((pool_uuid, device_uuid)) =
+                    device_identifiers(&mut OpenOptions::new().read(true).open(&devnode)?)?
+                {
+                    Ok(DevOwnership::Ours(pool_uuid, device_uuid))
+                } else {
+                    Ok(DevOwnership::Contradiction)
+                }
+            } else {
+                Ok(DevOwnership::Theirs(TheirsReason::Udev {
+                    id_part_table_type: None,
+                    id_fs_type: None,
+                }))
+            }
+        }
+        Some(Ok(Some(None))) => Ok(DevOwnership::Theirs(TheirsReason::Udev {
+            id_part_table_type: None,
+            id_fs_type: None,
+        })),
+        Some(Ok(None)) => {
+            // Not a Stratis device OR running an older version of libblkid
+            // that does not interpret Stratis devices. Fall back on reading
+            // Stratis header via Stratis.
+            // NOTE: This is a bit kludgy. If, at any time during stratisd
+            // execution, a device is identified as a Stratis device by libblkid
+            // then it is clear that the version of libblkid being run is new
+            // enough. But to track that information requires some kind of
+            // stateful global variable. So, instead, fall back on the safe
+            // approach of just always reading the Stratis header, regardless
+            // of what has happened in the past.
+            Ok(if let Some((pool_uuid, device_uuid)) =
+                device_identifiers(&mut OpenOptions::new().read(true).open(&devnode)?)?
+            {
+                DevOwnership::Ours(pool_uuid, device_uuid)
+            } else {
+                DevOwnership::Unowned
+            })
+        }
+        Some(Err(err)) => Err(err),
+        None => Err(StratisError::Engine(
+            ErrorEnum::NotFound,
+            format!(
+                "No device in udev database corresponding to device node {:?}",
+                devnode
+            ),
+        )),
+    }
 }

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -17,7 +17,6 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::super::types::{DevUuid, PoolUuid};
 
 use super::super::device::SyncAll;
-use super::super::engine::DevOwnership;
 
 pub use self::mda::{validate_mda_size, MIN_MDA_SECTORS};
 
@@ -41,6 +40,15 @@ enum MetadataLocation {
     Both,
     First,
     Second,
+}
+
+/// Return the pool and device UUID of a Stratis device.
+/// If no Stratis header on the device, return None.
+pub fn device_identifiers<F>(f: &mut F) -> StratisResult<Option<((PoolUuid, DevUuid))>>
+where
+    F: Read + Seek + SyncAll,
+{
+    StaticHeader::setup(f).map(|res| res.map(|sh| (sh.pool_uuid, sh.dev_uuid)))
 }
 
 impl BDA {
@@ -213,7 +221,7 @@ impl BDA {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct StaticHeader {
+struct StaticHeader {
     blkdev_size: Sectors,
     pool_uuid: PoolUuid,
     dev_uuid: DevUuid,
@@ -317,30 +325,6 @@ impl StaticHeader {
                 let err_str = "Appeared to be a Stratis device, but no valid sigblock found";
                 Err(StratisError::Engine(ErrorEnum::Invalid, err_str.into()))
             }
-        }
-    }
-
-    /// Determine the ownership of a device.
-    /// If the device is owned by Stratis, return its device UUID.
-    pub fn determine_ownership<F>(f: &mut F) -> StratisResult<DevOwnership>
-    where
-        F: Read + Seek + SyncAll,
-    {
-        // Using setup() as a test of ownership sets a high bar. It is
-        // not sufficient to have STRAT_MAGIC to be considered "Ours",
-        // it must also have correct CRC, no weird stuff in fields,
-        // etc!
-        match StaticHeader::setup(f) {
-            Ok(Some(sh)) => Ok(DevOwnership::Ours(sh.pool_uuid, sh.dev_uuid)),
-            Ok(None) => {
-                let buf = BDA::read(f)?;
-                if buf.iter().any(|x| *x != 0) {
-                    Ok(DevOwnership::Theirs)
-                } else {
-                    Ok(DevOwnership::Unowned)
-                }
-            }
-            Err(err) => Err(err),
         }
     }
 
@@ -885,8 +869,6 @@ mod tests {
     use quickcheck::{QuickCheck, TestResult};
     use uuid::Uuid;
 
-    use super::super::super::engine::DevOwnership;
-
     use super::*;
 
     /// Return a static header with random block device and MDA size.
@@ -906,34 +888,6 @@ mod tests {
     }
 
     #[test]
-    /// Verify that the file is theirs, if there are any non-zero bits in BDA.
-    /// Unowned if all bits are 0.
-    fn test_other_ownership() {
-        fn property(offset: u8, length: u8, value: u8) -> TestResult {
-            if value == 0 || length == 0 {
-                return TestResult::discard();
-            }
-            let mut buf = Cursor::new(vec![0; _BDA_STATIC_HDR_SIZE]);
-            match StaticHeader::determine_ownership(&mut buf).unwrap() {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
-            }
-
-            let data = vec![value; length as usize];
-            buf.seek(SeekFrom::Start(offset as u64)).unwrap();
-            buf.write(&data).unwrap();
-            match StaticHeader::determine_ownership(&mut buf).unwrap() {
-                DevOwnership::Theirs => {}
-                _ => return TestResult::failed(),
-            }
-            TestResult::passed()
-        }
-        QuickCheck::new()
-            .tests(10)
-            .quickcheck(property as fn(u8, u8, u8) -> TestResult);
-    }
-
-    #[test]
     /// Construct an arbitrary StaticHeader object.
     /// Verify that the "file" is unowned.
     /// Initialize a BDA.
@@ -945,10 +899,9 @@ mod tests {
             let sh = random_static_header(blkdev_size, mda_size_factor);
             let buf_size = *sh.mda_size.bytes() as usize + _BDA_STATIC_HDR_SIZE;
             let mut buf = Cursor::new(vec![0; buf_size]);
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
+            let ownership = device_identifiers(&mut buf).unwrap();
+            if ownership.is_some() {
+                return TestResult::failed();
             }
 
             BDA::initialize(
@@ -959,21 +912,18 @@ mod tests {
                 sh.blkdev_size,
                 Utc::now().timestamp() as u64,
             ).unwrap();
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Ours(pool_uuid, dev_uuid) => {
-                    if sh.pool_uuid != pool_uuid || sh.dev_uuid != dev_uuid {
-                        return TestResult::failed();
-                    }
+            if let Some((t_p, t_d)) = device_identifiers(&mut buf).unwrap() {
+                if t_p != sh.pool_uuid || t_d != sh.dev_uuid {
+                    return TestResult::failed();
                 }
-                _ => return TestResult::failed(),
+            } else {
+                return TestResult::failed();
             }
 
             BDA::wipe(&mut buf).unwrap();
-            let ownership = StaticHeader::determine_ownership(&mut buf).unwrap();
-            match ownership {
-                DevOwnership::Unowned => {}
-                _ => return TestResult::failed(),
+            let ownership = device_identifiers(&mut buf).unwrap();
+            if ownership.is_some() {
+                return TestResult::failed();
             }
 
             TestResult::passed()

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -16,5 +16,6 @@ mod udev;
 pub use self::backstore::Backstore;
 #[cfg(test)]
 pub use self::device::blkdev_size;
+pub use self::device::{identify, DevOwnership};
 pub use self::metadata::MIN_MDA_SECTORS;
-pub use self::setup::{find_all, get_metadata, is_stratis_device, setup_pool};
+pub use self::setup::{find_all, get_metadata, setup_pool};

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -11,7 +11,7 @@ mod device;
 mod metadata;
 mod range_alloc;
 mod setup;
-mod util;
+mod udev;
 
 pub use self::backstore::Backstore;
 #[cfg(test)]

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -6,71 +6,27 @@
 // Initial setup steps are steps that do not alter the environment.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::{read_dir, OpenOptions};
-use std::io::ErrorKind;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 
-use nix::errno::Errno;
+use libudev;
 use serde_json;
 
-use devicemapper::{devnode_to_devno, Device};
+use devicemapper::Device;
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::structures::Table;
 use super::super::super::types::{Name, PoolUuid};
+use super::super::super::udev::{get_device_devnode, get_udev};
 
-use super::super::engine::DevOwnership;
 use super::super::pool::{check_metadata, StratPool};
 use super::super::serde_structs::{BackstoreSave, PoolSave};
 
 use super::blockdev::StratBlockDev;
 use super::device::blkdev_size;
-use super::metadata::{StaticHeader, BDA};
-
-/// Determine if devnode is a Stratis device. Return the device's Stratis
-/// pool UUID if it belongs to Stratis.
-pub fn is_stratis_device(devnode: &PathBuf) -> StratisResult<Option<PoolUuid>> {
-    match OpenOptions::new().read(true).open(&devnode) {
-        Ok(mut f) => {
-            if let DevOwnership::Ours(pool_uuid, _) = StaticHeader::determine_ownership(&mut f)? {
-                Ok(Some(pool_uuid))
-            } else {
-                Ok(None)
-            }
-        }
-        Err(err) => {
-            // There are some reasons for OpenOptions::open() to return an error
-            // which are not reasons for this method to return an error.
-            // Try to distinguish. Non-error conditions are:
-            //
-            // 1. ENXIO: The device does not exist anymore. This means that the device
-            // was volatile for some reason; in that case it can not belong to
-            // Stratis so it is safe to ignore it.
-            //
-            // 2. ENOMEDIUM: The device has no medium. An example of this case is an
-            // empty optical drive.
-            //
-            // Note that it is better to be conservative and return with an
-            // error in any case where failure to read the device could result
-            // in bad data for Stratis. Additional exceptions may be added,
-            // but only with a complete justification.
-            match err.kind() {
-                ErrorKind::NotFound => Ok(None),
-                _ => {
-                    if let Some(errno) = err.raw_os_error() {
-                        match Errno::from_i32(errno) {
-                            Errno::ENXIO | Errno::ENOMEDIUM => Ok(None),
-                            _ => Err(StratisError::Io(err)),
-                        }
-                    } else {
-                        Err(StratisError::Io(err))
-                    }
-                }
-            }
-        }
-    }
-}
+use super::metadata::{device_identifiers, BDA};
+use super::udev::unclaimed;
 
 /// Setup a pool from constituent devices in the context of some already
 /// setup pools. Return an error on anything that prevents the pool
@@ -134,26 +90,55 @@ pub fn setup_pool(
 ///
 /// Returns a map of pool uuids to a map of devices to devnodes for each pool.
 pub fn find_all() -> StratisResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> {
-    let mut pool_map = HashMap::new();
-    let mut devno_set = HashSet::new();
-    for dir_e in read_dir("/dev")? {
-        let dir_e = dir_e?;
-        let devnode = dir_e.path();
+    let context = get_udev();
 
-        match devnode_to_devno(&devnode)? {
-            None => continue,
-            Some(devno) => {
-                if devno_set.insert(devno) {
-                    is_stratis_device(&devnode)?.and_then(|pool_uuid| {
-                        pool_map
-                            .entry(pool_uuid)
-                            .or_insert_with(HashMap::new)
-                            .insert(Device::from(devno), devnode)
-                    });
-                } else {
-                    continue;
-                }
+    let mut enumerator = libudev::Enumerator::new(context)?;
+    enumerator.match_subsystem("block")?;
+    enumerator.match_property("ID_FS_TYPE", "stratis")?;
+
+    // Skip any block devices w/out a devnode and a device number.
+    let devices: Vec<(Device, PathBuf)> = enumerator
+        .scan_devices()?
+        .filter_map(|x| get_device_devnode(&x))
+        .collect();
+
+    // TODO: If at some point it is guaranteed that libblkid version is
+    // not less than that required to identify Stratis devices, this block
+    // can be removed.
+    let (devices, only_stratis) = if devices.is_empty() {
+        // There are no Stratis devices OR libblkid is an early version that
+        // doesn't support identifying Stratis devices. Fall back to using
+        // udev to get all devices that are lacking any signature which
+        // identifies them as belonging to some other system or application.
+
+        let mut enumerator = libudev::Enumerator::new(context)?;
+        enumerator.match_subsystem("block")?;
+
+        (
+            enumerator
+                .scan_devices()?
+                .filter(|d| unclaimed(d))
+                .filter_map(|x| get_device_devnode(&x))
+                .collect(),
+            false,
+        )
+    } else {
+        (devices, true)
+    };
+
+    let mut pool_map = HashMap::new();
+    for (device, devnode) in devices {
+        match device_identifiers(&mut OpenOptions::new().read(true).open(&devnode)?)? {
+            Some((pool_uuid, _)) => {
+                pool_map
+                    .entry(pool_uuid)
+                    .or_insert_with(HashMap::new)
+                    .insert(device, devnode);
             }
+            None => if only_stratis {
+                return Err(StratisError::Engine(ErrorEnum::Invalid,
+                                                "udev has identified this device as a Stratis device, but no Stratis header was found on the device".into()));
+            },
         }
     }
 

--- a/src/engine/strat_engine/backstore/udev.rs
+++ b/src/engine/strat_engine/backstore/udev.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Utilities to support Stratis.
+// Udev dependent code for getting information about devices.
 
 use std::path::Path;
 

--- a/src/engine/strat_engine/backstore/udev.rs
+++ b/src/engine/strat_engine/backstore/udev.rs
@@ -13,6 +13,23 @@ use stratis::{StratisError, StratisResult};
 
 use super::super::super::udev::get_udev;
 
+/// If the expression is true, then it seems that no other system is
+/// known to udev to claim this device.
+/// Note from mulhern: I have no idea myself why this particular expression
+/// should be correct. The expression is equivalent to that used in PR:
+/// https://github.com/stratis-storage/stratisd/pull/936.
+pub fn unclaimed(device: &libudev::Device) -> bool {
+    (get_udev_property(device, "ID_PART_TABLE_TYPE")
+        .map(|v| v.is_none())
+        .unwrap_or(false)
+        || get_udev_property(device, "ID_PART_ENTRY_DISK")
+            .map(|v| v.is_some())
+            .unwrap_or(true))
+        && get_udev_property(device, "ID_FS_USAGE")
+            .map(|v| v.is_none())
+            .unwrap_or(false)
+}
+
 /// Get a udev property with the given name for the given device.
 /// Returns an error if the value of the property can not be converted
 /// to a String using the standard conversion for this OS.

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -10,10 +10,12 @@ use libudev;
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
+use super::super::super::udev::get_udev;
+
 /// Lookup the WWN from the udev db using the device node eg. /dev/sda
 pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
     #![allow(let_and_return)]
-    let context = libudev::Context::new()?;
+    let context = get_udev();
     let mut enumerator = libudev::Enumerator::new(&context)?;
     enumerator.match_subsystem("block")?;
     enumerator.match_property("DEVTYPE", "disk")?;

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(renamed_and_removed_lints)]
+
 use std::path::PathBuf;
 
 use mnt::get_submounts;

--- a/src/engine/udev.rs
+++ b/src/engine/udev.rs
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Get ability to instantiate a devicemapper context.
+
+use std::sync::{Once, ONCE_INIT};
+
+use libudev::{self, Context};
+
+use stratis::{ErrorEnum, StratisError, StratisResult};
+
+static INIT: Once = ONCE_INIT;
+static mut UDEV_CONTEXT: Option<libudev::Result<Context>> = None;
+
+pub fn get_udev_init() -> StratisResult<&'static Context> {
+    unsafe {
+        INIT.call_once(|| UDEV_CONTEXT = Some(Context::new()));
+        match UDEV_CONTEXT {
+            Some(Ok(ref context)) => Ok(context),
+            // Can not move the error out of UDEV_CONTEXT, so synthesize a new
+            // error.
+            Some(Err(_)) => Err(StratisError::Engine(
+                ErrorEnum::Error,
+                "Failed to initialize udev context".into(),
+            )),
+            _ => panic!("UDEV_CONTEXT.is_some()"),
+        }
+    }
+}
+
+pub fn get_udev() -> &'static Context {
+    get_udev_init().expect(
+        "stratisd has already invoked get_udev_init() and exited if get_dm_init() returned an error",
+    )
+}

--- a/src/engine/udev.rs
+++ b/src/engine/udev.rs
@@ -4,9 +4,12 @@
 
 // Get ability to instantiate a devicemapper context.
 
+use std::path::PathBuf;
 use std::sync::{Once, ONCE_INIT};
 
 use libudev::{self, Context};
+
+use devicemapper::Device;
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
@@ -33,4 +36,14 @@ pub fn get_udev() -> &'static Context {
     get_udev_init().expect(
         "stratisd has already invoked get_udev_init() and exited if get_dm_init() returned an error",
     )
+}
+
+/// Get a devicemapper device and a device node from a libudev device.
+/// Returns None if either could not be found.
+pub fn get_device_devnode(device: &libudev::Device) -> Option<(Device, PathBuf)> {
+    device.devnode().and_then(|devnode| {
+        device
+            .devnum()
+            .and_then(|devnum| Some((Device::from(devnum), PathBuf::from(devnode))))
+    })
 }


### PR DESCRIPTION
Supercedes #1011.

Adapted from #1006. The general approach is maintained. The design is significantly different.

Comments:
"Run Travis...' obviously will not exist in final copy.
"Allow renamed and removed lints..." is necessary for compilation but went into master after this branch. It should be removed in final copy.

The part of the code that uses udev properties to identify other devices for ```DevOwnership::Theirs``` constructor is deliberately incomplete. I think it is important to be able to inform users why we don't want to touch a device, but I don't undertand the approach that I'm trying to adapt, so I thought it best not to finish it.