### PR TITLE
BDA::read use O_DIRECT

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate uuid;
 #[cfg(feature = "dbus_enabled")]
 extern crate dbus;
 
+extern crate libc;
 extern crate libmount;
 extern crate rand;
 extern crate serde;


### PR DESCRIPTION
It appears that when the read goes through the cache(s) in the
kernel that a bad sector on adjacent reads will cause a read of
a specific good sector to return EIO.  Use O_DIRECT to ensure
we read the specific sector.  This is complicated by the fact
that O_DIRECT read requires reads to be aligned to physical
sector geometry with a buffer that is aligned too, for DMA
transfers.

Note: This change is incomplete in that we haven't handled the
write path too.

Signed-off-by: Tony Asleson <tasleson@redhat.com>