### PR TITLE
sync udev db and DM before cleanup

### DIFF
--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -11,6 +11,7 @@ use nix::mount::{MntFlags, umount2};
 
 use devicemapper::{DevId, DmOptions};
 
+use super::super::cmd;
 use super::super::dm::{get_dm, get_dm_init};
 
 #[allow(renamed_and_removed_lints)]
@@ -67,6 +68,7 @@ fn dm_stratis_devices_remove() -> Result<()> {
     }
 
     || -> Result<()> {
+        cmd::udev_settle().unwrap();
         get_dm_init().map_err(|err| Error::with_chain(err, "Unable to initialize DM"))?;
         do_while_progress().and_then(|remain| {
             if !remain.is_empty() {


### PR DESCRIPTION
Add a call to udev_settle() to sync udev db and DM before we try to
cleanup the DM devices when a test is complete.

Signed-off-by: Todd Gill <tgill@redhat.com>