### PR TITLE
Omit explicit "object" in bases lists

### DIFF
--- a/tests/client-dbus/src/stratisd_client_dbus/_connection.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_connection.py
@@ -20,7 +20,7 @@ import dbus
 from ._constants import SERVICE
 
 
-class Bus(object):
+class Bus():
     """
     Our bus.
     """

--- a/tests/client-dbus/tests/dbus/_loopback.py
+++ b/tests/client-dbus/tests/dbus/_loopback.py
@@ -23,7 +23,7 @@ import uuid
 _LOSETUP_BIN = os.getenv('STRATIS_LOSETUP_BIN', "/usr/sbin/losetup")
 
 
-class LoopBackDevices(object):
+class LoopBackDevices():
     """
     Class for creating and managing loop back devices which are needed for
     specific types of udev event testing.

--- a/tests/client-dbus/tests/dbus/_misc.py
+++ b/tests/client-dbus/tests/dbus/_misc.py
@@ -36,7 +36,7 @@ def _device_list(minimum):
         min_size=minimum)
 
 
-class Service(object):
+class Service():
     """
     Handle starting and stopping the Rust service.
     """


### PR DESCRIPTION
In Python 3, every class implicitly inherits from object, directly
or indirectly if some other class is specified.

Pylint 2.0, which is what is now being run by Travis CI via tox is Python 3
only and has introduced this new useless-object-inheritance check because
being Python 3 only, it can.

Signed-off-by: mulhern <amulhern@redhat.com>