### PR TITLE
Set dbus object path for Pool, Filesystem and BlockDev

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -260,7 +260,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         libstratis::dbus_api::connect(Rc::clone(&engine))?;
 
     #[cfg(feature = "dbus_enabled")]
-    for (_, pool_uuid, pool) in engine.borrow().pools() {
+    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
         libstratis::dbus_api::register_pool(
             &dbus_conn,
             &dbus_context,
@@ -298,8 +298,8 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                                 &mut tree,
                                 pool_uuid,
                                 engine
-                                    .borrow()
-                                    .get_pool(pool_uuid)
+                                    .borrow_mut()
+                                    .get_mut_pool(pool_uuid)
                                     .expect(
                                         "block_evaluate() returned a pool UUID, pool must be available",
                                     )

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -55,10 +55,12 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             let (_, pool) = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
             pool.set_dbus_path(object_path.clone());
-            let bd_object_paths = pool.blockdevs()
-                .iter()
-                .map(|&(uuid, _)| {
-                    create_dbus_blockdev(dbus_context, pool_object_path.clone(), uuid)
+            let bd_object_paths = pool.blockdevs_mut()
+                .into_iter()
+                .map(|(uuid, bd)| {
+                    let blockdev_object_path =
+                        create_dbus_blockdev(dbus_context, pool_object_path.clone(), uuid, bd);
+                    blockdev_object_path
                 })
                 .collect::<Vec<_>>();
 
@@ -202,8 +204,8 @@ fn register_pool_dbus(
     for (_, fs_uuid, fs) in pool.filesystems_mut() {
         create_dbus_filesystem(dbus_context, pool_path.clone(), fs_uuid, fs);
     }
-    for (dev_uuid, _) in pool.blockdevs() {
-        create_dbus_blockdev(dbus_context, pool_path.clone(), dev_uuid);
+    for (uuid, bd) in pool.blockdevs_mut() {
+        create_dbus_blockdev(dbus_context, pool_path.clone(), uuid, bd);
     }
 }
 

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -199,8 +199,8 @@ fn register_pool_dbus(
 ) {
     let pool_path = create_dbus_pool(dbus_context, object_path.clone(), pool_uuid);
     pool.set_dbus_path(object_path.clone());
-    for (_, fs_uuid, _) in pool.filesystems() {
-        create_dbus_filesystem(dbus_context, pool_path.clone(), fs_uuid);
+    for (_, fs_uuid, fs) in pool.filesystems_mut() {
+        create_dbus_filesystem(dbus_context, pool_path.clone(), fs_uuid, fs);
     }
     for (dev_uuid, _) in pool.blockdevs() {
         create_dbus_blockdev(dbus_context, pool_path.clone(), dev_uuid);

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -54,6 +54,7 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
             let (_, pool) = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
+            pool.set_dbus_path(object_path.clone());
             let bd_object_paths = pool.blockdevs()
                 .iter()
                 .map(|&(uuid, _)| {
@@ -193,10 +194,11 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>, db
 fn register_pool_dbus(
     dbus_context: &DbusContext,
     pool_uuid: PoolUuid,
-    pool: &Pool,
+    pool: &mut Pool,
     object_path: &dbus::Path<'static>,
 ) {
     let pool_path = create_dbus_pool(dbus_context, object_path.clone(), pool_uuid);
+    pool.set_dbus_path(object_path.clone());
     for (_, fs_uuid, _) in pool.filesystems() {
         create_dbus_filesystem(dbus_context, pool_path.clone(), fs_uuid);
     }
@@ -232,7 +234,7 @@ pub fn register_pool(
     dbus_context: &DbusContext,
     tree: &mut Tree<MTFn<TData>, TData>,
     pool_uuid: Uuid,
-    pool: &Pool,
+    pool: &mut Pool,
     object_path: &dbus::Path<'static>,
 ) -> Result<(), dbus::Error> {
     register_pool_dbus(dbus_context, pool_uuid, pool, object_path);

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -24,6 +24,7 @@ pub fn create_dbus_blockdev<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
     uuid: Uuid,
+    blockdev: &mut BlockDev,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
@@ -104,6 +105,7 @@ pub fn create_dbus_blockdev<'a>(
 
     let path = object_path.get_name().to_owned();
     dbus_context.actions.borrow_mut().push_add(object_path);
+    blockdev.set_dbus_path(path.clone());
     path
 }
 

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -24,6 +24,7 @@ pub fn create_dbus_filesystem<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
     uuid: Uuid,
+    filesystem: &mut Filesystem,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
@@ -74,6 +75,7 @@ pub fn create_dbus_filesystem<'a>(
 
     let path = object_path.get_name().to_owned();
     dbus_context.actions.borrow_mut().push_add(object_path);
+    filesystem.set_dbus_path(path.clone());
     path
 }
 

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -206,10 +206,10 @@ fn add_blockdevs(m: &MethodInfo<MTFn<TData>, TData>, tier: BlockDevTier) -> Meth
 
     let result = pool.add_blockdevs(pool_uuid, &*pool_name, &blockdevs, tier, force);
     let msg = match result {
-        Ok(uuids) => {
-            let return_value = uuids
-                .iter()
-                .map(|uuid| create_dbus_blockdev(dbus_context, object_path.clone(), *uuid))
+        Ok(_uuids) => {
+            let return_value = pool.blockdevs_mut()
+                .into_iter()
+                .map(|(uuid, bd)| create_dbus_blockdev(dbus_context, object_path.clone(), uuid, bd))
                 .collect::<Vec<_>>();
 
             return_message.append3(return_value, msg_code_ok(), msg_string_ok())

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -217,6 +217,9 @@ pub trait Engine: Debug {
     /// Get all pools belonging to this engine.
     fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)>;
 
+    /// Get mutable references to all pools belonging to this engine.
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)>;
+
     /// If the engine would like to include an event in the message loop, it
     /// may return an Eventable from this method.
     fn get_eventable(&self) -> Option<&'static Eventable>;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -140,6 +140,9 @@ pub trait Pool: Debug {
     /// Get all the filesystems belonging to this pool.
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)>;
 
+    /// Get all the filesystems belonging to this pool as mutable references.
+    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)>;
+
     /// Get the filesystem in this pool with this UUID.
     fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)>;
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -122,7 +122,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<FilesystemUuid>;
+    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)>;
 
     /// The total number of Sectors belonging to this pool.
     /// There are no exclusions, so this number includes overhead sectors

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::fmt::Debug;
 use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
@@ -19,6 +22,14 @@ use stratis::StratisResult;
 pub trait Filesystem: Debug {
     /// path of the device node
     fn devnode(&self) -> PathBuf;
+
+    /// Set dbus path associated with the Pool.
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> ();
+
+    /// Get dbus path associated with the Pool.
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>>;
 }
 
 pub trait BlockDev: Debug {
@@ -40,6 +51,14 @@ pub trait BlockDev: Debug {
 
     /// The current state of the blockdev.
     fn state(&self) -> BlockDevState;
+
+    /// Set dbus path associated with the BlockDev.
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> ();
+
+    /// Get dbus path associated with the BlockDev.
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>>;
 }
 
 pub trait Pool: Debug {
@@ -142,6 +161,14 @@ pub trait Pool: Debug {
         uuid: DevUuid,
         user_info: Option<&str>,
     ) -> StratisResult<bool>;
+
+    /// Set dbus path associated with the Pool.
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> ();
+
+    /// Get dbus path associated with the Pool.
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>>;
 }
 
 pub trait Engine: Debug {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -153,6 +153,9 @@ pub trait Pool: Debug {
     /// All really means all. For example, it does not exclude cache blockdevs.
     fn blockdevs(&self) -> Vec<(Uuid, &BlockDev)>;
 
+    /// Get all the blockdevs belonging to this pool as mutable references.
+    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut BlockDev)>;
+
     /// Get the blockdev in this pool with this UUID.
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)>;
 

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -24,6 +27,8 @@ pub struct SimDev {
     user_info: Option<String>,
     hardware_info: Option<String>,
     initialization_time: u64,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl BlockDev for SimDev {
@@ -50,6 +55,16 @@ impl BlockDev for SimDev {
     fn state(&self) -> BlockDevState {
         BlockDevState::InUse
     }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
+    }
 }
 
 impl SimDev {
@@ -63,6 +78,8 @@ impl SimDev {
                 user_info: None,
                 hardware_info: None,
                 initialization_time: Utc::now().timestamp() as u64,
+                #[cfg(feature = "dbus_enabled")]
+                dbus_path: None,
             },
         )
     }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -121,6 +121,13 @@ impl Engine for SimEngine {
             .collect()
     }
 
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)> {
+        self.pools
+            .iter_mut()
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut Pool))
+            .collect()
+    }
+
     fn get_eventable(&self) -> Option<&'static Eventable> {
         None
     }

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use rand;
 
 use std::path::PathBuf;
@@ -11,12 +14,16 @@ use super::super::engine::Filesystem;
 #[derive(Debug)]
 pub struct SimFilesystem {
     rand: u32,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl SimFilesystem {
     pub fn new() -> SimFilesystem {
         SimFilesystem {
             rand: rand::random::<u32>(),
+            #[cfg(feature = "dbus_enabled")]
+            dbus_path: None,
         }
     }
 }
@@ -26,5 +33,15 @@ impl Filesystem for SimFilesystem {
         ["/dev/stratis", &format!("random-{}", self.rand)]
             .into_iter()
             .collect()
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
     }
 }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::cell::RefCell;
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet};
@@ -33,6 +36,8 @@ pub struct SimPool {
     filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl SimPool {
@@ -51,6 +56,8 @@ impl SimPool {
                 filesystems: Table::default(),
                 redundancy,
                 rdm: Rc::clone(rdm),
+                #[cfg(feature = "dbus_enabled")]
+                dbus_path: None,
             },
         )
     }
@@ -247,6 +254,16 @@ impl Pool for SimPool {
             },
             |(_, b)| Ok(b.set_user_info(user_info)),
         )
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
     }
 }
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -241,6 +241,13 @@ impl Pool for SimPool {
             .collect()
     }
 
+    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut BlockDev)> {
+        self.block_devs
+            .iter_mut()
+            .map(|(uuid, b)| (uuid.clone(), b as &mut BlockDev))
+            .collect()
+    }
+
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)> {
         self.block_devs
             .get(&uuid)

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -208,6 +208,13 @@ impl Pool for SimPool {
             .collect()
     }
 
+    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)> {
+        self.filesystems
+            .iter_mut()
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &mut Filesystem))
+            .collect()
+    }
+
     fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)> {
         self.filesystems
             .get_by_uuid(uuid)

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -175,7 +175,7 @@ impl Pool for SimPool {
         _pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<FilesystemUuid> {
+    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)> {
         let uuid = Uuid::new_v4();
         let snapshot = match self.get_filesystem(origin_uuid) {
             Some(_filesystem) => SimFilesystem::new(),
@@ -188,7 +188,13 @@ impl Pool for SimPool {
         };
         self.filesystems
             .insert(Name::new(snapshot_name.to_owned()), uuid, snapshot);
-        Ok(uuid)
+        Ok((
+            uuid,
+            self.filesystems
+                .get_mut_by_uuid(uuid)
+                .expect("just inserted")
+                .1,
+        ))
     }
 
     fn total_physical_size(&self) -> Sectors {

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -216,6 +216,17 @@ impl Backstore {
         }
     }
 
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        match self.cache_tier {
+            Some(ref mut cache) => cache
+                .blockdevs_mut()
+                .into_iter()
+                .chain(self.data_tier.blockdevs_mut().into_iter())
+                .collect(),
+            None => self.data_tier.blockdevs_mut(),
+        }
+    }
+
     /// The current capacity of all the blockdevs in the data tier.
     pub fn datatier_current_capacity(&self) -> Sectors {
         self.data_tier.current_capacity()

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -4,6 +4,9 @@
 
 // Code to handle a single block device.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 
@@ -29,6 +32,8 @@ pub struct StratBlockDev {
     used: RangeAllocator,
     user_info: Option<String>,
     hardware_info: Option<String>,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl StratBlockDev {
@@ -66,6 +71,8 @@ impl StratBlockDev {
             used: allocator,
             user_info,
             hardware_info,
+            #[cfg(feature = "dbus_enabled")]
+            dbus_path: None,
         })
     }
 
@@ -170,6 +177,16 @@ impl BlockDev for StratBlockDev {
     fn state(&self) -> BlockDevState {
         // TODO: Implement states for blockdevs
         BlockDevState::InUse
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
     }
 }
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -20,7 +20,6 @@ use devicemapper::{
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{DevUuid, PoolUuid};
-
 use super::super::serde_structs::{BlockDevSave, Recordable};
 
 use super::blockdev::StratBlockDev;
@@ -302,6 +301,13 @@ impl BlockDevMgr {
     /// Get references to managed blockdevs.
     pub fn blockdevs(&self) -> Vec<(DevUuid, &StratBlockDev)> {
         self.block_devs.iter().map(|bd| (bd.uuid(), bd)).collect()
+    }
+
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        self.block_devs
+            .iter_mut()
+            .map(|bd| (bd.uuid(), bd as &mut StratBlockDev))
+            .collect()
     }
 
     pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<&StratBlockDev> {

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -11,7 +11,6 @@ use devicemapper::{CacheDev, DmDevice, LinearDev, Sectors, IEC};
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
-
 use super::super::device::wipe_sectors;
 use super::super::dm::get_dm;
 use super::super::dmnames::{format_backstore_ids, CacheRole};
@@ -227,6 +226,10 @@ impl CacheTier {
     /// Get all the blockdevs belonging to this tier.
     pub fn blockdevs(&self) -> Vec<(DevUuid, &StratBlockDev)> {
         self.block_mgr.blockdevs()
+    }
+
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        self.block_mgr.blockdevs_mut()
     }
 
     /// Lookup an immutable blockdev by its Stratis UUID.

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -245,6 +245,10 @@ impl DataTier {
         self.block_mgr.blockdevs()
     }
 
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        self.block_mgr.blockdevs_mut()
+    }
+
     /// Assert things that should always hold true of a DataTier
     #[allow(dead_code)]
     fn invariant(&self) -> () {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -281,6 +281,13 @@ impl Engine for StratEngine {
             .collect()
     }
 
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)> {
+        self.pools
+            .iter_mut()
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut Pool))
+            .collect()
+    }
+
     fn get_eventable(&self) -> Option<&'static Eventable> {
         Some(get_dm())
     }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -307,6 +307,14 @@ impl Pool for StratPool {
             .collect()
     }
 
+    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut BlockDev)> {
+        self.backstore
+            .blockdevs_mut()
+            .into_iter()
+            .map(|(u, b)| (u, b as &mut BlockDev))
+            .collect()
+    }
+
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)> {
         self.backstore
             .get_blockdev_by_uuid(uuid)

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -264,7 +264,7 @@ impl Pool for StratPool {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<FilesystemUuid> {
+    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)> {
         self.thin_pool
             .snapshot_filesystem(pool_uuid, pool_name, origin_uuid, snapshot_name)
     }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
@@ -54,6 +57,8 @@ pub struct StratPool {
     backstore: Backstore,
     redundancy: Redundancy,
     thin_pool: ThinPool,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl StratPool {
@@ -89,6 +94,8 @@ impl StratPool {
             backstore,
             redundancy,
             thin_pool: thinpool,
+            #[cfg(feature = "dbus_enabled")]
+            dbus_path: None,
         };
 
         pool.write_metadata(&Name::new(name.to_owned()))?;
@@ -119,6 +126,8 @@ impl StratPool {
                 backstore,
                 redundancy: Redundancy::NONE,
                 thin_pool: thinpool,
+                #[cfg(feature = "dbus_enabled")]
+                dbus_path: None,
             },
         ))
     }
@@ -312,6 +321,16 @@ impl Pool for StratPool {
         } else {
             Ok(false)
         }
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
     }
 }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -283,6 +283,10 @@ impl Pool for StratPool {
         self.thin_pool.filesystems()
     }
 
+    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)> {
+        self.thin_pool.filesystems_mut()
+    }
+
     fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)> {
         self.thin_pool
             .get_filesystem_by_uuid(uuid)

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -570,6 +570,13 @@ impl ThinPool {
             .collect()
     }
 
+    pub fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)> {
+        self.filesystems
+            .iter_mut()
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &mut Filesystem))
+            .collect()
+    }
+
     /// Create a filesystem within the thin pool. Given name must not
     /// already be in use.
     pub fn create_filesystem(

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -614,7 +614,7 @@ impl ThinPool {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<FilesystemUuid> {
+    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)> {
         let snapshot_fs_uuid = Uuid::new_v4();
         let (snapshot_dm_name, snapshot_dm_uuid) =
             format_thin_ids(pool_uuid, ThinRole::Filesystem(snapshot_fs_uuid));
@@ -642,7 +642,13 @@ impl ThinPool {
         devlinks::filesystem_added(pool_name, &new_fs_name, &new_filesystem.devnode())?;
         self.filesystems
             .insert(new_fs_name, snapshot_fs_uuid, new_filesystem);
-        Ok(snapshot_fs_uuid)
+        Ok((
+            snapshot_fs_uuid,
+            self.filesystems
+                .get_mut_by_uuid(snapshot_fs_uuid)
+                .expect("just inserted")
+                .1,
+        ))
     }
 
     /// Destroy a filesystem within the thin pool.
@@ -1039,7 +1045,7 @@ mod tests {
         pool.extend_thinpool(INITIAL_DATA_SIZE, &mut backstore)
             .unwrap();
 
-        let snapshot_uuid =
+        let (_, snapshot_filesystem) =
             pool.snapshot_filesystem(pool_uuid, pool_name, fs_uuid, "test_snapshot")
                 .unwrap();
         let mut read_buf = [0u8; SECTOR_SIZE];
@@ -1048,7 +1054,6 @@ mod tests {
             .tempdir()
             .unwrap();
         {
-            let (_, snapshot_filesystem) = pool.get_filesystem_by_uuid(snapshot_uuid).unwrap();
             mount(
                 Some(&snapshot_filesystem.devnode()),
                 snapshot_tmp_dir.path(),


### PR DESCRIPTION

Update the dbus_api layer to set the object path for Pool, Filesystem and BlockDev.

This is a step towards #959 and assoicated alerts.
