### PR TITLE
Buff log2 (excellent logging)

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -9,6 +9,7 @@ extern crate devicemapper;
 extern crate libstratis;
 #[macro_use]
 extern crate log;
+extern crate chrono;
 extern crate clap;
 #[cfg(feature = "dbus_enabled")]
 extern crate dbus;
@@ -26,11 +27,14 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::rc::Rc;
 
+use chrono::Duration;
 use clap::{App, Arg, ArgMatches};
 use env_logger::Builder;
 use libc::pid_t;
 use log::LevelFilter;
 use nix::fcntl::{flock, FlockArg};
+use nix::sys::signal::{self, SigSet};
+use nix::sys::signalfd::{SfdFlags, SignalFd};
 use nix::unistd::getpid;
 
 #[cfg(feature = "dbus_enabled")]
@@ -40,28 +44,61 @@ use devicemapper::Device;
 
 use libstratis::engine::{Engine, SimEngine, StratEngine};
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
+use libstratis::stratis::{alarm, buff_log};
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
+
+/// Interval at which to have stratisd perform periodic tasks.
+const STRATISD_ALARM_SECONDS: u32 = 600;
+
+/// Number of minutes to buffer log entries.
+const DEFAULT_LOG_HOLD_MINUTES: i64 = 30;
 
 /// If writing a program error to stderr fails, panic.
 fn print_err(err: &StratisError) -> () {
     eprintln!("{}", err);
 }
 
+/// Log the engine state in a formatted way.
+fn log_engine_state(engine: &Engine) {
+    debug!("Engine state: \n{:#?}", engine);
+}
+
+/// Configure the env_logger as necessary in order to allow the buffered
+/// logger to work correctly. Return a Handle to the underlying env_logger.
+pub fn from_env_logger(
+    mut builder: env_logger::Builder,
+    pass_through: bool,
+    hold_time: Option<Duration>,
+) -> buff_log::Handle<env_logger::Logger> {
+    // Do not have the env_logger set the timestamp. Because the entries are
+    // buffered, the timestamp set by the env_logger will correspond to the
+    // time at which the entry was dumped, not the time of its origination.
+    builder.default_format_timestamp(false);
+    buff_log::Logger::new(builder.build(), pass_through, hold_time).init()
+}
+
 /// Configure and initialize the logger.
 /// If debug is true, log at debug level. Otherwise read log configuration
 /// parameters from the environment if RUST_LOG is set. Otherwise, just
 /// accept the default configuration.
-fn initialize_log(debug: bool) -> () {
+fn initialize_log(debug: bool) -> buff_log::Handle<env_logger::Logger> {
     let mut builder = Builder::new();
     if debug {
         builder.filter(Some("stratisd"), LevelFilter::Debug);
         builder.filter(Some("libstratis"), LevelFilter::Debug);
-    } else if let Ok(s) = env::var("RUST_LOG") {
-        builder.parse(&s);
-    };
-
-    builder.init()
+        from_env_logger(builder, true, None)
+    } else {
+        builder.filter_level(LevelFilter::Trace);
+        if let Ok(s) = env::var("RUST_LOG") {
+            builder.parse(&s);
+        }
+        from_env_logger(
+            builder,
+            false,
+            Some(Duration::minutes(DEFAULT_LOG_HOLD_MINUTES)),
+        )
+    }
 }
 
 /// Given a udev event check to see if it's an add and if it is return the device node and
@@ -120,7 +157,14 @@ fn trylock_pid_file() -> StratisResult<File> {
     }
 }
 
-fn run(matches: &ArgMatches) -> StratisResult<()> {
+/// Set up all sorts of signal and event handling mechanisms.
+/// Initialize the engine and keep it running until a signal is received
+/// or a fatal error is encountered. Dump log entries on specified signal
+/// via buff_log.
+fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) -> StratisResult<()> {
+    // Ensure that the debug log is output when we leave this function.
+    let _guard = buff_log.to_guard();
+
     // Setup a udev listener before initializing the engine. A device may
     // appear after the engine has read the /dev directory but before it has
     // completed initialization. Unless the udev event has been recorded, the
@@ -142,14 +186,18 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
     };
 
     /*
-    The file descriptor array indexes are laid out in the following:
+    The file descriptor array indexes are:
 
     0   == Always udev fd index
-    1   == engine index if eventable
-    1/2 == Start of dbus client file descriptor(s), 1 if engine is not eventable, else 2
+    1   == SIGNAL FD index
+    2   == engine index if eventable
+    2/3 == Start of dbus client file descriptor(s)
+            * 2 if engine is not eventable
+            * else 3
     */
     const FD_INDEX_UDEV: usize = 0;
-    const FD_INDEX_ENGINE: usize = 1;
+    const FD_INDEX_SIGNALFD: usize = 1;
+    const FD_INDEX_ENGINE: usize = 2;
 
     /*
     fds is a Vec of libc::pollfd structs. Ideally, it would be possible
@@ -166,6 +214,22 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
 
     fds.push(libc::pollfd {
         fd: udev.as_raw_fd(),
+        revents: 0,
+        events: libc::POLLIN,
+    });
+
+    // Signals can be queued up on this file descriptor
+    let mut sfd = {
+        let mut mask = SigSet::empty();
+        mask.add(signal::SIGINT);
+        mask.add(signal::SIGALRM);
+        mask.add(signal::SIGUSR1);
+        mask.thread_block()?;
+        SignalFd::with_flags(&mask, SfdFlags::SFD_NONBLOCK)?
+    };
+
+    fds.push(libc::pollfd {
+        fd: sfd.as_raw_fd(),
         revents: 0,
         events: libc::POLLIN,
     });
@@ -207,6 +271,9 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
         )?;
     }
 
+    log_engine_state(&*engine.borrow());
+    alarm(STRATISD_ALARM_SECONDS);
+
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
@@ -245,6 +312,42 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
             }
         }
 
+        // Process any signals off signalfd
+        if fds[FD_INDEX_SIGNALFD].revents != 0 {
+            match sfd.read_signal() {
+                // This is an unsafe conversion, but in this context that is
+                // mostly harmless. A negative converted value, which is
+                // virtually impossible, will not match any of the masked
+                // values, and stratisd will panic and exit.
+                Ok(Some(sig)) => match sig.ssi_signo as i32 {
+                    nix::libc::SIGALRM => {
+                        info!("SIGALRM received, performing periodic tasks");
+                        log_engine_state(&*engine.borrow());
+                        alarm(STRATISD_ALARM_SECONDS);
+                    }
+                    nix::libc::SIGUSR1 => {
+                        info!(
+                            "SIGUSR1 received, dumping {} buffered log entries",
+                            buff_log.buffered_count()
+                        );
+                        buff_log.dump()
+                    }
+                    nix::libc::SIGINT => {
+                        info!("SIGINT received, exiting");
+                        return Ok(());
+                    }
+                    signo => {
+                        panic!("Caught an impossible signal {:?}", signo);
+                    }
+                },
+                // No signals waiting (SFD_NONBLOCK flag is set)
+                Ok(None) => (),
+
+                // Pessimistically exit on an error reading the signal.
+                Err(err) => return Err(err.into()),
+            }
+        }
+
         // Handle engine events, if the engine is eventable
         match eventable {
             Some(ref evt) => {
@@ -273,6 +376,7 @@ fn run(matches: &ArgMatches) -> StratisResult<()> {
                     if let Err(r) =
                         libstratis::dbus_api::handle(&dbus_conn, &item, &mut tree, &dbus_context)
                     {
+                        log_engine_state(&*engine.borrow());
                         print_err(&From::from(r));
                     }
                 }
@@ -324,8 +428,8 @@ fn main() {
         match lock_file {
             Err(err) => Err(err),
             Ok(_) => {
-                initialize_log(matches.is_present("debug"));
-                run(&matches)
+                let log_handle = initialize_log(matches.is_present("debug"));
+                run(&matches, &log_handle)
             }
         }
     };

--- a/src/stratis/buff_log.rs
+++ b/src/stratis/buff_log.rs
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! A logger that wraps another logger, and provides "flight data recorder"
+//! semantics: nothing is output until asked for. This can be by calling
+//! `Handle::dump()`, or a `HandleGuard` can be used to dump the log when a
+//! scope is exited.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Duration, Utc};
+use log::{self, Level, Log, Metadata, MetadataBuilder, Record};
+
+const LOCK_EXPECT_MSG: &str =
+    "No code in this module can panic; therefore the mutex can not be poisoned.";
+
+#[derive(Debug, Clone)]
+/// A structure that allows interaction with the installed buff_log.
+pub struct Handle<L: Log> {
+    shared: Arc<Mutex<BuffLogger<L>>>,
+}
+
+impl<L: Log> Handle<L> {
+    fn new(shared: &Arc<Mutex<BuffLogger<L>>>) -> Handle<L> {
+        Handle {
+            shared: shared.clone(),
+        }
+    }
+
+    /// Send buffered logs to the wrapped logger.
+    pub fn dump(&self) -> () {
+        let shared = self.shared.lock().expect(LOCK_EXPECT_MSG);
+        let mut vec = shared.buff.lock().expect(LOCK_EXPECT_MSG);
+        for (time, item) in vec.drain(..) {
+            shared.log.log(&Record::builder()
+                .metadata(
+                    MetadataBuilder::new()
+                        .level(item.metadata.level)
+                        .target(&item.metadata.target)
+                        .build(),
+                )
+                .args(format_args!("{} {}", time, item.args))
+                .file(item.file.as_ref().map(|s| &**s))
+                .line(item.line)
+                .module_path(item.module_path.as_ref().map(|s| &**s))
+                .build());
+        }
+    }
+
+    pub fn buffered_count(&self) -> usize {
+        let shared = self.shared.lock().expect(LOCK_EXPECT_MSG);
+        let vec = shared.buff.lock().expect(LOCK_EXPECT_MSG);
+        vec.len()
+    }
+
+    /// Construct a HandleGuard, that will call `dump()` when it goes out of
+    /// scope.
+    pub fn to_guard(&self) -> HandleGuard<L> {
+        HandleGuard {
+            handle: Handle::new(&self.shared.clone()),
+        }
+    }
+}
+
+/// A structure that will output all buffered log lines when it leaves scope.
+pub struct HandleGuard<L: Log> {
+    handle: Handle<L>,
+}
+
+impl<L: Log> Drop for HandleGuard<L> {
+    fn drop(&mut self) {
+        self.handle.dump()
+    }
+}
+
+/// Create a new BuffLog wrapping another implementer of the `Log` trait.
+#[derive(Debug)]
+pub struct Logger<L: Log>(Arc<Mutex<BuffLogger<L>>>);
+
+impl<L: Log + 'static> Logger<L> {
+    /// If `pass_through` is `true`, no buffering is performed. One may wish to disable
+    /// buffering in some cases, and this is an easy way to do it.
+    /// If `hold_time` is given, log messages may be discarded after this time passes.
+    /// `None` means keep indefinitely.
+    pub fn new(logger: L, pass_through: bool, hold_time: Option<Duration>) -> Logger<L> {
+        Logger(Arc::new(Mutex::new(BuffLogger::new(
+            logger,
+            pass_through,
+            hold_time,
+        ))))
+    }
+
+    /// Set buff_log as the global logging instance.
+    pub fn init(self) -> Handle<L> {
+        let (pass_through, hold_time) = {
+            let shared = self.0.lock().expect(LOCK_EXPECT_MSG);
+            (shared.pass_through, shared.hold_time)
+        };
+        let handle = Handle::new(&self.0);
+        log::set_max_level(Level::max().to_level_filter());
+        log::set_boxed_logger(Box::new(self)).expect("set_logger should only be called once");
+        debug!(
+            "BuffLogger: pass_through: {} hold time: {}",
+            pass_through,
+            hold_time
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "none".into())
+        );
+        handle
+    }
+}
+
+impl<L: Log> Log for Logger<L> {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.0.lock().expect(LOCK_EXPECT_MSG).log.enabled(metadata)
+    }
+    fn log(&self, record: &Record) {
+        let shared = self.0.lock().expect(LOCK_EXPECT_MSG);
+        if shared.pass_through {
+            shared.log.log(record)
+        } else {
+            let now = Utc::now();
+            let mut v = shared.buff.lock().expect(LOCK_EXPECT_MSG);
+            v.push_back((now, OwnedRecord::from_record(record)));
+
+            // Drop entries that are older than hold time
+            if let Some(hold_time) = shared.hold_time {
+                v.retain(|(time, _)| *time + hold_time >= now);
+            }
+        }
+    }
+    fn flush(&self) {
+        self.0.lock().expect(LOCK_EXPECT_MSG).log.flush()
+    }
+}
+
+/// An owned version of Metadata
+#[derive(Debug)]
+struct OwnedMetadata {
+    level: Level,
+    target: String,
+}
+
+/// An owned version of `log::Record`
+#[derive(Debug)]
+struct OwnedRecord {
+    metadata: OwnedMetadata,
+    args: String,
+    module_path: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+impl OwnedRecord {
+    fn from_record(record: &Record) -> OwnedRecord {
+        OwnedRecord {
+            metadata: OwnedMetadata {
+                level: record.metadata().level(),
+                target: record.metadata().target().into(),
+            },
+            args: format!("{}", record.args()),
+            module_path: record.module_path().map(|s| s.to_owned()),
+            file: record.file().map(|s| s.to_owned()),
+            line: record.line(),
+        }
+    }
+}
+
+#[allow(type_complexity)]
+#[derive(Debug)]
+struct BuffLogger<L: Log> {
+    pass_through: bool,
+    hold_time: Option<Duration>,
+    log: L,
+    buff: Arc<Mutex<VecDeque<(DateTime<Utc>, OwnedRecord)>>>,
+}
+
+impl<L: Log> BuffLogger<L> {
+    fn new(log: L, pass_through: bool, hold_time: Option<Duration>) -> BuffLogger<L> {
+        BuffLogger {
+            pass_through,
+            hold_time,
+            log,
+            buff: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestLog {}
+
+    impl Log for TestLog {
+        fn enabled(&self, _metadata: &Metadata) -> bool {
+            true
+        }
+        fn log(&self, record: &Record) {
+            println!(
+                "{}:{} -- {}",
+                record.level(),
+                record.target(),
+                record.args()
+            );
+        }
+        fn flush(&self) {}
+    }
+
+    #[test]
+    fn test_buffering() {
+        let logger = Logger::new(TestLog {}, false, None);
+        let handle = logger.init();
+
+        // buff-log adds its own initial (buffered) log message
+        assert_eq!(handle.buffered_count(), 1);
+
+        error!("error 1");
+        warn!("warn 1");
+        info!("info 1");
+        debug!("debug 1");
+        trace!("trace 1");
+
+        assert_eq!(handle.buffered_count(), 6);
+        handle.dump();
+        assert_eq!(handle.buffered_count(), 0);
+    }
+}

--- a/src/stratis/mod.rs
+++ b/src/stratis/mod.rs
@@ -4,8 +4,10 @@
 
 pub use self::errors::{ErrorEnum, StratisError, StratisResult};
 pub use self::stratis::VERSION;
+pub use self::util::alarm;
 
 pub mod buff_log;
 mod errors;
 #[allow(module_inception)]
 mod stratis;
+mod util;

--- a/src/stratis/mod.rs
+++ b/src/stratis/mod.rs
@@ -5,6 +5,7 @@
 pub use self::errors::{ErrorEnum, StratisError, StratisResult};
 pub use self::stratis::VERSION;
 
+pub mod buff_log;
 mod errors;
 #[allow(module_inception)]
 mod stratis;

--- a/src/stratis/util.rs
+++ b/src/stratis/util.rs
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use nix::libc::alarm as libc_alarm;
+
+/// Ask for a SIGARLM to be sent to the process after some number of seconds.
+/// See `man 2 alarm` for more.
+// This should go in Nix crate.
+pub fn alarm(seconds: u32) -> u32 {
+    unsafe { libc_alarm(seconds) }
+}


### PR DESCRIPTION
A new version of #1026

buff-log buffers log messages, until the dump() method is called, or a HandleGuard goes out of scope. This should let us be generous with our diagnostic output but only spew when an error occurs.

Only buffers when stratisd not invoked with "--debug". Default behavior is to discard buffered log messages more than 30 minutes old.

fixes #309