### PR TITLE
Temporarily allow Travis cross-compilation target to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ addons:
 language: rust
 
 matrix:
+    allow_failures:
+        # See GitHub issue: https://github.com/travis-ci/travis-ci/issues/9891.
+        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         - rust: stable
           env: TASK=fmt-travis TARGET=x86_64-unknown-linux-gnu


### PR DESCRIPTION
It's failing due to an inability to install Oracle JDK 8.

The relevant GitHub issue is:
https://github.com/travis-ci/travis-ci/issues/9891.

Signed-off-by: mulhern <amulhern@redhat.com>