### PR TITLE
Rewrite get_blockdevs method

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -897,8 +897,10 @@ mod tests {
 
     /// Create a backstore with a cache.
     /// Setup the same backstore, should succeed.
+    /// Verify that blockdev metadatas are the same for the backstores.
     /// Tear down the backstore.
     /// Setup the same backstore again.
+    /// Verify blockdev metadata again.
     /// Destroy all.
     fn test_setup(paths: &[&Path]) -> () {
         assert!(paths.len() > 1);
@@ -927,6 +929,10 @@ mod tests {
         let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
         invariant(&backstore);
 
+        let backstore_save2 = backstore.record();
+        assert_eq!(backstore_save.cache_devs, backstore_save2.cache_devs);
+        assert_eq!(backstore_save.data_devs, backstore_save2.data_devs);
+
         backstore.teardown().unwrap();
 
         cmd::udev_settle().unwrap();
@@ -934,6 +940,10 @@ mod tests {
         let map = map.get(&pool_uuid).unwrap();
         let backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
         invariant(&backstore);
+
+        let backstore_save2 = backstore.record();
+        assert_eq!(backstore_save.cache_devs, backstore_save2.cache_devs);
+        assert_eq!(backstore_save.data_devs, backstore_save2.data_devs);
 
         backstore.destroy().unwrap();
     }

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -239,7 +239,7 @@ pub fn get_blockdevs(
         ))
     }
 
-    let (mut datadevs, mut cachedevs) = (vec![], vec![]);
+    let (mut datadevs, mut cachedevs): (Vec<StratBlockDev>, Vec<StratBlockDev>) = (vec![], vec![]);
     for (device, devnode) in devnodes {
         let bda = BDA::load(&mut OpenOptions::new().read(true).open(devnode)?)?.ok_or_else(|| {
             StratisError::Engine(ErrorEnum::NotFound,


### PR DESCRIPTION
This includes a bunch of tidies and clarifications and changes the specification so that the devices are sorted in the order in which they were previously recorded in the Stratis metadata.