### PR TITLE
Remove an unnecessary clippy allow

### DIFF
--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -14,7 +14,6 @@ use devicemapper::{DevId, DmOptions};
 use super::super::cmd;
 use super::super::dm::{get_dm, get_dm_init};
 
-#[allow(renamed_and_removed_lints)]
 mod cleanup_errors {
     use libmount;
     use nix;


### PR DESCRIPTION
This was added because previous version of error-chain had some newly
introduced clippy errors that it didn't either allow or avoid.
Since the upgrade to the new version error-chain has fixed this problem,
and so stratis can skip this allow.

Signed-off-by: mulhern <amulhern@redhat.com>