### PR TITLE
Omit BackstoreSave.next field from metadata

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -230,13 +230,23 @@ impl Backstore {
         self.data_tier.current_capacity()
     }
 
-    /// The available number of Sectors.
-    pub fn available(&self) -> Sectors {
+    /// The size of the cap device.
+    ///
+    /// The size of the cap device is obtained from the size of the component
+    /// DM devices. But the devicemapper library stores the data from which
+    /// the size of each DM device is calculated; the result is computed and
+    /// no ioctl is required.
+    fn size(&self) -> Sectors {
         self.linear
             .as_ref()
             .map(|d| d.size())
             .or_else(|| self.cache.as_ref().map(|d| d.size()))
-            .expect("either linear or cache must be Some") - self.next
+            .expect("either linear or cache must be Some")
+    }
+
+    /// The available number of Sectors.
+    pub fn available(&self) -> Sectors {
+        self.size() - self.next
     }
 
     /// Destroy the entire store.

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -69,7 +69,6 @@ pub struct BackstoreSave {
     pub data_segments: Vec<(Uuid, Sectors, Sectors)>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta_segments: Option<Vec<(Uuid, Sectors, Sectors)>>,
-    pub next: Sectors,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR has two purposes:
1. It distinguishes between the cap device and the blockdevs of which it is currently formed by making the amount available to the upper layers associated with the size of the cap device, not the number of sectors allocated from the blockdevs. These amounts are still equal, but the calculations are based on different values. This sets up for the next change, when allocations from the blockdevs to the cap device will be on demand, rather than done eagerly.
2. It eliminates the ```BackstoreSave.next``` field from the metadata. This field is still calculated from the metadata and it is used in ```Backstore``` to track the allocations from the cap device, but it is no longer stored in the metadata.

The only change in behavior is that ```next``` is not saved.