### PR TITLE
Revert "Temporarily allow Travis cross-compilation target to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ addons:
 language: rust
 
 matrix:
-    allow_failures:
-        # See GitHub issue: https://github.com/travis-ci/travis-ci/issues/9891.
-        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         - rust: stable
           env: TASK=fmt-travis TARGET=x86_64-unknown-linux-gnu


### PR DESCRIPTION
This reverts commit f0261fa0b4f94a0c5be0e451481c24dd6659fceb.

The Travis bug which caused this build to fail has now been fixed.
https://github.com/travis-ci/travis-ci/issues/9891