### PR TITLE
Make allocation from block devices lazy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_
 
 test-real:
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test real_
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test real_test_full_pool
 
 test-travis:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test travis_

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -202,6 +202,9 @@ impl Backstore {
     /// WARNING: All this must change when it becomes possible to return
     /// sectors to the store.
     /// WARNING: metadata changing event
+    /// Postcondition: forall i, sizes_i == result_i.1. The second value in each
+    /// pair in the returned vector is therefore redundant, but is retained
+    /// as a convenience to the caller.
     pub fn alloc_space(&mut self, sizes: &[Sectors]) -> Option<Vec<(Sectors, Sectors)>> {
         if self.available() < sizes.iter().cloned().sum() {
             return None;

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -75,9 +75,6 @@ fn make_cache(
 /// This structure can allocate additional space to the upper layer, but it
 /// cannot accept returned space. When it is extended to be able to accept
 /// returned space the allocation algorithm will have to be revised.
-///
-/// self.linear.is_some() XOR self.cache.is_some()
-/// self.cache.is_some() <=> self.cache_tier.is_some()
 #[derive(Debug)]
 pub struct Backstore {
     /// A cache DM Device.
@@ -99,6 +96,12 @@ impl Backstore {
     /// belong to the pool with the specified pool_uuid.
     /// Precondition: next <= the sum of the lengths of the segments allocated
     /// to the data tier cap device.
+    /// Precondition: backstore_save.data_segments is not empty. This is a
+    /// consequence of the fact that metadata is saved by the pool, and if
+    /// a pool exists, data has been allocated to the cap device.
+    /// Postcondition:
+    /// self.linear.is_some() XOR self.cache.is_some()
+    /// self.cache.is_some() <=> self.cache_tier.is_some()
     pub fn setup(
         pool_uuid: PoolUuid,
         backstore_save: &BackstoreSave,
@@ -157,18 +160,22 @@ impl Backstore {
     ) -> StratisResult<Backstore> {
         let data_tier = DataTier::new(BlockDevMgr::initialize(pool_uuid, paths, mda_size, force)?);
 
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
-        let linear = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&data_tier.segments),
-        )?;
+        let linear = if !data_tier.segments.is_empty() {
+            let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
+            Some(LinearDev::setup(
+                get_dm(),
+                &dm_name,
+                Some(&dm_uuid),
+                map_to_dm(&data_tier.segments),
+            )?)
+        } else {
+            None
+        };
 
         Ok(Backstore {
             data_tier,
             cache_tier: None,
-            linear: Some(linear),
+            linear,
             cache: None,
             next: Sectors(0),
         })
@@ -178,6 +185,9 @@ impl Backstore {
     ///
     /// If the cache tier does not already exist, create it.
     ///
+    /// Precondition: Must be invoked only after some space has been allocated
+    /// from the backstore. This ensures that there is certainly a cap device.
+    // Precondition: self.linear.is_some() XOR self.cache.is_some()
     // Postcondition: self.cache.is_some() && self.linear.is_none()
     fn add_cachedevs(
         &mut self,
@@ -216,7 +226,7 @@ impl Backstore {
 
                 let linear = self.linear
                     .take()
-                    .expect("cache_tier.is_none() <=> self.linear.is_some()");
+                    .expect("some space has already been allocated from the backstore => (cache_tier.is_none() <=> self.linear.is_some())");
 
                 let cache = make_cache(pool_uuid, &cache_tier, linear, true)?;
 
@@ -238,6 +248,8 @@ impl Backstore {
 
     /// Add datadevs to the backstore. The data tier always exists if the
     /// backstore exists at all, so there is no need to create it.
+    /// Precondition: Must be invoked only after some space has been allocated
+    /// from the backstore. This ensures that there is certainly a cap device.
     fn add_datadevs(
         &mut self,
         pool_uuid: PoolUuid,
@@ -257,7 +269,7 @@ impl Backstore {
                 linear.set_table(get_dm(), table)?;
                 linear.resume(get_dm())
             }
-            _ => panic!("self.cache.is_some() XOR self.linear.is_some()"),
+            _ => panic!("some space has already been allocated from the backstore => (self.cache.is_some() XOR self.linear.is_some())"),
         }?;
 
         Ok(uuids)
@@ -346,7 +358,7 @@ impl Backstore {
             .as_ref()
             .map(|d| d.size())
             .or_else(|| self.cache.as_ref().map(|d| d.size()))
-            .expect("either linear or cache must be Some")
+            .unwrap_or(Sectors(0))
     }
 
     /// The available number of Sectors.
@@ -375,9 +387,9 @@ impl Backstore {
                     .destroy()?;
             }
             None => {
-                self.linear
-                    .expect("self.cache.is_none()")
-                    .teardown(get_dm())?;
+                if let Some(linear) = self.linear {
+                    linear.teardown(get_dm())?;
+                }
             }
         };
         self.data_tier.destroy()
@@ -388,21 +400,23 @@ impl Backstore {
     pub fn teardown(self) -> StratisResult<()> {
         match self.cache {
             Some(cache) => cache.teardown(get_dm()),
-            None => self.linear
-                .expect("self.cache.is_none()")
-                .teardown(get_dm()),
+            None => if let Some(linear) = self.linear {
+                linear.teardown(get_dm())
+            } else {
+                Ok(())
+            },
         }.map_err(|e| e.into())
     }
 
     /// Return the device that this tier is currently using.
     /// This changes, depending on whether the backstore is supporting a cache
-    /// or not.
-    pub fn device(&self) -> Device {
+    /// or not. There may be no device if no data has yet been allocated from
+    /// the backstore.
+    pub fn device(&self) -> Option<Device> {
         self.cache
             .as_ref()
             .map(|d| d.device())
             .or_else(|| self.linear.as_ref().map(|d| d.device()))
-            .expect("must be one or the other")
     }
 
     /// Lookup an immutable blockdev by its Stratis UUID.
@@ -492,9 +506,7 @@ mod tests {
     ///   device
     fn invariant(backstore: &Backstore) -> () {
         assert!(
-            (backstore.cache_tier.is_none()
-                && backstore.cache.is_none()
-                && backstore.linear.is_some())
+            (backstore.cache_tier.is_none() && backstore.cache.is_none())
                 || (backstore.cache_tier.is_some()
                     && backstore.cache.is_some()
                     && backstore.linear.is_none())
@@ -502,6 +514,7 @@ mod tests {
         assert_eq!(
             backstore.data_tier.capacity(),
             match (&backstore.linear, &backstore.cache) {
+                (None, None) => Sectors(0),
                 (&None, &Some(ref cache)) => cache.size(),
                 (&Some(ref linear), &None) => linear.size(),
                 _ => panic!("impossible; see first assertion"),
@@ -529,6 +542,9 @@ mod tests {
             Backstore::initialize(pool_uuid, initdatapaths, MIN_MDA_SECTORS, false).unwrap();
 
         invariant(&backstore);
+
+        // Allocate space from the backstore so that the cap device is made.
+        backstore.alloc_space(pool_uuid, &[Sectors(1)]).unwrap();
 
         let cache_uuids = backstore
             .add_blockdevs(pool_uuid, initcachepaths, BlockDevTier::Cache, false)
@@ -627,6 +643,10 @@ mod tests {
         let mut backstore =
             Backstore::initialize(pool_uuid, paths1, MIN_MDA_SECTORS, false).unwrap();
         invariant(&backstore);
+
+        // Allocate space from the backstore so that the cap device is made.
+        backstore.alloc_space(pool_uuid, &[Sectors(1)]).unwrap();
+
         let old_device = backstore.device();
 
         backstore

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -485,10 +485,8 @@ mod tests {
     use super::*;
 
     /// Assert some invariants of the backstore
-    /// * self.cache_tier.is_some() && self.cache.is_some() XOR
-    ///   self.linear.is_some()).
-    /// * self.data_tier.block_mgr.avail_space() is always 0, because
-    ///   everything is allocated to the DM device.
+    /// * backstore.cache_tier.is_some() <=> backstore.cache.is_some() &&
+    ///   backstore.cache_tier.is_some() => backstore.linear.is_none()
     /// * backstore's data tier capacity is equal to the size of the cap device
     /// * backstore's next index is always less than the size of the cap
     ///   device
@@ -501,7 +499,6 @@ mod tests {
                     && backstore.cache.is_some()
                     && backstore.linear.is_none())
         );
-        assert_eq!(backstore.data_tier.block_mgr.avail_space(), Sectors(0));
         assert_eq!(
             backstore.data_tier.capacity(),
             match (&backstore.linear, &backstore.cache) {

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -31,6 +31,47 @@ use super::setup::get_blockdevs;
 /// typical size.
 const CACHE_BLOCK_SIZE: Sectors = Sectors(2048); // 1024 KiB
 
+/// Make a DM cache device. If the cache device is being made new,
+/// take extra steps to make it clean.
+fn make_cache(
+    pool_uuid: PoolUuid,
+    cache_tier: &CacheTier,
+    origin: LinearDev,
+    new: bool,
+) -> StratisResult<CacheDev> {
+    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
+    let meta = LinearDev::setup(
+        get_dm(),
+        &dm_name,
+        Some(&dm_uuid),
+        map_to_dm(&cache_tier.meta_segments),
+    )?;
+
+    if new {
+        // See comment in ThinPool::new() method
+        wipe_sectors(&meta.devnode(), Sectors(0), meta.size())?;
+    }
+
+    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
+    let cache = LinearDev::setup(
+        get_dm(),
+        &dm_name,
+        Some(&dm_uuid),
+        map_to_dm(&cache_tier.cache_segments),
+    )?;
+
+    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
+    Ok(CacheDev::setup(
+        get_dm(),
+        &dm_name,
+        Some(&dm_uuid),
+        meta,
+        cache,
+        origin,
+        CACHE_BLOCK_SIZE,
+    )?)
+}
+
 /// This structure can allocate additional space to the upper layer, but it
 /// cannot accept returned space. When it is extended to be able to accept
 /// returned space the allocation algorithm will have to be revised.
@@ -85,33 +126,7 @@ impl Backstore {
                 (&Some(ref cache_segments), &Some(ref meta_segments)) => {
                     let cache_tier = CacheTier::setup(block_mgr, cache_segments, meta_segments)?;
 
-                    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-                    let meta = LinearDev::setup(
-                        get_dm(),
-                        &dm_name,
-                        Some(&dm_uuid),
-                        map_to_dm(&cache_tier.meta_segments),
-                    )?;
-
-                    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-                    let cache = LinearDev::setup(
-                        get_dm(),
-                        &dm_name,
-                        Some(&dm_uuid),
-                        map_to_dm(&cache_tier.cache_segments),
-                    )?;
-
-                    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
-                    let cache_device = CacheDev::setup(
-                        get_dm(),
-                        &dm_name,
-                        Some(&dm_uuid),
-                        meta,
-                        cache,
-                        origin,
-                        CACHE_BLOCK_SIZE,
-                    )?;
-
+                    let cache_device = make_cache(pool_uuid, &cache_tier, origin, false)?;
                     (Some(cache_tier), Some(cache_device), None)
                 }
                 _ => {
@@ -203,35 +218,8 @@ impl Backstore {
                     .take()
                     .expect("cache_tier.is_none() <=> self.linear.is_some()");
 
-                let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-                let meta = LinearDev::setup(
-                    get_dm(),
-                    &dm_name,
-                    Some(&dm_uuid),
-                    map_to_dm(&cache_tier.meta_segments),
-                )?;
+                let cache = make_cache(pool_uuid, &cache_tier, linear, true)?;
 
-                // See comment in ThinPool::new() method
-                wipe_sectors(&meta.devnode(), Sectors(0), meta.size())?;
-
-                let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-                let cache = LinearDev::setup(
-                    get_dm(),
-                    &dm_name,
-                    Some(&dm_uuid),
-                    map_to_dm(&cache_tier.cache_segments),
-                )?;
-
-                let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
-                let cache = CacheDev::new(
-                    get_dm(),
-                    &dm_name,
-                    Some(&dm_uuid),
-                    meta,
-                    cache,
-                    linear,
-                    CACHE_BLOCK_SIZE,
-                )?;
                 self.cache = Some(cache);
 
                 let uuids = cache_tier

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -15,15 +15,21 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
 
+use super::super::device::wipe_sectors;
 use super::super::dm::get_dm;
+use super::super::dmnames::{format_backstore_ids, CacheRole};
 use super::super::serde_structs::{BackstoreSave, Recordable};
 
 use super::blockdev::StratBlockDev;
-use super::blockdevmgr::BlockDevMgr;
+use super::blockdevmgr::{map_to_dm, BlockDevMgr};
 use super::cache_tier::CacheTier;
 use super::data_tier::DataTier;
 use super::metadata::MIN_MDA_SECTORS;
 use super::setup::get_blockdevs;
+
+/// Use a cache block size that the kernel docs indicate is the largest
+/// typical size.
+const CACHE_BLOCK_SIZE: Sectors = Sectors(2048); // 1024 KiB
 
 /// This structure can allocate additional space to the upper layer, but it
 /// cannot accept returned space. When it is extended to be able to accept
@@ -61,23 +67,51 @@ impl Backstore {
     ) -> StratisResult<Backstore> {
         let (datadevs, cachedevs) = get_blockdevs(pool_uuid, backstore_save, devnodes)?;
         let block_mgr = BlockDevMgr::new(datadevs, last_update_time);
-        let (data_tier, dm_device) =
-            DataTier::setup(pool_uuid, block_mgr, &backstore_save.data_segments)?;
+        let data_tier = DataTier::setup(block_mgr, &backstore_save.data_segments)?;
+        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
+        let origin = LinearDev::setup(
+            get_dm(),
+            &dm_name,
+            Some(&dm_uuid),
+            map_to_dm(&data_tier.segments),
+        )?;
 
-        let (cache_tier, cache, linear) = if !cachedevs.is_empty() {
+        let (cache_tier, cache, origin) = if !cachedevs.is_empty() {
             let block_mgr = BlockDevMgr::new(cachedevs, last_update_time);
             match (
                 &backstore_save.cache_segments,
                 &backstore_save.meta_segments,
             ) {
                 (&Some(ref cache_segments), &Some(ref meta_segments)) => {
-                    let (cache_tier, cache_device) = CacheTier::setup(
-                        pool_uuid,
-                        block_mgr,
-                        dm_device,
-                        cache_segments,
-                        meta_segments,
+                    let cache_tier = CacheTier::setup(block_mgr, cache_segments, meta_segments)?;
+
+                    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
+                    let meta = LinearDev::setup(
+                        get_dm(),
+                        &dm_name,
+                        Some(&dm_uuid),
+                        map_to_dm(&cache_tier.meta_segments),
                     )?;
+
+                    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
+                    let cache = LinearDev::setup(
+                        get_dm(),
+                        &dm_name,
+                        Some(&dm_uuid),
+                        map_to_dm(&cache_tier.cache_segments),
+                    )?;
+
+                    let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
+                    let cache_device = CacheDev::setup(
+                        get_dm(),
+                        &dm_name,
+                        Some(&dm_uuid),
+                        meta,
+                        cache,
+                        origin,
+                        CACHE_BLOCK_SIZE,
+                    )?;
+
                     (Some(cache_tier), Some(cache_device), None)
                 }
                 _ => {
@@ -86,13 +120,13 @@ impl Backstore {
                 }
             }
         } else {
-            (None, None, Some(dm_device))
+            (None, None, Some(origin))
         };
 
         Ok(Backstore {
             data_tier,
             cache_tier,
-            linear,
+            linear: origin,
             cache,
             next,
         })
@@ -106,14 +140,20 @@ impl Backstore {
         mda_size: Sectors,
         force: bool,
     ) -> StratisResult<Backstore> {
-        let (data_tier, dm_device) = DataTier::new(
-            pool_uuid,
-            BlockDevMgr::initialize(pool_uuid, paths, mda_size, force)?,
+        let data_tier = DataTier::new(BlockDevMgr::initialize(pool_uuid, paths, mda_size, force)?);
+
+        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
+        let linear = LinearDev::setup(
+            get_dm(),
+            &dm_name,
+            Some(&dm_uuid),
+            map_to_dm(&data_tier.segments),
         )?;
+
         Ok(Backstore {
             data_tier,
             cache_tier: None,
-            linear: Some(dm_device),
+            linear: Some(linear),
             cache: None,
             next: Sectors(0),
         })
@@ -135,15 +175,51 @@ impl Backstore {
                 let mut cache_device = self.cache
                     .as_mut()
                     .expect("cache_tier.is_some() <=> self.cache.is_some()");
-                cache_tier.add(pool_uuid, &mut cache_device, paths, force)
+                let uuids = cache_tier.add(pool_uuid, paths, force);
+
+                let table = map_to_dm(&cache_tier.cache_segments);
+                cache_device.set_cache_table(get_dm(), table)?;
+                cache_device.resume(get_dm())?;
+                uuids
             }
             None => {
                 let bdm = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, force)?;
 
+                let cache_tier = CacheTier::new(bdm);
+
                 let linear = self.linear
                     .take()
                     .expect("cache_tier.is_none() <=> self.linear.is_some()");
-                let (cache_tier, cache) = CacheTier::new(pool_uuid, bdm, linear)?;
+
+                let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
+                let meta = LinearDev::setup(
+                    get_dm(),
+                    &dm_name,
+                    Some(&dm_uuid),
+                    map_to_dm(&cache_tier.meta_segments),
+                )?;
+
+                // See comment in ThinPool::new() method
+                wipe_sectors(&meta.devnode(), Sectors(0), meta.size())?;
+
+                let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
+                let cache = LinearDev::setup(
+                    get_dm(),
+                    &dm_name,
+                    Some(&dm_uuid),
+                    map_to_dm(&cache_tier.cache_segments),
+                )?;
+
+                let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
+                let cache = CacheDev::new(
+                    get_dm(),
+                    &dm_name,
+                    Some(&dm_uuid),
+                    meta,
+                    cache,
+                    linear,
+                    CACHE_BLOCK_SIZE,
+                )?;
                 self.cache = Some(cache);
 
                 let uuids = cache_tier
@@ -168,13 +244,23 @@ impl Backstore {
         paths: &[&Path],
         force: bool,
     ) -> StratisResult<Vec<DevUuid>> {
-        self.data_tier.add(
-            pool_uuid,
-            self.cache.as_mut(),
-            self.linear.as_mut(),
-            paths,
-            force,
-        )
+        let uuids = self.data_tier.add(pool_uuid, paths, force)?;
+
+        let table = map_to_dm(&self.data_tier.segments);
+
+        match (self.cache.as_mut(), self.linear.as_mut()) {
+            (Some(cache), None) => {
+                cache.set_origin_table(get_dm(), table)?;
+                cache.resume(get_dm())
+            }
+            (None, Some(linear)) => {
+                linear.set_table(get_dm(), table)?;
+                linear.resume(get_dm())
+            }
+            _ => panic!("self.cache.is_some() XOR self.linear.is_some()"),
+        }?;
+
+        Ok(uuids)
     }
 
     /// Add the given paths to self. Return UUIDs of the new blockdevs

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -6,22 +6,14 @@
 
 use std::path::Path;
 
-use devicemapper::{CacheDev, DmDevice, LinearDev, Sectors, IEC};
+use devicemapper::{Sectors, IEC};
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
 
-use super::super::device::wipe_sectors;
-use super::super::dm::get_dm;
-use super::super::dmnames::{format_backstore_ids, CacheRole};
-
 use super::blockdev::StratBlockDev;
-use super::blockdevmgr::{coalesce_blkdevsegs, map_to_dm, BlkDevSegment, BlockDevMgr, Segment};
-
-/// Use a cache block size that the kernel docs indicate is the largest
-/// typical size.
-const CACHE_BLOCK_SIZE: Sectors = Sectors(2048); // 1024 KiB
+use super::blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment};
 
 /// Handles the cache devices.
 #[derive(Debug)]
@@ -39,16 +31,11 @@ pub struct CacheTier {
 impl CacheTier {
     /// Setup a previously existing cache layer from the block_mgr and
     /// previously allocated segments.
-    ///
-    /// Returns the CacheTier and the cache DM device that was created during
-    /// setup.
     pub fn setup(
-        pool_uuid: PoolUuid,
         block_mgr: BlockDevMgr,
-        origin: LinearDev,
         cache_segments: &[(DevUuid, Sectors, Sectors)],
         meta_segments: &[(DevUuid, Sectors, Sectors)],
-    ) -> StratisResult<(CacheTier, CacheDev)> {
+    ) -> StratisResult<CacheTier> {
         if block_mgr.avail_space() != Sectors(0) {
             let err_msg = format!(
                 "{} unallocated to device; probable metadata corruption",
@@ -75,45 +62,17 @@ impl CacheTier {
             .iter()
             .map(&mapper)
             .collect::<StratisResult<Vec<_>>>()?;
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-        let meta = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&meta_segments),
-        )?;
 
         let cache_segments = cache_segments
             .iter()
             .map(&mapper)
             .collect::<StratisResult<Vec<_>>>()?;
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-        let cache = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&cache_segments),
-        )?;
 
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
-        let cd = CacheDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            meta,
-            cache,
-            origin,
-            CACHE_BLOCK_SIZE,
-        )?;
-
-        Ok((
-            CacheTier {
-                block_mgr,
-                meta_segments,
-                cache_segments,
-            },
-            cd,
-        ))
+        Ok(CacheTier {
+            block_mgr,
+            meta_segments,
+            cache_segments,
+        })
     }
 
     /// Add the given paths to self. Return UUIDs of the new blockdevs
@@ -127,7 +86,6 @@ impl CacheTier {
     pub fn add(
         &mut self,
         pool_uuid: PoolUuid,
-        cache_device: &mut CacheDev,
         paths: &[&Path],
         force: bool,
     ) -> StratisResult<Vec<DevUuid>> {
@@ -141,27 +99,15 @@ impl CacheTier {
             .flat_map(|s| s.iter())
             .cloned()
             .collect::<Vec<_>>();
-        let coalesced = coalesce_blkdevsegs(&self.cache_segments, &segments);
-        let table = map_to_dm(&coalesced);
-
-        cache_device.set_cache_table(get_dm(), table)?;
-        cache_device.resume(get_dm())?;
-
-        self.cache_segments = coalesced;
+        self.cache_segments = coalesce_blkdevsegs(&self.cache_segments, &segments);
 
         Ok(uuids)
     }
 
     /// Setup a new CacheTier struct from the block_mgr.
     ///
-    /// Returns the CacheTier and the cache device that was created.
-    ///
     /// WARNING: metadata changing event
-    pub fn new(
-        pool_uuid: PoolUuid,
-        mut block_mgr: BlockDevMgr,
-        origin: LinearDev,
-    ) -> StratisResult<(CacheTier, CacheDev)> {
+    pub fn new(mut block_mgr: BlockDevMgr) -> CacheTier {
         let avail_space = block_mgr.avail_space();
 
         // FIXME: Come up with a better way to choose metadata device size
@@ -179,44 +125,11 @@ impl CacheTier {
         let cache_segments = segments.pop().expect("segments.len() == 2");
         let meta_segments = segments.pop().expect("segments.len() == 1");
 
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-        let meta = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&meta_segments),
-        )?;
-
-        // See comment in ThinPool::new() method
-        wipe_sectors(&meta.devnode(), Sectors(0), meta.size())?;
-
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-        let cache = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&cache_segments),
-        )?;
-
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
-        let cd = CacheDev::new(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            meta,
-            cache,
-            origin,
-            CACHE_BLOCK_SIZE,
-        )?;
-
-        Ok((
-            CacheTier {
-                block_mgr,
-                meta_segments,
-                cache_segments,
-            },
-            cd,
-        ))
+        CacheTier {
+            block_mgr,
+            meta_segments,
+            cache_segments,
+        }
     }
 
     /// Destroy the tier. Wipe its blockdevs.

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -76,7 +76,9 @@ impl CacheTier {
     }
 
     /// Add the given paths to self. Return UUIDs of the new blockdevs
-    /// corresponding to the specified paths.
+    /// corresponding to the specified paths and a pair of Boolean values.
+    /// The first is true if the cache sub-device's segments were changed,
+    /// the second is true if the meta sub-device's segments were changed.
     /// Adds all additional space to cache sub-device.
     /// WARNING: metadata changing event
     // FIXME: That all segments on the newly added device are added to the
@@ -88,7 +90,7 @@ impl CacheTier {
         pool_uuid: PoolUuid,
         paths: &[&Path],
         force: bool,
-    ) -> StratisResult<Vec<DevUuid>> {
+    ) -> StratisResult<(Vec<DevUuid>, (bool, bool))> {
         let uuids = self.block_mgr.add(pool_uuid, paths, force)?;
 
         let avail_space = self.block_mgr.avail_space();
@@ -101,7 +103,7 @@ impl CacheTier {
             .collect::<Vec<_>>();
         self.cache_segments = coalesce_blkdevsegs(&self.cache_segments, &segments);
 
-        Ok(uuids)
+        Ok((uuids, (true, false)))
     }
 
     /// Setup a new CacheTier struct from the block_mgr.

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -56,20 +56,10 @@ impl DataTier {
     }
 
     /// Setup a new DataTier struct from the block_mgr.
-    ///
-    /// WARNING: metadata changing event
-    pub fn new(mut block_mgr: BlockDevMgr) -> DataTier {
-        let avail_space = block_mgr.avail_space();
-        let segments = block_mgr
-            .alloc_space(&[avail_space])
-            .expect("asked for exactly the space available, must get")
-            .iter()
-            .flat_map(|s| s.iter())
-            .cloned()
-            .collect::<Vec<_>>();
+    pub fn new(block_mgr: BlockDevMgr) -> DataTier {
         DataTier {
             block_mgr,
-            segments,
+            segments: vec![],
         }
     }
 
@@ -82,22 +72,30 @@ impl DataTier {
         paths: &[&Path],
         force: bool,
     ) -> StratisResult<Vec<DevUuid>> {
-        let uuids = self.block_mgr.add(pool_uuid, paths, force)?;
-
-        let avail_space = self.block_mgr.avail_space();
-        let segments = self.block_mgr
-            .alloc_space(&[avail_space])
-            .expect("asked for exactly the space available, must get")
-            .iter()
-            .flat_map(|s| s.iter())
-            .cloned()
-            .collect::<Vec<_>>();
-        self.segments = coalesce_blkdevsegs(&self.segments, &segments);
-
-        Ok(uuids)
+        self.block_mgr.add(pool_uuid, paths, force)
     }
 
-    /// All the sectors available to this device
+    /// Allocate at least request sectors from unallocated segments in
+    /// block devices belonging to the data tier. Return true if requested
+    /// amount or more was allocated, otherwise, false.
+    pub fn alloc_segments(&mut self, request: Sectors) -> bool {
+        match self.block_mgr.alloc_space(&[request]) {
+            Some(segments) => {
+                self.segments = coalesce_blkdevsegs(
+                    &self.segments,
+                    &segments
+                        .iter()
+                        .flat_map(|s| s.iter())
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                );
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// All the blockdev sectors that have been mapped to an upper device.
     pub fn capacity(&self) -> Sectors {
         self.segments
             .iter()

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -276,7 +276,7 @@ impl Pool for StratPool {
     ) -> StratisResult<Vec<DevUuid>> {
         self.thin_pool.suspend()?;
         let bdev_info = self.backstore.add_blockdevs(pool_uuid, paths, tier, force)?;
-        self.thin_pool.set_device(self.backstore.device())?;
+        self.thin_pool.set_device(self.backstore.device().expect("Since thin pool exists, space must have been allocated from the backstore, so backstore must have a cap device"))?;
         self.thin_pool.resume()?;
         self.write_metadata(pool_name)?;
         Ok(bdev_info)

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -400,6 +400,7 @@ impl ThinPool {
                 }
 
                 if usage.used_data > cmp::max(usage.total_data, DATA_LOWATER) - DATA_LOWATER {
+                    assert!(backstore.available() != Sectors(0));
                     // Request expansion of physical space allocated to the pool
                     // TODO: we request that the space be doubled or use the remaining space by
                     // requesting the minimum total_data vs. available space.

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -188,7 +188,9 @@ impl ThinPool {
         let spare_segments = segments_list.pop().expect("len(segments_list) == 2");
         let meta_segments = segments_list.pop().expect("len(segments_list) == 1");
 
-        let backstore_device = backstore.device();
+        let backstore_device = backstore.device().expect(
+            "Space has just been allocated from the backstore, so it must have a cap device",
+        );
 
         // When constructing a thin-pool, Stratis reserves the first N
         // sectors on a block device by creating a linear device with a
@@ -266,7 +268,7 @@ impl ThinPool {
         let data_segments = flex_devs.thin_data_dev.to_vec();
         let spare_segments = flex_devs.thin_meta_dev_spare.to_vec();
 
-        let backstore_device = backstore.device();
+        let backstore_device = backstore.device().expect("When stratisd was running previously, space was allocated from the backstore, so backstore must have a cap device");
 
         let (thinpool_name, thinpool_uuid) = format_thinpool_ids(pool_uuid, ThinPoolRole::Pool);
         let (meta_dev, meta_segments, spare_segments) = setup_metadev(
@@ -355,7 +357,12 @@ impl ThinPool {
     /// metadata save has been made.
     pub fn check(&mut self, backstore: &mut Backstore) -> StratisResult<bool> {
         #![allow(match_same_arms)]
-        assert_eq!(backstore.device(), self.backstore_device);
+        assert_eq!(
+            backstore.device().expect(
+                "thinpool exists and has been allocated to, so backstore must have a cap device"
+            ),
+            self.backstore_device
+        );
 
         let mut should_save: bool = false;
 
@@ -453,7 +460,12 @@ impl ThinPool {
         backstore: &mut Backstore,
     ) -> StratisResult<DataBlocks> {
         let backstore_device = self.backstore_device;
-        assert_eq!(backstore.device(), backstore_device);
+        assert_eq!(
+            backstore.device().expect(
+                "thinpool exists and has been allocated to, so backstore must have a cap device"
+            ),
+            backstore_device
+        );
         if let Some(mut regions) = backstore.alloc_space(&[*extend_size * DATA_BLOCK_SIZE]) {
             self.suspend()?;
             self.extend_data(backstore_device, regions.pop().expect("len(regions) == 1"))?;
@@ -476,7 +488,12 @@ impl ThinPool {
         backstore: &mut Backstore,
     ) -> StratisResult<MetaBlocks> {
         let backstore_device = self.backstore_device;
-        assert_eq!(backstore.device(), backstore_device);
+        assert_eq!(
+            backstore.device().expect(
+                "thinpool exists and has been allocated to, so backstore must have a cap device"
+            ),
+            backstore_device
+        );
         if let Some(mut regions) = backstore.alloc_space(&[extend_size.sectors()]) {
             self.suspend()?;
             self.extend_meta(backstore_device, regions.pop().expect("len(regions) == 1"))?;
@@ -1581,11 +1598,15 @@ mod tests {
         );
 
         pool.suspend().unwrap();
-        let old_device = backstore.device();
+        let old_device = backstore
+            .device()
+            .expect("Space already allocated from backstore, backstore must have device");
         backstore
             .add_blockdevs(pool_uuid, paths1, BlockDevTier::Cache, false)
             .unwrap();
-        let new_device = backstore.device();
+        let new_device = backstore
+            .device()
+            .expect("Space already allocated from backstore, backstore must have device");
         assert!(old_device != new_device);
         pool.set_device(new_device).unwrap();
         pool.resume().unwrap();

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -958,9 +958,9 @@ mod tests {
             loop {
                 let status: dm::ThinPoolStatus = pool.thin_pool.status(get_dm()).unwrap();
                 match status {
-                    dm::ThinPoolStatus::Working(ref _status) => {
+                    dm::ThinPoolStatus::Working(_) => {
                         f.write_all(write_buf).unwrap();
-                        if let Err(_e) = f.sync_data() {
+                        if f.sync_data().is_err() {
                             break;
                         }
                     }


### PR DESCRIPTION
Previously, all available segments in data block devices were greedily added to the cap device. Now, they are allocated lazily, on request by the thin pool.

This change required a relaxation of two previous invariants:
1. There was always either a linear DM device or a cache DM device belonging to the backstore. If segments are allocated only on demand, and demand has not occurred, then there are zero segments allocated. It is impossible to make a completely empty linear device, so after the backstore is created and before the thinpool requests space, there is neither a linear nor a cache DM device in the backstore.
2. All segments in the data blockdevs were always fully allocated to the backstore. This is not true any more.

The metadata checks were changed to handle the relaxing of these invariants.

Relaxing the two invariants increased the complexity of handling of the two alternate DM devices. Therefore, all such handling was moved into the backstore, making the *Tier structs just manage block devices and segment allocations. This changed the signatures of some methods in the *Tier implementations from ```Result<T>``` to ```T```.

The last part, making allocation lazy, required that backstore handle making or updating DM devices in its ```alloc_space``` method. This meant that this method could return an error, so its signature was changed accordingly.

