### PR TITLE
Set dbus object path for Pool, Filesystem and BlockDev

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -260,7 +260,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         libstratis::dbus_api::connect(Rc::clone(&engine))?;
 
     #[cfg(feature = "dbus_enabled")]
-    for (_, pool_uuid, pool) in engine.borrow().pools() {
+    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
         libstratis::dbus_api::register_pool(
             &dbus_conn,
             &dbus_context,
@@ -298,8 +298,8 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                                 &mut tree,
                                 pool_uuid,
                                 engine
-                                    .borrow()
-                                    .get_pool(pool_uuid)
+                                    .borrow_mut()
+                                    .get_mut_pool(pool_uuid)
                                     .expect(
                                         "block_evaluate() returned a pool UUID, pool must be available",
                                     )

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -49,15 +49,15 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let msg = match result {
         Ok(pool_uuid) => {
-            let pool_object_path: dbus::Path =
-                create_dbus_pool(dbus_context, object_path.clone(), pool_uuid);
-
             let (_, pool) = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
-            let bd_object_paths = pool.blockdevs()
-                .iter()
-                .map(|&(uuid, _)| {
-                    create_dbus_blockdev(dbus_context, pool_object_path.clone(), uuid)
+            let pool_object_path: dbus::Path =
+                create_dbus_pool(dbus_context, object_path.clone(), pool_uuid, pool);
+
+            let bd_object_paths = pool.blockdevs_mut()
+                .into_iter()
+                .map(|(uuid, bd)| {
+                    create_dbus_blockdev(dbus_context, pool_object_path.clone(), uuid, bd)
                 })
                 .collect::<Vec<_>>();
 
@@ -193,15 +193,15 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>, db
 fn register_pool_dbus(
     dbus_context: &DbusContext,
     pool_uuid: PoolUuid,
-    pool: &Pool,
+    pool: &mut Pool,
     object_path: &dbus::Path<'static>,
 ) {
-    let pool_path = create_dbus_pool(dbus_context, object_path.clone(), pool_uuid);
-    for (_, fs_uuid, _) in pool.filesystems() {
-        create_dbus_filesystem(dbus_context, pool_path.clone(), fs_uuid);
+    let pool_path = create_dbus_pool(dbus_context, object_path.clone(), pool_uuid, pool);
+    for (_, fs_uuid, fs) in pool.filesystems_mut() {
+        create_dbus_filesystem(dbus_context, pool_path.clone(), fs_uuid, fs);
     }
-    for (dev_uuid, _) in pool.blockdevs() {
-        create_dbus_blockdev(dbus_context, pool_path.clone(), dev_uuid);
+    for (uuid, bd) in pool.blockdevs_mut() {
+        create_dbus_blockdev(dbus_context, pool_path.clone(), uuid, bd);
     }
 }
 
@@ -232,7 +232,7 @@ pub fn register_pool(
     dbus_context: &DbusContext,
     tree: &mut Tree<MTFn<TData>, TData>,
     pool_uuid: Uuid,
-    pool: &Pool,
+    pool: &mut Pool,
     object_path: &dbus::Path<'static>,
 ) -> Result<(), dbus::Error> {
     register_pool_dbus(dbus_context, pool_uuid, pool, object_path);

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -24,6 +24,7 @@ pub fn create_dbus_blockdev<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
     uuid: Uuid,
+    blockdev: &mut BlockDev,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
@@ -104,6 +105,7 @@ pub fn create_dbus_blockdev<'a>(
 
     let path = object_path.get_name().to_owned();
     dbus_context.actions.borrow_mut().push_add(object_path);
+    blockdev.set_dbus_path(path.clone());
     path
 }
 

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -24,6 +24,7 @@ pub fn create_dbus_filesystem<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
     uuid: Uuid,
+    filesystem: &mut Filesystem,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
@@ -74,6 +75,7 @@ pub fn create_dbus_filesystem<'a>(
 
     let path = object_path.get_name().to_owned();
     dbus_context.actions.borrow_mut().push_add(object_path);
+    filesystem.set_dbus_path(path.clone());
     path
 }
 

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -24,6 +27,8 @@ pub struct SimDev {
     user_info: Option<String>,
     hardware_info: Option<String>,
     initialization_time: u64,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl BlockDev for SimDev {
@@ -50,6 +55,16 @@ impl BlockDev for SimDev {
     fn state(&self) -> BlockDevState {
         BlockDevState::InUse
     }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
+    }
 }
 
 impl SimDev {
@@ -63,6 +78,8 @@ impl SimDev {
                 user_info: None,
                 hardware_info: None,
                 initialization_time: Utc::now().timestamp() as u64,
+                #[cfg(feature = "dbus_enabled")]
+                dbus_path: None,
             },
         )
     }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -121,6 +121,13 @@ impl Engine for SimEngine {
             .collect()
     }
 
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)> {
+        self.pools
+            .iter_mut()
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut Pool))
+            .collect()
+    }
+
     fn get_eventable(&self) -> Option<&'static Eventable> {
         None
     }

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use rand;
 
 use std::path::PathBuf;
@@ -11,12 +14,16 @@ use super::super::engine::Filesystem;
 #[derive(Debug)]
 pub struct SimFilesystem {
     rand: u32,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl SimFilesystem {
     pub fn new() -> SimFilesystem {
         SimFilesystem {
             rand: rand::random::<u32>(),
+            #[cfg(feature = "dbus_enabled")]
+            dbus_path: None,
         }
     }
 }
@@ -26,5 +33,15 @@ impl Filesystem for SimFilesystem {
         ["/dev/stratis", &format!("random-{}", self.rand)]
             .into_iter()
             .collect()
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
     }
 }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::cell::RefCell;
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet};
@@ -33,6 +36,8 @@ pub struct SimPool {
     filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl SimPool {
@@ -51,6 +56,8 @@ impl SimPool {
                 filesystems: Table::default(),
                 redundancy,
                 rdm: Rc::clone(rdm),
+                #[cfg(feature = "dbus_enabled")]
+                dbus_path: None,
             },
         )
     }
@@ -59,7 +66,7 @@ impl SimPool {
         !self.filesystems.is_empty()
     }
 
-    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut SimDev)> {
+    fn get_mut_blockdev_internal(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut SimDev)> {
         let cache_devs = &mut self.cache_devs;
         self.block_devs
             .get_mut(&uuid)
@@ -168,7 +175,7 @@ impl Pool for SimPool {
         _pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<FilesystemUuid> {
+    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)> {
         let uuid = Uuid::new_v4();
         let snapshot = match self.get_filesystem(origin_uuid) {
             Some(_filesystem) => SimFilesystem::new(),
@@ -181,7 +188,13 @@ impl Pool for SimPool {
         };
         self.filesystems
             .insert(Name::new(snapshot_name.to_owned()), uuid, snapshot);
-        Ok(uuid)
+        Ok((
+            uuid,
+            self.filesystems
+                .get_mut_by_uuid(uuid)
+                .expect("just inserted")
+                .1,
+        ))
     }
 
     fn total_physical_size(&self) -> Sectors {
@@ -198,6 +211,13 @@ impl Pool for SimPool {
         self.filesystems
             .iter()
             .map(|(name, uuid, x)| (name.clone(), *uuid, x as &Filesystem))
+            .collect()
+    }
+
+    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)> {
+        self.filesystems
+            .iter_mut()
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &mut Filesystem))
             .collect()
     }
 
@@ -221,6 +241,14 @@ impl Pool for SimPool {
             .collect()
     }
 
+    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut BlockDev)> {
+        self.block_devs
+            .iter_mut()
+            .chain(self.cache_devs.iter_mut().into_iter())
+            .map(|(uuid, b)| (uuid.clone(), b as &mut BlockDev))
+            .collect()
+    }
+
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)> {
         self.block_devs
             .get(&uuid)
@@ -232,13 +260,18 @@ impl Pool for SimPool {
             })
     }
 
+    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut BlockDev)> {
+        self.get_mut_blockdev_internal(uuid)
+            .map(|(tier, bd)| (tier, bd as &mut BlockDev))
+    }
+
     fn set_blockdev_user_info(
         &mut self,
         _pool_name: &str,
         uuid: DevUuid,
         user_info: Option<&str>,
     ) -> StratisResult<bool> {
-        self.get_mut_blockdev(uuid).map_or_else(
+        self.get_mut_blockdev_internal(uuid).map_or_else(
             || {
                 Err(StratisError::Engine(
                     ErrorEnum::NotFound,
@@ -247,6 +280,16 @@ impl Pool for SimPool {
             },
             |(_, b)| Ok(b.set_user_info(user_info)),
         )
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
     }
 }
 

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -226,6 +226,17 @@ impl Backstore {
         }
     }
 
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        match self.cache_tier {
+            Some(ref mut cache) => cache
+                .blockdevs_mut()
+                .into_iter()
+                .chain(self.data_tier.blockdevs_mut().into_iter())
+                .collect(),
+            None => self.data_tier.blockdevs_mut(),
+        }
+    }
+
     /// The current capacity of all the blockdevs in the data tier.
     pub fn datatier_current_capacity(&self) -> Sectors {
         self.data_tier.current_capacity()
@@ -300,7 +311,7 @@ impl Backstore {
     }
 
     /// Lookup a mutable blockdev by its Stratis UUID.
-    fn get_mut_blockdev_by_uuid(
+    pub fn get_mut_blockdev_by_uuid(
         &mut self,
         uuid: DevUuid,
     ) -> Option<(BlockDevTier, &mut StratBlockDev)> {

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -4,6 +4,9 @@
 
 // Code to handle a single block device.
 
+#[cfg(feature = "dbus_enabled")]
+use dbus;
+
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 
@@ -29,6 +32,8 @@ pub struct StratBlockDev {
     used: RangeAllocator,
     user_info: Option<String>,
     hardware_info: Option<String>,
+    #[cfg(feature = "dbus_enabled")]
+    dbus_path: Option<dbus::Path<'static>>,
 }
 
 impl StratBlockDev {
@@ -66,6 +71,8 @@ impl StratBlockDev {
             used: allocator,
             user_info,
             hardware_info,
+            #[cfg(feature = "dbus_enabled")]
+            dbus_path: None,
         })
     }
 
@@ -170,6 +177,16 @@ impl BlockDev for StratBlockDev {
     fn state(&self) -> BlockDevState {
         // TODO: Implement states for blockdevs
         BlockDevState::InUse
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
+        self.dbus_path = Some(path)
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+        &self.dbus_path
     }
 }
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -304,6 +304,13 @@ impl BlockDevMgr {
         self.block_devs.iter().map(|bd| (bd.uuid(), bd)).collect()
     }
 
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        self.block_devs
+            .iter_mut()
+            .map(|bd| (bd.uuid(), bd as &mut StratBlockDev))
+            .collect()
+    }
+
     pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<&StratBlockDev> {
         self.block_devs.iter().find(|bd| bd.uuid() == uuid)
     }

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -229,6 +229,10 @@ impl CacheTier {
         self.block_mgr.blockdevs()
     }
 
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        self.block_mgr.blockdevs_mut()
+    }
+
     /// Lookup an immutable blockdev by its Stratis UUID.
     pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<(BlockDevTier, &StratBlockDev)> {
         self.block_mgr

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -213,6 +213,10 @@ impl DataTier {
         self.block_mgr.blockdevs()
     }
 
+    pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut StratBlockDev)> {
+        self.block_mgr.blockdevs_mut()
+    }
+
     /// Assert things that should always hold true of a DataTier
     #[allow(dead_code)]
     fn invariant(&self) -> () {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -281,6 +281,13 @@ impl Engine for StratEngine {
             .collect()
     }
 
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)> {
+        self.pools
+            .iter_mut()
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut Pool))
+            .collect()
+    }
+
     fn get_eventable(&self) -> Option<&'static Eventable> {
         Some(get_dm())
     }


### PR DESCRIPTION
Update the dbus_api layer to set the object path for Pool, Filesystem and BlockDev.

This is a step towards #959 and assoicated alerts.