### PR TITLE
Do not suspend filesystems ourselves when suspending the thinpool

### DIFF
--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -215,11 +215,13 @@ impl StratFilesystem {
         }
     }
 
+    #[allow(dead_code)]
     pub fn suspend(&mut self, flush: bool) -> StratisResult<()> {
         self.thin_dev.suspend(get_dm(), flush)?;
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn resume(&mut self) -> StratisResult<()> {
         self.thin_dev.resume(get_dm())?;
         Ok(())

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -702,9 +702,7 @@ impl ThinPool {
 
     /// Suspend the thinpool
     pub fn suspend(&mut self) -> StratisResult<()> {
-        for (_, _, fs) in &mut self.filesystems {
-            fs.suspend(false)?;
-        }
+        // thindevs automatically suspended when thinpool is suspended
         self.thin_pool.suspend(get_dm(), true)?;
         self.mdv.suspend()?;
         Ok(())
@@ -713,10 +711,8 @@ impl ThinPool {
     /// Resume the thinpool
     pub fn resume(&mut self) -> StratisResult<()> {
         self.mdv.resume()?;
+        // thindevs automatically resumed here
         self.thin_pool.resume(get_dm())?;
-        for (_, _, fs) in &mut self.filesystems {
-            fs.resume()?;
-        }
         Ok(())
     }
 


### PR DESCRIPTION
It turns out the kernel already does this when the thinpool is suspended,
so us doing it is redundant.

Signed-off-by: Andy Grover <agrover@redhat.com>