### PR TITLE
Dbus: Add "Mounts" property for filesystem

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -30,6 +30,10 @@ pub trait Filesystem: Debug {
     /// Get dbus path associated with the Pool.
     #[cfg(feature = "dbus_enabled")]
     fn get_dbus_path(&self) -> &Option<dbus::Path<'static>>;
+
+    /// Get the filesystem mount points
+    #[cfg(feature = "dbus_enabled")]
+    fn get_mount_points(&self) -> StratisResult<Vec<String>>;
 }
 
 pub trait BlockDev: Debug {

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -9,6 +9,9 @@ use rand;
 
 use std::path::PathBuf;
 
+#[cfg(feature = "dbus_enabled")]
+use stratis::StratisResult;
+
 use super::super::engine::Filesystem;
 
 #[derive(Debug)]
@@ -43,5 +46,11 @@ impl Filesystem for SimFilesystem {
     #[cfg(feature = "dbus_enabled")]
     fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
         &self.dbus_path
+    }
+
+    #[cfg(feature = "dbus_enabled")]
+    fn get_mount_points(&self) -> StratisResult<Vec<String>> {
+        let rc: Vec<String> = Vec::new();
+        Ok(rc)
     }
 }


### PR DESCRIPTION
Property "Mounts" will return an array of strings which are the
current mounts points of the filesystem.

Fixes: https://github.com/stratis-storage/stratisd/issues/501

**Note:  I'm not sure how useful this will be in some contexts as we are using `/proc/self/mounts`.  If a client process is running in the chroot environment, it will have a different view of mounted file systems than what is returned.  Could this be considered a security concern?**

Signed-off-by: Tony Asleson <tasleson@redhat.com>