### PR TITLE
Add/change properties to D-Bus filesystem interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,21 @@ language: rust
 
 matrix:
     include:
+        # Verify formatting of Rust code
         - rust: stable
           env: TASK=fmt-travis TARGET=x86_64-unknown-linux-gnu
+        # Verify that source builds with standard defaults
         - rust: stable
           env: TASK=build TARGET=x86_64-unknown-linux-gnu
+        # Verify that source builds with no defaults enabled
         - rust: stable
           env: TASK=build-no-default TARGET=x86_64-unknown-linux-gnu
+        # Verify that source builds with rustc 1.25
         - rust: stable
           env: TASK=build TARGET=x86_64-unknown-linux-gnu
           install:
             - rustup default 1.25.0
+        # Verify that source builds on a 32 bit system
         - rust: stable
           env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
           install:
@@ -31,21 +36,27 @@ matrix:
             - sudo dpkg --add-architecture i386
             - sudo apt-get update
             - sudo apt-get install -y gcc-multilib libdbus-1-dev:i386 libdbus-glib-1-dev:i386 libglib2.0-dev:i386 libudev-dev:i386
+        # Verify that docs build
         - rust: stable
           env: TASK=docs-travis TARGET=x86_64-unknown-linux-gnu
+        # Run non-destructive tests
         - rust: stable
           env: TASK=test TARGET=x86_64-unknown-linux-gnu
+        # Run destructive tests that can be run on Travis
         - rust: stable
           env: TASK=test-travis TARGET=x86_64-unknown-linux-gnu
           sudo: required
+        # Run clippy, Rust linter, on src tree only
         - rust: nightly
           env: TASK=clippy TARGET=x86_64-unknown-linux-gnu
+        # Run pylint, Python linter, on any Python test code
         - language: python
           python: "3.4"
           install: pip3 install -r tests/client-dbus/requirements.txt
           before_script:
               - cd tests/client-dbus
           env: TASK=lint
+        # Format any Python test code using yapf
         - language: python
           python: "3.4"
           install: pip3 install -r tests/client-dbus/requirements.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,10 +75,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.0"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -273,7 +274,7 @@ name = "libstratis"
 version = "0.5.5"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -393,35 +394,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "num-integer"
-version = "0.1.35"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-traits"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -746,7 +733,7 @@ dependencies = [
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
+"checksum chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e48d85528df61dc964aa43c5f6ca681a19cfa74939b2348d204bd08a981f2fb0"
 "checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
 "checksum crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc1914fae6f18ae347320f0ba5e4fc270e17c037ea621fe41ec7e8adf67d11b0"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
@@ -781,10 +768,9 @@ dependencies = [
 "checksum newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 "checksum nix 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
-"checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
-"checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
-"checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
+"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13f4460d3daa06eb1c4b9a3c55dffe65cb030dd70cf1bfdd482532f48ab24f74"

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -224,6 +224,7 @@ fn get_filesystem_created(
     })
 }
 
+/// Get the number of bytes used for any purpose on the filesystem
 fn get_filesystem_used(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,
@@ -235,6 +236,7 @@ fn get_filesystem_used(
     })
 }
 
+/// Get all filesystem mount points
 fn get_filesystem_mount_points(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -230,7 +230,7 @@ fn get_filesystem_used(
 ) -> Result<(), MethodErr> {
     get_filesystem_property(i, p, |(_, _, fs)| {
         fs.used()
-            .map(|v| format!("{}", *v))
+            .map(|v| v.to_string())
             .map_err(|_| MethodErr::failed(&"fs used() engine call failed".to_owned()))
     })
 }

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -231,7 +231,7 @@ fn get_filesystem_used(
 ) -> Result<(), MethodErr> {
     get_filesystem_property(i, p, |(_, _, fs)| {
         fs.used()
-            .map(|v| v.to_string())
+            .map(|v| (*v).to_string())
             .map_err(|_| MethodErr::failed(&"fs used() engine call failed".to_owned()))
     })
 }

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -202,7 +202,7 @@ fn get_filesystem_devnode(
     get_filesystem_property(i, p, |(pool_name, fs_name, _)| {
         Ok(format!(
             "{}",
-            devpath_from_names(&pool_name, &fs_name).display()
+            devpath_from_names(pool_name, fs_name).display()
         ))
     })
 }

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -12,7 +12,7 @@ use dbus::Message;
 
 use uuid::Uuid;
 
-use super::super::engine::{devpath_from_names, Filesystem, Name, RenameAction};
+use super::super::engine::{filesystem_mount_path, Filesystem, Name, RenameAction};
 
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
@@ -202,7 +202,7 @@ fn get_filesystem_devnode(
     get_filesystem_property(i, p, |(pool_name, fs_name, _)| {
         Ok(format!(
             "{}",
-            devpath_from_names(pool_name, fs_name).display()
+            filesystem_mount_path(pool_name, fs_name).display()
         ))
     })
 }

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -117,6 +117,10 @@ pub fn filesystem_renamed(pool_name: &str, old_name: &str, new_name: &str) -> St
     Ok(())
 }
 
+/// Given a pool name and a filesystem name, return the path it should be
+/// available as a device for mounting.
 pub fn devpath_from_names<T: AsRef<str>>(pool_name: T, fs_name: T) -> PathBuf {
-    vec![DEV_PATH, pool_name.as_ref(), fs_name.as_ref()].iter().collect()
+    vec![DEV_PATH, pool_name.as_ref(), fs_name.as_ref()]
+        .iter()
+        .collect()
 }

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -44,7 +44,7 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(
             pool_added(pool_name)?;
         }
 
-        let pool_path: PathBuf = vec![DEV_PATH, pool_name].iter().collect();
+        let pool_path = pool_directory(pool_name);
 
         let mut existing_files = fs::read_dir(pool_path)?
             .map(|dir_e| {
@@ -71,22 +71,22 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(
 
 /// Create a directory when a pool is added.
 pub fn pool_added(pool: &str) -> StratisResult<()> {
-    let p: PathBuf = vec![DEV_PATH, pool].iter().collect();
+    let p = pool_directory(pool);
     fs::create_dir(&p)?;
     Ok(())
 }
 
 /// Remove the directory and its contents when the pool is removed.
 pub fn pool_removed(pool: &str) -> StratisResult<()> {
-    let p: PathBuf = vec![DEV_PATH, pool].iter().collect();
+    let p = pool_directory(pool);
     fs::remove_dir_all(&p)?;
     Ok(())
 }
 
 /// Rename the directory to match the pool's new name.
 pub fn pool_renamed(old_name: &str, new_name: &str) -> StratisResult<()> {
-    let old: PathBuf = vec![DEV_PATH, old_name].iter().collect();
-    let new: PathBuf = vec![DEV_PATH, new_name].iter().collect();
+    let old = pool_directory(old_name);
+    let new = pool_directory(new_name);
     fs::rename(&old, &new)?;
     Ok(())
 }
@@ -115,6 +115,12 @@ pub fn filesystem_renamed(pool_name: &str, old_name: &str, new_name: &str) -> St
     let new = filesystem_mount_path(pool_name, new_name);
     fs::rename(&old, &new)?;
     Ok(())
+}
+
+/// Given a pool name, synthesize a pool directory name for storing filesystem
+/// mount paths.
+fn pool_directory<T: AsRef<str>>(pool_name: T) -> PathBuf {
+    vec![DEV_PATH, pool_name.as_ref()].iter().collect()
 }
 
 /// Given a pool name and a filesystem name, return the path it should be

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -11,7 +11,7 @@ use std::{fs, str};
 use stratis::StratisResult;
 
 use super::super::engine::Pool;
-use super::super::types::{Name, PoolUuid};
+use super::types::{Name, PoolUuid};
 
 use super::engine::DEV_PATH;
 
@@ -115,4 +115,8 @@ pub fn filesystem_renamed(pool_name: &str, old_name: &str, new_name: &str) -> St
     let new: PathBuf = vec![DEV_PATH, pool_name, new_name].iter().collect();
     fs::rename(&old, &new)?;
     Ok(())
+}
+
+pub fn devpath_from_names(pool_name: &Name, fs_name: &Name) -> PathBuf {
+    vec![DEV_PATH, pool_name, fs_name].iter().collect()
 }

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -94,7 +94,7 @@ pub fn pool_renamed(old_name: &str, new_name: &str) -> StratisResult<()> {
 /// Create a symlink to the new filesystem's block device within its pool's
 /// directory.
 pub fn filesystem_added(pool_name: &str, fs_name: &str, devnode: &Path) -> StratisResult<()> {
-    let p = devpath_from_names(pool_name, fs_name);
+    let p = filesystem_mount_path(pool_name, fs_name);
 
     // Remove existing and recreate to ensure it points to the correct devnode
     let _ = fs::remove_file(&p);
@@ -104,22 +104,22 @@ pub fn filesystem_added(pool_name: &str, fs_name: &str, devnode: &Path) -> Strat
 
 /// Remove the symlink when the filesystem is destroyed.
 pub fn filesystem_removed(pool_name: &str, fs_name: &str) -> StratisResult<()> {
-    let p = devpath_from_names(pool_name, fs_name);
+    let p = filesystem_mount_path(pool_name, fs_name);
     fs::remove_file(&p)?;
     Ok(())
 }
 
 /// Rename the symlink to track the filesystem's new name.
 pub fn filesystem_renamed(pool_name: &str, old_name: &str, new_name: &str) -> StratisResult<()> {
-    let old = devpath_from_names(pool_name, old_name);
-    let new = devpath_from_names(pool_name, new_name);
+    let old = filesystem_mount_path(pool_name, old_name);
+    let new = filesystem_mount_path(pool_name, new_name);
     fs::rename(&old, &new)?;
     Ok(())
 }
 
 /// Given a pool name and a filesystem name, return the path it should be
 /// available as a device for mounting.
-pub fn devpath_from_names<T: AsRef<str>>(pool_name: T, fs_name: T) -> PathBuf {
+pub fn filesystem_mount_path<T: AsRef<str>>(pool_name: T, fs_name: T) -> PathBuf {
     vec![DEV_PATH, pool_name.as_ref(), fs_name.as_ref()]
         .iter()
         .collect()

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -94,7 +94,7 @@ pub fn pool_renamed(old_name: &str, new_name: &str) -> StratisResult<()> {
 /// Create a symlink to the new filesystem's block device within its pool's
 /// directory.
 pub fn filesystem_added(pool_name: &str, fs_name: &str, devnode: &Path) -> StratisResult<()> {
-    let p: PathBuf = vec![DEV_PATH, pool_name, fs_name].iter().collect();
+    let p = devpath_from_names(pool_name, fs_name);
 
     // Remove existing and recreate to ensure it points to the correct devnode
     let _ = fs::remove_file(&p);
@@ -104,19 +104,19 @@ pub fn filesystem_added(pool_name: &str, fs_name: &str, devnode: &Path) -> Strat
 
 /// Remove the symlink when the filesystem is destroyed.
 pub fn filesystem_removed(pool_name: &str, fs_name: &str) -> StratisResult<()> {
-    let p: PathBuf = vec![DEV_PATH, pool_name, fs_name].iter().collect();
+    let p = devpath_from_names(pool_name, fs_name);
     fs::remove_file(&p)?;
     Ok(())
 }
 
 /// Rename the symlink to track the filesystem's new name.
 pub fn filesystem_renamed(pool_name: &str, old_name: &str, new_name: &str) -> StratisResult<()> {
-    let old: PathBuf = vec![DEV_PATH, pool_name, old_name].iter().collect();
-    let new: PathBuf = vec![DEV_PATH, pool_name, new_name].iter().collect();
+    let old = devpath_from_names(pool_name, old_name);
+    let new = devpath_from_names(pool_name, new_name);
     fs::rename(&old, &new)?;
     Ok(())
 }
 
-pub fn devpath_from_names(pool_name: &Name, fs_name: &Name) -> PathBuf {
-    vec![DEV_PATH, pool_name, fs_name].iter().collect()
+pub fn devpath_from_names<T: AsRef<str>>(pool_name: T, fs_name: T) -> PathBuf {
+    vec![DEV_PATH, pool_name.as_ref(), fs_name.as_ref()].iter().collect()
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -12,16 +12,27 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use devicemapper::{Device, Sectors};
+use devicemapper::{Bytes, Device, Sectors};
 
 use super::types::{
     BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, Name, PoolUuid, RenameAction,
 };
 use stratis::StratisResult;
 
+pub const DEV_PATH: &str = "/dev/stratis";
+
 pub trait Filesystem: Debug {
     /// path of the device node
     fn devnode(&self) -> PathBuf;
+
+    /// When the filesystem was created.
+    fn created(&self) -> DateTime<Utc>;
+
+    /// The amount of data stored on the filesystem, including overhead.
+    fn used(&self) -> StratisResult<Bytes>;
+
+    /// Get the mount_point(s) for the file system.
+    fn mount_points(&self) -> StratisResult<Vec<PathBuf>>;
 
     /// Set dbus path associated with the Pool.
     #[cfg(feature = "dbus_enabled")]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,6 +4,8 @@
 
 pub use devicemapper::{IEC, SECTOR_SIZE};
 
+pub use self::devlinks::devpath_from_names;
+
 pub use self::engine::BlockDev;
 pub use self::engine::Engine;
 pub use self::engine::Filesystem;
@@ -24,6 +26,7 @@ pub use self::types::RenameAction;
 #[macro_use]
 mod macros;
 
+mod devlinks;
 #[allow(module_inception)]
 mod engine;
 mod sim_engine;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,7 +4,7 @@
 
 pub use devicemapper::{IEC, SECTOR_SIZE};
 
-pub use self::devlinks::devpath_from_names;
+pub use self::devlinks::filesystem_mount_path;
 
 pub use self::engine::BlockDev;
 pub use self::engine::Engine;

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use chrono::{DateTime, Utc};
 #[cfg(feature = "dbus_enabled")]
 use dbus;
 
@@ -9,11 +10,16 @@ use rand;
 
 use std::path::PathBuf;
 
+use devicemapper::Bytes;
+
 use super::super::engine::Filesystem;
+
+use stratis::StratisResult;
 
 #[derive(Debug)]
 pub struct SimFilesystem {
     rand: u32,
+    created: DateTime<Utc>,
     #[cfg(feature = "dbus_enabled")]
     dbus_path: Option<dbus::Path<'static>>,
 }
@@ -22,6 +28,7 @@ impl SimFilesystem {
     pub fn new() -> SimFilesystem {
         SimFilesystem {
             rand: rand::random::<u32>(),
+            created: Utc::now(),
             #[cfg(feature = "dbus_enabled")]
             dbus_path: None,
         }
@@ -33,6 +40,18 @@ impl Filesystem for SimFilesystem {
         ["/dev/stratis", &format!("random-{}", self.rand)]
             .into_iter()
             .collect()
+    }
+
+    fn created(&self) -> DateTime<Utc> {
+        self.created
+    }
+
+    fn used(&self) -> StratisResult<Bytes> {
+        Ok(Bytes(12345678))
+    }
+
+    fn mount_points(&self) -> StratisResult<Vec<PathBuf>> {
+        Ok(Vec::new())
     }
 
     #[cfg(feature = "dbus_enabled")]

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -4,6 +4,7 @@
 
 // Code to handle the backing store of a pool.
 
+use std::cmp;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -193,16 +194,21 @@ impl Backstore {
         }
     }
 
-    /// Allocate requested chunks from device.
-    /// Returns None if it is not possible to satisfy the request.
-    /// Each segment allocated is contiguous with its neighbors in the return
-    /// vector.
+    /// Satisfy a request for multiple segments. This request must
+    /// always be satisfied exactly, None is returned if this can not
+    /// be done.
+    ///
     /// Precondition: self.next <= self.size()
     /// Postcondition: self.next <= self.size()
-    /// WARNING: All this must change when it becomes possible to return
-    /// sectors to the store.
+    ///
+    /// Postcondition: forall i, sizes_i == result_i.1. The second value
+    /// in each pair in the returned vector is therefore redundant, but is
+    /// retained as a convenience to the caller.
+    /// Postcondition:
+    /// forall i, result_i.0 = result_(i - 1).0 + result_(i - 1).1
+    ///
     /// WARNING: metadata changing event
-    pub fn alloc_space(&mut self, sizes: &[Sectors]) -> Option<Vec<(Sectors, Sectors)>> {
+    pub fn alloc(&mut self, sizes: &[Sectors]) -> Option<Vec<(Sectors, Sectors)>> {
         if self.available() < sizes.iter().cloned().sum() {
             return None;
         }
@@ -212,7 +218,46 @@ impl Backstore {
             chunks.push((self.next, *size));
             self.next += *size;
         }
+
+        // Assert that the postcondition holds.
+        assert_eq!(
+            sizes,
+            chunks
+                .iter()
+                .map(|x| x.1)
+                .collect::<Vec<Sectors>>()
+                .as_slice()
+        );
+
         Some(chunks)
+    }
+
+    /// Allocate a single segment from the backstore.
+    /// If it is impossible to allocate the requested amount, try
+    /// something smaller. If it is impossible to allocate any amount
+    /// greater than 0, return None. Only allocate amounts that are divisible
+    /// by modulus.
+    ///
+    /// Precondition: self.next <= self.size()
+    /// Postcondition: self.next <= self.size()
+    ///
+    /// Postcondition: result.1 % modulus == 0
+    /// Postcondition: result.1 <= request
+    ///
+    /// WARNING: metadata changing event
+    pub fn request(&mut self, request: Sectors, modulus: Sectors) -> Option<(Sectors, Sectors)> {
+        assert!(modulus != Sectors(0));
+
+        let internal_request = cmp::min(request, self.available());
+        let internal_request = (internal_request / modulus) * modulus;
+
+        if internal_request != Sectors(0) {
+            let result = (self.next, internal_request);
+            self.next += internal_request;
+            Some(result)
+        } else {
+            None
+        }
     }
 
     /// Return a reference to all the blockdevs that this pool has ownership
@@ -522,6 +567,52 @@ mod tests {
             loopbacked::DeviceLimits::Range(4, 5, None),
             test_add_cache_devs,
         );
+    }
+
+    /// Create a backstore.
+    /// Request a amount that can not be allocated because the modulus is
+    /// bigger than the reqested amount.
+    /// Request an impossibly large amount.
+    /// Verify that the backstore is now all used up.
+    fn test_request(paths: &[&Path]) -> () {
+        assert!(paths.len() > 0);
+
+        let mut backstore =
+            Backstore::initialize(Uuid::new_v4(), paths, MIN_MDA_SECTORS, false).unwrap();
+
+        assert!(
+            backstore
+                .request(Sectors(IEC::Ki), Sectors(IEC::Mi))
+                .is_none()
+        );
+
+        let request = Sectors(IEC::Ei);
+        let modulus = Sectors(IEC::Ki);
+        let old_next = backstore.next;
+        let (start, length) = backstore.request(request, modulus).unwrap();
+        assert!(length < request);
+        // FIXME: change to Sector operation once implemented in devicemapper
+        assert_eq!(*length % *modulus, 0);
+        assert_eq!(backstore.next, old_next + length);
+        assert_eq!(start, old_next);
+
+        assert!(backstore.request(request, Sectors(IEC::Ki)).is_none());
+        backstore.destroy().unwrap();
+    }
+
+    #[test]
+    pub fn loop_test_request() {
+        loopbacked::test_with_spec(loopbacked::DeviceLimits::Range(1, 3, None), test_request);
+    }
+
+    #[test]
+    pub fn real_test_request() {
+        real::test_with_spec(real::DeviceLimits::AtLeast(1, None, None), test_request);
+    }
+
+    #[test]
+    pub fn travis_test_request() {
+        loopbacked::test_with_spec(loopbacked::DeviceLimits::Range(1, 3, None), test_request);
     }
 
     /// Create a backstore with a cache.

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -9,6 +9,7 @@ use devicemapper::{Device, DmNameBuf};
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
+use super::super::devlinks;
 use super::super::engine::{Engine, Eventable, Pool};
 use super::super::structures::Table;
 use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
@@ -18,11 +19,9 @@ use super::backstore::{find_all, get_metadata};
 #[cfg(test)]
 use super::cleanup::teardown_pools;
 use super::cmd::verify_binaries;
-use super::devlinks;
 use super::dm::{get_dm, get_dm_init};
 use super::pool::{check_metadata, StratPool};
 
-pub const DEV_PATH: &str = "/dev/stratis";
 const REQUIRED_DM_MINOR_VERSION: u32 = 37;
 
 /// Setup a pool from constituent devices in the context of some already
@@ -321,6 +320,8 @@ impl Engine for StratEngine {
 #[cfg(test)]
 mod test {
     use std::fs::remove_dir_all;
+
+    use engine::engine::DEV_PATH;
 
     use super::super::tests::{loopbacked, real};
 

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -7,7 +7,6 @@ mod backstore;
 mod cleanup;
 mod cmd;
 mod device;
-mod devlinks;
 mod dm;
 mod dmnames;
 mod engine;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -412,11 +412,11 @@ mod tests {
     use nix::mount::{mount, umount, MsFlags};
     use tempfile;
 
+    use super::super::super::devlinks;
     use super::super::super::types::Redundancy;
 
     use super::super::backstore::{find_all, get_metadata};
     use super::super::cmd;
-    use super::super::devlinks;
     use super::super::tests::{loopbacked, real};
 
     use super::*;

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -49,6 +49,7 @@ pub struct FilesystemSave {
     pub uuid: FilesystemUuid,
     pub thin_id: ThinDevId,
     pub size: Sectors,
+    pub created: u64, // Unix timestamp
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use chrono::{DateTime, TimeZone, Utc};
 #[cfg(feature = "dbus_enabled")]
 use dbus;
+use uuid::Uuid;
 
 use std::fs::File;
 use std::io::Read;
@@ -22,11 +24,14 @@ use tempfile;
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::engine::Filesystem;
-use super::super::super::types::{FilesystemUuid, Name};
+use super::super::super::types::{FilesystemUuid, Name, PoolUuid};
 
 use super::super::cmd::{create_fs, set_uuid, xfs_growfs};
 use super::super::dm::get_dm;
+use super::super::dmnames::{format_thin_ids, ThinRole};
 use super::super::serde_structs::FilesystemSave;
+
+const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
 /// TODO: confirm that 256 MiB leaves enough time for stratisd to respond and extend before
 /// the filesystem is out of space.
@@ -35,6 +40,7 @@ pub const FILESYSTEM_LOWATER: Sectors = Sectors(256 * IEC::Mi / (SECTOR_SIZE as 
 #[derive(Debug)]
 pub struct StratFilesystem {
     thin_dev: ThinDev,
+    created: DateTime<Utc>,
     #[cfg(feature = "dbus_enabled")]
     dbus_path: Option<dbus::Path<'static>>,
 }
@@ -48,20 +54,56 @@ pub enum FilesystemStatus {
 
 impl StratFilesystem {
     /// Create a StratFilesystem on top of the given ThinDev.
-    pub fn initialize(fs_id: FilesystemUuid, thin_dev: ThinDev) -> StratisResult<StratFilesystem> {
-        let fs = StratFilesystem::setup(thin_dev);
+    pub fn initialize(
+        pool_uuid: PoolUuid,
+        thinpool_dev: &ThinPoolDev,
+        size: Option<Sectors>,
+        id: ThinDevId,
+    ) -> StratisResult<(FilesystemUuid, StratFilesystem)> {
+        let fs_uuid = Uuid::new_v4();
+        let (dm_name, dm_uuid) = format_thin_ids(pool_uuid, ThinRole::Filesystem(fs_uuid));
+        let thin_dev = ThinDev::new(
+            get_dm(),
+            &dm_name,
+            Some(&dm_uuid),
+            size.unwrap_or(DEFAULT_THIN_DEV_SIZE),
+            thinpool_dev,
+            id,
+        )?;
 
-        create_fs(&fs.devnode(), fs_id)?;
-        Ok(fs)
+        create_fs(&thin_dev.devnode(), fs_uuid)?;
+        Ok((
+            fs_uuid,
+            StratFilesystem {
+                thin_dev,
+                created: Utc::now(),
+                #[cfg(feature = "dbus_enabled")]
+                dbus_path: None,
+            },
+        ))
     }
 
     /// Build a StratFilesystem that includes the ThinDev and related info.
-    pub fn setup(thin_dev: ThinDev) -> StratFilesystem {
-        StratFilesystem {
+    pub fn setup(
+        pool_uuid: PoolUuid,
+        thinpool_dev: &ThinPoolDev,
+        fssave: &FilesystemSave,
+    ) -> StratisResult<StratFilesystem> {
+        let (dm_name, dm_uuid) = format_thin_ids(pool_uuid, ThinRole::Filesystem(fssave.uuid));
+        let thin_dev = ThinDev::setup(
+            get_dm(),
+            &dm_name,
+            Some(&dm_uuid),
+            fssave.size,
+            &thinpool_dev,
+            fssave.thin_id,
+        )?;
+        Ok(StratFilesystem {
             thin_dev,
+            created: Utc.timestamp(fssave.created as i64, 0),
             #[cfg(feature = "dbus_enabled")]
             dbus_path: None,
-        }
+        })
     }
 
     /// Create a snapshot of the filesystem. Return the resulting filesystem/ThinDev
@@ -98,7 +140,7 @@ impl StratFilesystem {
                 //
                 // If the source is unmounted the XFS log will be clean so
                 // we can skip the mount/unmount.
-                if self.get_mount_point()?.is_some() {
+                if !self.mount_points()?.is_empty() {
                     let tmp_dir = tempfile::Builder::new().prefix("stratis_mp_").tempdir()?;
                     // Mount the snapshot with the "nouuid" option. mount
                     // will fail due to duplicate UUID otherwise.
@@ -113,7 +155,12 @@ impl StratFilesystem {
                 }
 
                 set_uuid(&thin_dev.devnode(), snapshot_fs_uuid)?;
-                Ok(StratFilesystem::setup(thin_dev))
+                Ok(StratFilesystem {
+                    thin_dev,
+                    created: Utc::now(),
+                    #[cfg(feature = "dbus_enabled")]
+                    dbus_path: None,
+                })
             }
             Err(e) => Err(StratisError::Engine(
                 ErrorEnum::Error,
@@ -130,7 +177,7 @@ impl StratFilesystem {
     pub fn check(&mut self) -> StratisResult<FilesystemStatus> {
         match self.thin_dev.status(get_dm())? {
             ThinStatus::Working(_) => {
-                if let Some(mount_point) = self.get_mount_point()? {
+                if let Some(mount_point) = self.mount_points()?.first() {
                     let (fs_total_bytes, fs_total_used_bytes) = fs_usage(&mount_point)?;
                     let free_bytes = fs_total_bytes - fs_total_used_bytes;
                     if free_bytes.sectors() < FILESYSTEM_LOWATER {
@@ -153,45 +200,11 @@ impl StratFilesystem {
         Ok(FilesystemStatus::Good)
     }
 
-    /// The thin id for the thin device that backs this filesystem.
-    #[cfg(test)]
-    pub fn thin_id(&self) -> ThinDevId {
-        self.thin_dev.id()
-    }
-
     /// Return an extend size for the thindev under the filesystem
     /// TODO: returning the current size will double the space provisioned to
     /// the thin device.  We should determine if this is a reasonable value.
     fn extend_size(&self, current_size: Sectors) -> Sectors {
         current_size
-    }
-
-    /// Get one (non-deterministic in the presence of errors) of the mount_point(s) for the file
-    /// system that is contained on the block device referred to as self.devnode(), i.e. the device
-    /// node, while ignoring parse errors as long as at least one mount point is found.
-    pub fn get_mount_point(&self) -> StratisResult<Option<PathBuf>> {
-        let major = u64::from(self.thin_dev.device().major);
-        let minor = u64::from(self.thin_dev.device().minor);
-
-        let mut mount_data = String::new();
-        File::open("/proc/self/mountinfo")?.read_to_string(&mut mount_data)?;
-        let parser = libmount::mountinfo::Parser::new(mount_data.as_bytes());
-
-        let mut last_error: Option<String> = None;
-        for mp in parser {
-            match mp {
-                Ok(mount) => {
-                    if mount.major as u64 == major && mount.minor as u64 == minor {
-                        return Ok(Some(PathBuf::from(mount.mount_point.into_owned())));
-                    }
-                }
-                Err(e) => {
-                    last_error = Some(format!("Error during parsing {:?} {:?}", *self, e));
-                }
-            }
-        }
-
-        last_error.map_or(Ok(None), |e| Err(StratisError::Engine(ErrorEnum::Error, e)))
     }
 
     /// Tear down the filesystem.
@@ -212,6 +225,7 @@ impl StratFilesystem {
             uuid,
             thin_id: self.thin_dev.id(),
             size: self.thin_dev.size(),
+            created: self.created.timestamp() as u64,
         }
     }
 
@@ -231,6 +245,56 @@ impl StratFilesystem {
 impl Filesystem for StratFilesystem {
     fn devnode(&self) -> PathBuf {
         self.thin_dev.devnode()
+    }
+
+    fn created(&self) -> DateTime<Utc> {
+        self.created
+    }
+
+    fn used(&self) -> StratisResult<Bytes> {
+        match self.mount_points()?.first() {
+            Some(mount_pt) => Ok(fs_usage(mount_pt)?.1),
+            None => {
+                let tmp_dir = tempfile::Builder::new().prefix("stratis_mp_").tempdir()?;
+                mount(
+                    Some(&self.devnode()),
+                    tmp_dir.path(),
+                    Some("xfs"),
+                    MsFlags::empty(),
+                    Some("nouuid"),
+                )?;
+                let used_result = fs_usage(tmp_dir.path());
+                umount(tmp_dir.path())?;
+                Ok(used_result?.1)
+            }
+        }
+    }
+
+    fn mount_points(&self) -> StratisResult<Vec<PathBuf>> {
+        // Use major:minor values to find mounts for this filesystem
+        let major = u64::from(self.thin_dev.device().major);
+        let minor = u64::from(self.thin_dev.device().minor);
+
+        let mut mount_data = String::new();
+        File::open("/proc/self/mountinfo")?.read_to_string(&mut mount_data)?;
+        let parser = libmount::mountinfo::Parser::new(mount_data.as_bytes());
+
+        let mut ret_vec = Vec::new();
+        for mp in parser {
+            match mp {
+                Ok(mount) => {
+                    if mount.major as u64 == major && mount.minor as u64 == minor {
+                        ret_vec.push(PathBuf::from(&mount.mount_point));
+                    }
+                }
+                Err(e) => {
+                    let error_msg = format!("Error during parsing {:?}: {:?}", *self, e);
+                    return Err(StratisError::Engine(ErrorEnum::Error, error_msg));
+                }
+            }
+        }
+
+        Ok(ret_vec)
     }
 
     #[cfg(feature = "dbus_enabled")]

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -18,11 +18,11 @@ use devicemapper::{DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
 
 use stratis::StratisResult;
 
+use super::super::super::engine::DEV_PATH;
 use super::super::super::types::{FilesystemUuid, Name, PoolUuid};
 
 use super::super::cmd::create_fs;
 use super::super::dm::get_dm;
-use super::super::engine::DEV_PATH;
 use super::super::serde_structs::FilesystemSave;
 
 use super::filesystem::StratFilesystem;

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -5,7 +5,6 @@
 // Code to handle management of a pool's thinpool device.
 
 use std::borrow::BorrowMut;
-use std::cmp;
 
 use uuid::Uuid;
 
@@ -169,7 +168,7 @@ impl ThinPool {
         data_block_size: Sectors,
         backstore: &mut Backstore,
     ) -> StratisResult<ThinPool> {
-        let mut segments_list = match backstore.alloc_space(&[
+        let mut segments_list = match backstore.alloc(&[
             thin_pool_size.meta_size(),
             thin_pool_size.meta_size(),
             thin_pool_size.data_size(),
@@ -353,6 +352,26 @@ impl ThinPool {
     /// metadata save has been made.
     pub fn check(&mut self, backstore: &mut Backstore) -> StratisResult<bool> {
         #![allow(match_same_arms)]
+
+        /// Calculate requested additional amount to allocate given total,
+        /// used, and low_water. Return None if there is no need to allocate
+        /// a new amount.
+        /// Postcondition: 2 * usage.used = usage.total - low_water AND
+        /// usage.total > low_water. In other words, usage can double before
+        /// it is necessary to expand again.
+        fn calculate_request(total: Sectors, used: Sectors, low_water: Sectors) -> Option<Sectors> {
+            if total >= low_water {
+                let excess = total - low_water;
+                if used >= excess {
+                    Some((used - excess) + used)
+                } else {
+                    None
+                }
+            } else {
+                Some((low_water - total) + 2usize * used)
+            }
+        }
+
         assert_eq!(backstore.device(), self.backstore_device);
 
         let mut should_save: bool = false;
@@ -373,35 +392,45 @@ impl ThinPool {
                     }
                 }
 
-                let usage = &status.usage;
-                if usage.used_meta > cmp::max(usage.total_meta, META_LOWATER) - META_LOWATER {
-                    // Request expansion of physical space allocated to the pool
-                    // meta device.
-                    // TODO: we just request that the space be doubled here.
-                    // A more sophisticated approach might be in order.
-                    let meta_extend_size = usage.total_meta;
-                    match self.extend_thinpool_meta(meta_extend_size, backstore) {
-                        #![allow(single_match)]
-                        Ok(_) => should_save = true,
-                        Err(_) => {} // TODO: Take pool offline?
-                    }
-                }
+                {
+                    let usage = &status.usage;
 
-                if usage.used_data > cmp::max(usage.total_data, DATA_LOWATER) - DATA_LOWATER {
-                    // Request expansion of physical space allocated to the pool
-                    // TODO: we request that the space be doubled or use the remaining space by
-                    // requesting the minimum total_data vs. available space.
-                    // A more sophisticated approach might be in order.
-                    match self.extend_thinpool(
-                        DataBlocks(cmp::min(
-                            *usage.total_data,
-                            backstore.available() / DATA_BLOCK_SIZE,
-                        )),
-                        backstore,
+                    if let Some(request) = calculate_request(
+                        usage.total_meta.sectors(),
+                        usage.used_meta.sectors(),
+                        META_LOWATER.sectors(),
                     ) {
-                        #![allow(single_match)]
-                        Ok(_) => should_save = true,
-                        Err(_) => {} // TODO: Take pool offline?
+                        match self.extend_thinpool(backstore, request, false) {
+                            Ok(actual) => {
+                                if request != actual {
+                                    // TODO: take an appropriate action in the
+                                    // case where actual amount allocated was
+                                    // less than the requested.
+                                }
+                                should_save = true;
+                            }
+                            // FIXME: Handle this error
+                            Err(_) => {}
+                        }
+                    }
+
+                    if let Some(request) = calculate_request(
+                        *usage.total_data * DATA_BLOCK_SIZE,
+                        *usage.used_data * DATA_BLOCK_SIZE,
+                        *DATA_LOWATER * DATA_BLOCK_SIZE,
+                    ) {
+                        match self.extend_thinpool(backstore, request, true) {
+                            Ok(actual) => {
+                                if request != actual {
+                                    // TODO: take an appropriate action in the
+                                    // case where actual amount allocated was
+                                    // less than the requested.
+                                }
+                                should_save = true;
+                            }
+                            // FIXME: Handle this error
+                            Err(_) => {}
+                        }
                     }
                 }
             }
@@ -441,74 +470,71 @@ impl ThinPool {
         Ok(())
     }
 
-    /// Expand the physical space allocated to a pool by extend_size.
-    /// Return the number of DataBlocks added.
-    // TODO: Refine this method. A hard fail if the request can not be
-    // satisfied may not be correct.
+    /// Extend the thinpool's data or meta devices. Attempt to allocate
+    /// extend_size, but if that fails, try smaller values until smallest
+    /// allocation chunk for meta or data device is reached.
+    /// Return the amount the device was extended by.
+    /// Always allocate sectors in increments of allocation chunk.
     fn extend_thinpool(
         &mut self,
-        extend_size: DataBlocks,
         backstore: &mut Backstore,
-    ) -> StratisResult<DataBlocks> {
+        extend_size: Sectors,
+        data: bool,
+    ) -> StratisResult<Sectors> {
+        /// Get the meta block size. It is stored internally in MetaBlocks as it
+        /// does not vary.
+        fn meta_block_size() -> Sectors {
+            Sectors(*INITIAL_META_SIZE.sectors() / *INITIAL_META_SIZE)
+        }
+
+        /// Extend the thinpool w/ a new data region if data is true, else a new
+        /// metadata region. There may be multiple segments, but they are all on
+        /// the same device. Returns an error if any of the devicemapper
+        /// operations fails.
+        fn extend(
+            thinpool: &mut ThinPool,
+            device: Device,
+            new_seg: (Sectors, Sectors),
+            data: bool,
+        ) -> StratisResult<()> {
+            thinpool.suspend()?;
+
+            if data {
+                let segments = coalesce_segs(&thinpool.data_segments, &[new_seg]);
+                thinpool
+                    .thin_pool
+                    .set_data_table(get_dm(), segs_to_table(device, &segments))?;
+                thinpool.thin_pool.resume(get_dm())?;
+                thinpool.data_segments = segments;
+            } else {
+                let segments = coalesce_segs(&thinpool.meta_segments, &[new_seg]);
+                thinpool
+                    .thin_pool
+                    .set_meta_table(get_dm(), segs_to_table(device, &segments))?;
+                thinpool.thin_pool.resume(get_dm())?;
+                thinpool.meta_segments = segments;
+            }
+
+            thinpool.resume()?;
+
+            Ok(())
+        }
+
         let backstore_device = self.backstore_device;
         assert_eq!(backstore.device(), backstore_device);
-        if let Some(mut regions) = backstore.alloc_space(&[*extend_size * DATA_BLOCK_SIZE]) {
-            self.suspend()?;
-            self.extend_data(backstore_device, regions.pop().expect("len(regions) == 1"))?;
-            self.resume()?;
+
+        let modulus = if data {
+            DATA_BLOCK_SIZE
         } else {
-            let err_msg = format!(
-                "Insufficient space to accommodate request for {}",
-                extend_size
-            );
-            return Err(StratisError::Engine(ErrorEnum::Error, err_msg));
-        }
-        Ok(extend_size)
-    }
-
-    /// Expand the physical space allocated to a pool meta by extend_size.
-    /// Return the number of MetaBlocks added.
-    fn extend_thinpool_meta(
-        &mut self,
-        extend_size: MetaBlocks,
-        backstore: &mut Backstore,
-    ) -> StratisResult<MetaBlocks> {
-        let backstore_device = self.backstore_device;
-        assert_eq!(backstore.device(), backstore_device);
-        if let Some(mut regions) = backstore.alloc_space(&[extend_size.sectors()]) {
-            self.suspend()?;
-            self.extend_meta(backstore_device, regions.pop().expect("len(regions) == 1"))?;
-            self.resume()?;
+            meta_block_size()
+        };
+        if let Some(region) = backstore.request(extend_size, modulus) {
+            extend(self, backstore_device, region, data)?;
+            Ok(region.1)
         } else {
-            let err_msg = format!(
-                "Insufficient space to accommodate request for {}",
-                extend_size
-            );
-            return Err(StratisError::Engine(ErrorEnum::Error, err_msg));
+            let err_msg = format!("Insufficient space to accommodate request for {}", modulus);
+            Err(StratisError::Engine(ErrorEnum::Error, err_msg))
         }
-        Ok(extend_size)
-    }
-
-    /// Extend the thinpool with a new data region.
-    fn extend_data(&mut self, device: Device, new_seg: (Sectors, Sectors)) -> StratisResult<()> {
-        let segments = coalesce_segs(&self.data_segments, &[new_seg]);
-        self.thin_pool
-            .set_data_table(get_dm(), segs_to_table(device, &segments))?;
-        self.thin_pool.resume(get_dm())?;
-        self.data_segments = segments;
-
-        Ok(())
-    }
-
-    /// Extend the thinpool meta device with an additional segment.
-    fn extend_meta(&mut self, device: Device, new_seg: (Sectors, Sectors)) -> StratisResult<()> {
-        let segments = coalesce_segs(&self.meta_segments, &[new_seg]);
-        self.thin_pool
-            .set_meta_table(get_dm(), segs_to_table(device, &segments))?;
-        self.thin_pool.resume(get_dm())?;
-        self.meta_segments = segments;
-
-        Ok(())
     }
 
     /// The number of physical sectors in use, that is, unavailable for storage
@@ -1034,7 +1060,7 @@ mod tests {
         // written above. If we attempt to update the UUID on the snapshot
         // without expanding the pool, the pool will go into out-of-data-space
         // (queue IO) mode, causing the test to fail.
-        pool.extend_thinpool(INITIAL_DATA_SIZE, &mut backstore)
+        pool.extend_thinpool(&mut backstore, *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE, true)
             .unwrap();
 
         let (_, snapshot_filesystem) =
@@ -1282,6 +1308,7 @@ mod tests {
             dm::ThinPoolStatus::Working(ref status) => {
                 let usage = &status.usage;
                 assert_eq!(usage.total_meta, small_meta_size);
+                assert!(usage.used_meta > MetaBlocks(0));
             }
             dm::ThinPoolStatus::Fail => panic!("thin_pool.status() failed"),
         }
@@ -1350,8 +1377,11 @@ mod tests {
                 // the amount of free space in pool has decreased to the
                 // DATA_LOWATER value.
                 if i == *(*(INITIAL_DATA_SIZE - DATA_LOWATER) * DATA_BLOCK_SIZE) {
-                    pool.extend_thinpool(INITIAL_DATA_SIZE, &mut backstore)
-                        .unwrap();
+                    pool.extend_thinpool(
+                        &mut backstore,
+                        *INITIAL_DATA_SIZE * DATA_BLOCK_SIZE,
+                        true,
+                    ).unwrap();
                 }
             }
         }

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -11,12 +11,13 @@ use uuid::Uuid;
 use devicemapper as dm;
 use devicemapper::{
     device_exists, DataBlocks, Device, DmDevice, DmName, DmNameBuf, FlakeyTargetParams, LinearDev,
-    LinearDevTargetParams, LinearTargetParams, MetaBlocks, Sectors, TargetLine, ThinDev, ThinDevId,
+    LinearDevTargetParams, LinearTargetParams, MetaBlocks, Sectors, TargetLine, ThinDevId,
     ThinPoolDev, ThinPoolStatusSummary, IEC,
 };
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
+use super::super::super::devlinks;
 use super::super::super::engine::Filesystem;
 use super::super::super::structures::Table;
 use super::super::super::types::{FilesystemUuid, Name, PoolUuid, RenameAction};
@@ -24,7 +25,6 @@ use super::super::super::types::{FilesystemUuid, Name, PoolUuid, RenameAction};
 use super::super::backstore::Backstore;
 use super::super::cmd::{thin_check, thin_repair};
 use super::super::device::wipe_sectors;
-use super::super::devlinks;
 use super::super::dm::get_dm;
 use super::super::dmnames::{
     format_flex_ids, format_thin_ids, format_thinpool_ids, FlexRole, ThinPoolRole, ThinRole,
@@ -38,8 +38,6 @@ use super::thinids::ThinDevIdPool;
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
 const DATA_LOWATER: DataBlocks = DataBlocks(512);
 const META_LOWATER: MetaBlocks = MetaBlocks(512);
-
-const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
 const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4 * IEC::Ki);
 pub const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);
@@ -306,21 +304,8 @@ impl ThinPool {
         let filesystems = filesystem_metadatas
             .iter()
             .map(|fssave| {
-                let (dm_name, dm_uuid) =
-                    format_thin_ids(pool_uuid, ThinRole::Filesystem(fssave.uuid));
-                let thin_dev = ThinDev::setup(
-                    get_dm(),
-                    &dm_name,
-                    Some(&dm_uuid),
-                    fssave.size,
-                    &thinpool_dev,
-                    fssave.thin_id,
-                )?;
-                Ok((
-                    Name::new(fssave.name.to_owned()),
-                    fssave.uuid,
-                    StratFilesystem::setup(thin_dev),
-                ))
+                StratFilesystem::setup(pool_uuid, &thinpool_dev, fssave)
+                    .map(|fs| (Name::new(fssave.name.to_owned()), fssave.uuid, fs))
             })
             .collect::<StratisResult<Vec<_>>>()?;
 
@@ -610,18 +595,8 @@ impl ThinPool {
         name: &str,
         size: Option<Sectors>,
     ) -> StratisResult<FilesystemUuid> {
-        let fs_uuid = Uuid::new_v4();
-        let (dm_name, dm_uuid) = format_thin_ids(pool_uuid, ThinRole::Filesystem(fs_uuid));
-        let thin_dev = ThinDev::new(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            size.unwrap_or(DEFAULT_THIN_DEV_SIZE),
-            &self.thin_pool,
-            self.id_gen.new_id()?,
-        )?;
-
-        let new_filesystem = StratFilesystem::initialize(fs_uuid, thin_dev)?;
+        let (fs_uuid, new_filesystem) =
+            StratFilesystem::initialize(pool_uuid, &self.thin_pool, size, self.id_gen.new_id()?)?;
         let name = Name::new(name.to_owned());
         self.mdv.save_fs(&name, fs_uuid, &new_filesystem)?;
         devlinks::filesystem_added(pool_name, &name, &new_filesystem.devnode())?;
@@ -1234,28 +1209,7 @@ mod tests {
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, &fs_name, None)
             .unwrap();
-        let thin_id = pool.get_filesystem_by_uuid(fs_uuid).unwrap().1.thin_id();
-        let (dm_name, dm_uuid) = format_thin_ids(pool_uuid, ThinRole::Filesystem(fs_uuid));
-        let thindev = ThinDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            DEFAULT_THIN_DEV_SIZE,
-            &pool.thin_pool,
-            thin_id,
-        );
-        assert!(thindev.is_ok());
         pool.destroy_filesystem(pool_name, fs_uuid).unwrap();
-
-        let thindev = ThinDev::setup(
-            get_dm(),
-            &dm_name,
-            None,
-            DEFAULT_THIN_DEV_SIZE,
-            &pool.thin_pool,
-            thin_id,
-        );
-        assert!(thindev.is_err());
         let flexdevs: FlexDevsSave = pool.record();
         let thinpooldevsave: ThinPoolDevSave = pool.record();
         pool.teardown().unwrap();

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1243,19 +1243,19 @@ mod tests {
     }
 
     #[test]
-    pub fn loop_test_meta_expand() {
+    pub fn loop_test_thindev_destroy() {
         // This test requires more than 1 GiB.
         loopbacked::test_with_spec(
             loopbacked::DeviceLimits::Range(2, 3, None),
-            test_meta_expand,
+            test_thindev_destroy,
         );
     }
 
     #[test]
-    pub fn real_test_meta_expand() {
+    pub fn real_test_thindev_destroy() {
         real::test_with_spec(
-            real::DeviceLimits::Range(2, 3, None, None),
-            test_meta_expand,
+            real::DeviceLimits::AtLeast(1, None, None),
+            test_thindev_destroy,
         );
     }
 
@@ -1299,19 +1299,19 @@ mod tests {
     }
 
     #[test]
-    pub fn loop_test_thindev_destroy() {
+    pub fn loop_test_meta_expand() {
         // This test requires more than 1 GiB.
         loopbacked::test_with_spec(
             loopbacked::DeviceLimits::Range(2, 3, None),
-            test_thindev_destroy,
+            test_meta_expand,
         );
     }
 
     #[test]
-    pub fn real_test_thindev_destroy() {
+    pub fn real_test_meta_expand() {
         real::test_with_spec(
-            real::DeviceLimits::AtLeast(1, None, None),
-            test_thindev_destroy,
+            real::DeviceLimits::Range(2, 3, None, None),
+            test_meta_expand,
         );
     }
 

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -68,6 +68,12 @@ impl Name {
     }
 }
 
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 impl Deref for Name {
     type Target = str;
 

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -117,14 +117,23 @@ SPECS = {
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
+<property name="Created" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
 <property name="Devnode" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="MountPoints" type="as" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="Name" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="Pool" type="o" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="Used" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="Uuid" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>

--- a/tests/client-dbus/tests/dbus/filesystem/test_properties.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_properties.py
@@ -19,10 +19,7 @@ import unittest
 
 from stratisd_client_dbus import Filesystem
 from stratisd_client_dbus import Manager
-from stratisd_client_dbus import ObjectManager
 from stratisd_client_dbus import Pool
-from stratisd_client_dbus import StratisdErrors
-from stratisd_client_dbus import filesystems
 from stratisd_client_dbus import get_object
 
 from stratisd_client_dbus._constants import TOP_OBJECT
@@ -100,4 +97,3 @@ class SetNameTestCase(unittest.TestCase):
         devnode = Filesystem.Properties.Devnode.Get(filesystem)
 
         self.assertEqual(devnode, "/dev/stratis/deadpool/fs")
-

--- a/tests/client-dbus/tests/dbus/filesystem/test_properties.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_properties.py
@@ -1,0 +1,103 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test accessing properties of a filesystem.
+"""
+
+import unittest
+
+from stratisd_client_dbus import Filesystem
+from stratisd_client_dbus import Manager
+from stratisd_client_dbus import ObjectManager
+from stratisd_client_dbus import Pool
+from stratisd_client_dbus import StratisdErrors
+from stratisd_client_dbus import filesystems
+from stratisd_client_dbus import get_object
+
+from stratisd_client_dbus._constants import TOP_OBJECT
+
+from .._misc import _device_list
+from .._misc import Service
+
+_DEVICE_STRATEGY = _device_list(0)
+
+
+class SetNameTestCase(unittest.TestCase):
+    """
+    Set up a pool with a name and one filesystem.
+    """
+
+    _POOLNAME = 'deadpool'
+
+    def setUp(self):
+        """
+        Start the stratisd daemon with the simulator.
+        """
+        self._fs_name = 'fs'
+        self._service = Service()
+        self._service.setUp()
+        self._proxy = get_object(TOP_OBJECT)
+        ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
+            self._proxy, {
+                'name': self._POOLNAME,
+                'redundancy': (True, 0),
+                'force': False,
+                'devices': _DEVICE_STRATEGY.example()
+            })
+        self._pool_object = get_object(self._pool_object_path)
+        (created, _, _) = Pool.Methods.CreateFilesystems(
+            self._pool_object, {'specs': [self._fs_name]})
+        self._filesystem_object_path = created[0][0]
+        Manager.Methods.ConfigureSimulator(self._proxy, {'denominator': 8})
+
+    def tearDown(self):
+        """
+        Stop the stratisd simulator and daemon.
+        """
+        self._service.tearDown()
+
+    def testProps(self):
+        """
+        Test reading some filesystem properties.
+        """
+        filesystem = get_object(self._filesystem_object_path)
+        name = Filesystem.Properties.Name.Get(filesystem)
+
+        self.assertEqual(self._fs_name, name)
+
+        uuid = Filesystem.Properties.Uuid.Get(filesystem)
+
+        # must be a 32 character string
+        self.assertEqual(32, len(uuid))
+
+        mount_points = Filesystem.Properties.MountPoints.Get(filesystem)
+
+        # we haven't mounted so it should be an empty array
+        self.assertEqual(list(), mount_points)
+
+        created = Filesystem.Properties.Created.Get(filesystem)
+
+        # Should be a UTC rfc3339 string, which should end in Z
+        self.assertTrue(created.endswith("Z"))
+        # I think this is also always true
+        self.assertEqual(len(created), 20)
+
+        used = Filesystem.Properties.Used.Get(filesystem)
+
+        self.assertEqual(used, "12345678")
+
+        devnode = Filesystem.Properties.Devnode.Get(filesystem)
+
+        self.assertEqual(devnode, "/dev/stratis/deadpool/fs")
+


### PR DESCRIPTION
Does 3 things:
1. Moves some filesystem initialization/setup inside filesystem (from ThinPool)
1. Adds support for Created, Used, and MountPoints filesystem properties in D-Bus
1. Changes filesystem Devnode property to return `/dev/stratis/<poolname>/<fsname>` instead of `/dev/dm-<number>`