### PR TITLE
Use write mode check instead of diff for cargo fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ fmt:
 fmt-travis:
 	rustup default 1.27.0
 	rustup component add rustfmt-preview
-	cargo fmt -- --write-mode=diff
+	cargo fmt -- --write-mode=check
 
 build:
 	PKG_CONFIG_ALLOW_CROSS=1 \


### PR DESCRIPTION
Semantics of diff seems to have changed. It used to return non-zero code
if there was a difference, now it doesn't. Semantics of check seems to
be what we want for a test; it seems to behave like diff used to.

Signed-off-by: mulhern <amulhern@redhat.com>