### PR TITLE
Move all handling of top-level DM device out of the Data and Cache Tiers

### DIFF
--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -6,22 +6,14 @@
 
 use std::path::Path;
 
-use devicemapper::{CacheDev, DmDevice, LinearDev, Sectors, IEC};
+use devicemapper::{Sectors, IEC};
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
 
-use super::super::device::wipe_sectors;
-use super::super::dm::get_dm;
-use super::super::dmnames::{format_backstore_ids, CacheRole};
-
 use super::blockdev::StratBlockDev;
-use super::blockdevmgr::{coalesce_blkdevsegs, map_to_dm, BlkDevSegment, BlockDevMgr, Segment};
-
-/// Use a cache block size that the kernel docs indicate is the largest
-/// typical size.
-const CACHE_BLOCK_SIZE: Sectors = Sectors(2048); // 1024 KiB
+use super::blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment};
 
 /// Handles the cache devices.
 #[derive(Debug)]
@@ -39,16 +31,11 @@ pub struct CacheTier {
 impl CacheTier {
     /// Setup a previously existing cache layer from the block_mgr and
     /// previously allocated segments.
-    ///
-    /// Returns the CacheTier and the cache DM device that was created during
-    /// setup.
     pub fn setup(
-        pool_uuid: PoolUuid,
         block_mgr: BlockDevMgr,
-        origin: LinearDev,
         cache_segments: &[(DevUuid, Sectors, Sectors)],
         meta_segments: &[(DevUuid, Sectors, Sectors)],
-    ) -> StratisResult<(CacheTier, CacheDev)> {
+    ) -> StratisResult<CacheTier> {
         if block_mgr.avail_space() != Sectors(0) {
             let err_msg = format!(
                 "{} unallocated to device; probable metadata corruption",
@@ -75,45 +62,17 @@ impl CacheTier {
             .iter()
             .map(&mapper)
             .collect::<StratisResult<Vec<_>>>()?;
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-        let meta = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&meta_segments),
-        )?;
 
         let cache_segments = cache_segments
             .iter()
             .map(&mapper)
             .collect::<StratisResult<Vec<_>>>()?;
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-        let cache = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&cache_segments),
-        )?;
 
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
-        let cd = CacheDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            meta,
-            cache,
-            origin,
-            CACHE_BLOCK_SIZE,
-        )?;
-
-        Ok((
-            CacheTier {
-                block_mgr,
-                meta_segments,
-                cache_segments,
-            },
-            cd,
-        ))
+        Ok(CacheTier {
+            block_mgr,
+            meta_segments,
+            cache_segments,
+        })
     }
 
     /// Add the given paths to self. Return UUIDs of the new blockdevs
@@ -127,7 +86,6 @@ impl CacheTier {
     pub fn add(
         &mut self,
         pool_uuid: PoolUuid,
-        cache_device: &mut CacheDev,
         paths: &[&Path],
         force: bool,
     ) -> StratisResult<Vec<DevUuid>> {
@@ -141,27 +99,15 @@ impl CacheTier {
             .flat_map(|s| s.iter())
             .cloned()
             .collect::<Vec<_>>();
-        let coalesced = coalesce_blkdevsegs(&self.cache_segments, &segments);
-        let table = map_to_dm(&coalesced);
-
-        cache_device.set_cache_table(get_dm(), table)?;
-        cache_device.resume(get_dm())?;
-
-        self.cache_segments = coalesced;
+        self.cache_segments = coalesce_blkdevsegs(&self.cache_segments, &segments);
 
         Ok(uuids)
     }
 
     /// Setup a new CacheTier struct from the block_mgr.
     ///
-    /// Returns the CacheTier and the cache device that was created.
-    ///
     /// WARNING: metadata changing event
-    pub fn new(
-        pool_uuid: PoolUuid,
-        mut block_mgr: BlockDevMgr,
-        origin: LinearDev,
-    ) -> StratisResult<(CacheTier, CacheDev)> {
+    pub fn new(mut block_mgr: BlockDevMgr) -> CacheTier {
         let avail_space = block_mgr.avail_space();
 
         // FIXME: Come up with a better way to choose metadata device size
@@ -179,44 +125,11 @@ impl CacheTier {
         let cache_segments = segments.pop().expect("segments.len() == 2");
         let meta_segments = segments.pop().expect("segments.len() == 1");
 
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-        let meta = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&meta_segments),
-        )?;
-
-        // See comment in ThinPool::new() method
-        wipe_sectors(&meta.devnode(), Sectors(0), meta.size())?;
-
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-        let cache = LinearDev::setup(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            map_to_dm(&cache_segments),
-        )?;
-
-        let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
-        let cd = CacheDev::new(
-            get_dm(),
-            &dm_name,
-            Some(&dm_uuid),
-            meta,
-            cache,
-            origin,
-            CACHE_BLOCK_SIZE,
-        )?;
-
-        Ok((
-            CacheTier {
-                block_mgr,
-                meta_segments,
-                cache_segments,
-            },
-            cd,
-        ))
+        CacheTier {
+            block_mgr,
+            meta_segments,
+            cache_segments,
+        }
     }
 
     /// Destroy the tier. Wipe its blockdevs.


### PR DESCRIPTION
Previously DM devices were constructed or updated in *Tier methods. Now, all updating of DM devices is done in the Backstore, using the data in the various Tier structs.

This does turn out to be more concise, which is good.

The principle motivation is that it is necessary in PR #1097 to relax certain invariants that currently hold for the DM devices. In particular, it was previously the case that the backstore held either a linear or a cache device. Now it may hold neither. It is easier to handle this wider range of possibilities in the backstore than when the code is distributed among three files.

One apparent drawback of this change is that the Data or CacheTier segments values are set before the DM devices are constructed or reconstructed. However, if the DM devices are not constructed properly, then the corresponding backstore method will fail, and the metadata will not be written so the change to the segments value is not visible. So the externally visible behavior of stratisd is the same with this change as w/out it.