### PR TITLE
 dm-multipath: Initial support

### DIFF
--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -54,11 +54,13 @@ pub enum DevOwnership {
     Theirs(String), // String is something useful to give back to end user about what's on device
 }
 
-/// Returns true if a device has no signature, yes this is a bit convoluted.  Logic gleaned from
-/// blivet library.
+/// Returns true if a device has no signature and is not one of the paths of a multipath device,
+/// yes this is a bit convoluted.  Logic gleaned from blivet library.
 fn empty(device: &HashMap<String, String>) -> bool {
-    !((device.contains_key("ID_PART_TABLE_TYPE") && !device.contains_key("ID_PART_ENTRY_DISK"))
-        || device.contains_key("ID_FS_USAGE"))
+    !device.contains_key("DM_MULTIPATH_DEVICE_PATH")
+        && !((device.contains_key("ID_PART_TABLE_TYPE")
+            && !device.contains_key("ID_PART_ENTRY_DISK"))
+            || device.contains_key("ID_FS_USAGE"))
 }
 
 /// Generate some kind of human readable text about what's on a device.
@@ -78,9 +80,7 @@ fn signature(device: &HashMap<String, String>) -> String {
 /// Determine what a block device is used for.
 pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
     if let Some(device) = get_udev_block_device(devnode)? {
-        if device.contains_key("DM_MULTIPATH_DEVICE_PATH") {
-            Ok(DevOwnership::Theirs(String::from("multipath path")))
-        } else if empty(&device) {
+        if empty(&device) {
             // The device is either really empty or we are running on a distribution that hasn't
             // picked up the latest libblkid, lets read down to the device and find out for sure.
             // TODO: At some point in the future we can remove this and just return Unowned.
@@ -91,6 +91,8 @@ pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
             } else {
                 Ok(DevOwnership::Unowned)
             }
+        } else if device.contains_key("DM_MULTIPATH_DEVICE_PATH") {
+            Ok(DevOwnership::Theirs(String::from("multipath path")))
         } else if device.contains_key("ID_FS_TYPE") && device["ID_FS_TYPE"] == "stratis" {
             // Device is ours, but we don't get everything we need from udev db, lets go to disk.
             if let Some((pool_uuid, device_uuid)) = StaticHeader::device_identifiers(

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -78,7 +78,9 @@ fn signature(device: &HashMap<String, String>) -> String {
 /// Determine what a block device is used for.
 pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
     if let Some(device) = get_udev_block_device(devnode)? {
-        if empty(&device) {
+        if device.contains_key("DM_MULTIPATH_DEVICE_PATH") {
+            Ok(DevOwnership::Theirs(String::from("multipath path")))
+        } else if empty(&device) {
             // The device is either really empty or we are running on a distribution that hasn't
             // picked up the latest libblkid, lets read down to the device and find out for sure.
             // TODO: At some point in the future we can remove this and just return Unowned.

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -89,7 +89,7 @@ pub fn get_stratis_block_devices() -> StratisResult<Vec<PathBuf>> {
 
         Ok(get_all_empty_devices()?
             .into_iter()
-            .filter(|x| is_stratis_device(&x).unwrap_or(None).is_some())
+            .filter(|x| is_stratis_device(&x).ok().is_some())
             .collect())
     } else {
         Ok(devices)

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -4,6 +4,7 @@
 
 // Utilities to support Stratis.
 use std::collections::HashMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use libudev;
@@ -33,9 +34,12 @@ pub fn get_udev_block_device(
     let mut enumerator = libudev::Enumerator::new(&context)?;
     enumerator.match_subsystem("block")?;
 
+    // Get canonical form to ensure we do correct lookup in udev db
+    let canonical = fs::canonicalize(dev_node_search)?;
+
     let result = enumerator
         .scan_devices()?
-        .find(|x| x.devnode().map_or(false, |d| dev_node_search == d))
+        .find(|x| x.devnode().map_or(false, |d| canonical == d))
         .and_then(|dev| Some(device_as_map(&dev)));
     Ok(result)
 }
@@ -46,7 +50,8 @@ pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
     Ok(dev.and_then(|dev| dev.get("ID_WWN").and_then(|i| Some(i.clone()))))
 }
 
-/// Collect paths for all the devices that appear to be empty from a udev db perspective.
+/// Collect paths for all the block devices which are not individual multipath paths and which
+/// appear to be empty from a udev perspective.
 fn get_all_empty_devices() -> StratisResult<Vec<PathBuf>> {
     let context = libudev::Context::new()?;
     let mut enumerator = libudev::Enumerator::new(&context)?;
@@ -55,9 +60,10 @@ fn get_all_empty_devices() -> StratisResult<Vec<PathBuf>> {
     Ok(enumerator
         .scan_devices()?
         .filter(|dev| {
-            !((dev.property_value("ID_PART_TABLE_TYPE").is_some()
-                && dev.property_value("ID_PART_ENTRY_DISK").is_none())
-                || dev.property_value("ID_FS_USAGE").is_some())
+            dev.property_value("DM_MULTIPATH_DEVICE_PATH").is_none()
+                && !((dev.property_value("ID_PART_TABLE_TYPE").is_some()
+                    && dev.property_value("ID_PART_ENTRY_DISK").is_none())
+                    || dev.property_value("ID_FS_USAGE").is_some())
         })
         .filter_map(|i| i.devnode().map(|d| d.into()))
         .collect())
@@ -72,6 +78,7 @@ pub fn get_stratis_block_devices() -> StratisResult<Vec<PathBuf>> {
 
     let devices: Vec<PathBuf> = enumerator
         .scan_devices()?
+        .filter(|dev| dev.property_value("DM_MULTIPATH_DEVICE_PATH").is_none())
         .filter_map(|i| i.devnode().map(|d| d.into()))
         .collect();
 
@@ -82,7 +89,7 @@ pub fn get_stratis_block_devices() -> StratisResult<Vec<PathBuf>> {
 
         Ok(get_all_empty_devices()?
             .into_iter()
-            .filter(|x| is_stratis_device(&x).ok().is_some())
+            .filter(|x| is_stratis_device(&x).unwrap_or(None).is_some())
             .collect())
     } else {
         Ok(devices)


### PR DESCRIPTION
Verify that a given device as supplied by user is not one of the individual
paths participating in a multipath configuration.  Additionally when
walking the udev db at start up, ensure we filter out these individual
paths too.

Signed-off-by: Tony Asleson <tasleson@redhat.com>