### PR TITLE
Correct poll_timeout, remove dbus type from service file

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -399,7 +399,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         // If dbus support is compiled in and dbus isn't available we will set timeout to
         // 1 second so that we periodically check to see if we can bring it up.
         #[cfg(feature = "dbus_enabled")]
-        let poll_timeout = dbus_handle.as_ref().map_or(-1, |_| 1000);
+        let poll_timeout = dbus_handle.as_ref().map_or(1000, |_| -1);
         // Default timeout is infinite
         #[cfg(not(feature = "dbus_enabled"))]
         let poll_timeout = -1;

--- a/stratisd.service
+++ b/stratisd.service
@@ -5,8 +5,6 @@ Before=local-fs-pre.target
 DefaultDependencies=no
 
 [Service]
-Type=dbus
-BusName=org.storage.stratis1
 ExecStart=/usr/libexec/stratisd --debug
 KillSignal=SIGINT
 Restart=on-abort


### PR DESCRIPTION
While verifying a service file correction, I discovered that the `poll_timeout`
was incorrect and we were using `-1` when we had no dbus services.  
Thus the dbus interface was not being brought up until we got a signal 
or some other event made us take a pass through the event loop.

We have conflicting requirements in our service file.  We cannot
be both a dbus service and want to run before file systems get
mounted as dbus is not available until after file systems have been
mounted.  Thus we cannot advertise as providing a dbus service in
the service file and still start up before file systems  get
mounted in fstab.

Notes:
* Tested in VM, stratis backed FS came up with FS UUID in fstab
* For my VM it takes about 3 seconds from the time we start stratisd until we can bring up the dbus interface