### PR TITLE
Remove support for filesystem.MountPoints from API and fs trait

### DIFF
--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -65,11 +65,6 @@ pub fn create_dbus_filesystem<'a>(
         .emits_changed(EmitsChangedSignal::False)
         .on_get(get_filesystem_used);
 
-    let mount_points_property = f.property::<&Vec<String>, _>("MountPoints", ())
-        .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
-        .on_get(get_filesystem_mount_points);
-
     let object_name = format!(
         "{}/{}",
         STRATIS_BASE_PATH,
@@ -88,8 +83,7 @@ pub fn create_dbus_filesystem<'a>(
                 .add_p(pool_property)
                 .add_p(uuid_property)
                 .add_p(created_property)
-                .add_p(used_property)
-                .add_p(mount_points_property),
+                .add_p(used_property),
         );
 
     let path = object_path.get_name().to_owned();
@@ -233,21 +227,5 @@ fn get_filesystem_used(
         fs.used()
             .map(|v| (*v).to_string())
             .map_err(|_| MethodErr::failed(&"fs used() engine call failed".to_owned()))
-    })
-}
-
-/// Get all filesystem mount points
-fn get_filesystem_mount_points(
-    i: &mut IterAppend,
-    p: &PropInfo<MTFn<TData>, TData>,
-) -> Result<(), MethodErr> {
-    get_filesystem_property(i, p, |(_, _, fs)| {
-        fs.mount_points()
-            .map(|vec| {
-                vec.iter()
-                    .map(|elem| format!("{}", elem.display()))
-                    .collect::<Vec<_>>()
-            })
-            .map_err(|_| MethodErr::failed(&"mount_points() engine call failed".to_owned()))
     })
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -31,9 +31,6 @@ pub trait Filesystem: Debug {
     /// The amount of data stored on the filesystem, including overhead.
     fn used(&self) -> StratisResult<Bytes>;
 
-    /// Get the mount_point(s) for the file system.
-    fn mount_points(&self) -> StratisResult<Vec<PathBuf>>;
-
     /// Set dbus path associated with the Pool.
     #[cfg(feature = "dbus_enabled")]
     fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> ();

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -50,10 +50,6 @@ impl Filesystem for SimFilesystem {
         Ok(Bytes(12345678))
     }
 
-    fn mount_points(&self) -> StratisResult<Vec<PathBuf>> {
-        Ok(Vec::new())
-    }
-
     #[cfg(feature = "dbus_enabled")]
     fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
         self.dbus_path = Some(path)

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -244,6 +244,34 @@ impl StratFilesystem {
         self.thin_dev.resume(get_dm())?;
         Ok(())
     }
+
+    /// Find places where this filesystem is mounted.
+    fn mount_points(&self) -> StratisResult<Vec<PathBuf>> {
+        // Use major:minor values to find mounts for this filesystem
+        let major = u64::from(self.thin_dev.device().major);
+        let minor = u64::from(self.thin_dev.device().minor);
+
+        let mut mount_data = String::new();
+        File::open("/proc/self/mountinfo")?.read_to_string(&mut mount_data)?;
+        let parser = libmount::mountinfo::Parser::new(mount_data.as_bytes());
+
+        let mut ret_vec = Vec::new();
+        for mp in parser {
+            match mp {
+                Ok(mount) => {
+                    if mount.major as u64 == major && mount.minor as u64 == minor {
+                        ret_vec.push(PathBuf::from(&mount.mount_point));
+                    }
+                }
+                Err(e) => {
+                    let error_msg = format!("Error during parsing {:?}: {:?}", *self, e);
+                    return Err(StratisError::Engine(ErrorEnum::Error, error_msg));
+                }
+            }
+        }
+
+        Ok(ret_vec)
+    }
 }
 
 impl Filesystem for StratFilesystem {
@@ -274,33 +302,6 @@ impl Filesystem for StratFilesystem {
                 Ok(used_result?.1)
             }
         }
-    }
-
-    fn mount_points(&self) -> StratisResult<Vec<PathBuf>> {
-        // Use major:minor values to find mounts for this filesystem
-        let major = u64::from(self.thin_dev.device().major);
-        let minor = u64::from(self.thin_dev.device().minor);
-
-        let mut mount_data = String::new();
-        File::open("/proc/self/mountinfo")?.read_to_string(&mut mount_data)?;
-        let parser = libmount::mountinfo::Parser::new(mount_data.as_bytes());
-
-        let mut ret_vec = Vec::new();
-        for mp in parser {
-            match mp {
-                Ok(mount) => {
-                    if mount.major as u64 == major && mount.minor as u64 == minor {
-                        ret_vec.push(PathBuf::from(&mount.mount_point));
-                    }
-                }
-                Err(e) => {
-                    let error_msg = format!("Error during parsing {:?}: {:?}", *self, e);
-                    return Err(StratisError::Engine(ErrorEnum::Error, error_msg));
-                }
-            }
-        }
-
-        Ok(ret_vec)
     }
 
     #[cfg(feature = "dbus_enabled")]

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -123,9 +123,6 @@ SPECS = {
 <property name="Devnode" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
 </property>
-<property name="MountPoints" type="as" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-</property>
 <property name="Name" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>

--- a/tests/client-dbus/tests/dbus/filesystem/test_properties.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_properties.py
@@ -78,11 +78,6 @@ class SetNameTestCase(unittest.TestCase):
         # must be a 32 character string
         self.assertEqual(32, len(uuid))
 
-        mount_points = Filesystem.Properties.MountPoints.Get(filesystem)
-
-        # we haven't mounted so it should be an empty array
-        self.assertEqual(list(), mount_points)
-
         created = Filesystem.Properties.Created.Get(filesystem)
 
         # Should be a UTC rfc3339 string, which should end in Z


### PR DESCRIPTION
We've decided not to show it in the cli, because it's already accessible
via the `mount` command. Given that, it doesn't appear to be useful or
used, so why support the method? We can always add it later, after all.

StratEngine support for getting mount points is still needed, so it
moves from the trait impl to the regular impl block.

Signed-off-by: Andy Grover <agrover@redhat.com>