### PR TITLE
Add framework for issuing dbus signals (final)

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -40,10 +40,15 @@ use nix::unistd::getpid;
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
 
 #[cfg(feature = "dbus_enabled")]
-use dbus::WatchEvent;
+use dbus::{Connection, WatchEvent};
 
 use devicemapper::Device;
-
+#[cfg(feature = "dbus_enabled")]
+use libstratis::dbus_api::{consts, prop_changed_dispatch};
+#[cfg(feature = "dbus_enabled")]
+use libstratis::engine::{
+    get_engine_listener_list_mut, EngineEvent, EngineListener, MaybeDbusPath,
+};
 use libstratis::engine::{Engine, SimEngine, StratEngine};
 use libstratis::stratis::buff_log;
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
@@ -155,6 +160,98 @@ fn trylock_pid_file() -> StratisResult<File> {
                 "Daemon already running with pid: {}",
                 pid_str
             )))
+        }
+    }
+}
+
+#[cfg(feature = "dbus_enabled")]
+#[derive(Debug)]
+struct EventHandler {
+    dbus_conn: Rc<RefCell<Connection>>,
+}
+
+#[cfg(feature = "dbus_enabled")]
+impl EventHandler {
+    pub fn new(dbus_conn: Rc<RefCell<Connection>>) -> EventHandler {
+        EventHandler {
+            dbus_conn: dbus_conn,
+        }
+    }
+}
+
+#[cfg(feature = "dbus_enabled")]
+impl EngineListener for EventHandler {
+    fn notify(&self, event: &EngineEvent) {
+        match event {
+            &EngineEvent::BlockdevStateChanged { dbus_path, state } => {
+                if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::BLOCKDEV_STATE_PROP,
+                        state.to_dbus_value(),
+                        &dbus_path,
+                    ).unwrap_or_else(|()| {
+                        error!(
+                            "BlockdevStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path,
+                            state.to_dbus_value(),
+                        );
+                    });
+                }
+            }
+            &EngineEvent::FilesystemRenamed {
+                dbus_path,
+                from,
+                to,
+            } => {
+                if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::FILESYSTEM_NAME_PROP,
+                        to.to_owned(),
+                        &dbus_path,
+                    ).unwrap_or_else(|()| {
+                        error!(
+                            "FilesystemRenamed: {} from: {} to: {} failed to send dbus update.",
+                            dbus_path, from, to,
+                        );
+                    });
+                }
+            }
+            &EngineEvent::FilesystemUsedChanged { dbus_path, used } => {
+                if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::FILESYSTEM_USED_PROP,
+                        *used,
+                        &dbus_path,
+                    ).unwrap_or_else(|()| {
+                        error!(
+                            "FilesystemUsedChanged: {} used: {} failed to send dbus update.",
+                            dbus_path, used,
+                        );
+                    });
+                }
+            }
+            &EngineEvent::PoolRenamed {
+                dbus_path,
+                from,
+                to,
+            } => {
+                if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_NAME_PROP,
+                        to.to_owned(),
+                        &dbus_path,
+                    ).unwrap_or_else(|()| {
+                        error!(
+                            "PoolRenamed: {} from: {} to: {} failed to send dbus update.",
+                            dbus_path, from, to,
+                        );
+                    });
+                }
+            }
         }
     }
 }
@@ -299,7 +396,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                         if let Some(ref mut handle) = dbus_handle {
                             if let Some(pool_uuid) = pool_uuid {
                                 libstratis::dbus_api::register_pool(
-                                    &handle.connection,
+                                    &handle.connection.borrow(),
                                     &handle.context,
                                     &mut handle.tree,
                                     pool_uuid,
@@ -376,10 +473,11 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                 {
                     for item in handle
                         .connection
+                        .borrow()
                         .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
                     {
                         if let Err(r) = libstratis::dbus_api::handle(
-                            &handle.connection,
+                            &handle.connection.borrow(),
                             &item,
                             &mut handle.tree,
                             &handle.context,
@@ -393,16 +491,24 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                 // Refresh list of dbus fds to poll for. This can change as
                 // D-Bus clients come and go.
                 fds.truncate(dbus_client_index_start);
-                fds.extend(handle.connection.watch_fds().iter().map(|w| w.to_pollfd()));
+                fds.extend(
+                    handle
+                        .connection
+                        .borrow()
+                        .watch_fds()
+                        .iter()
+                        .map(|w| w.to_pollfd()),
+                );
             } else {
                 // See if we can bring up dbus.
                 if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
                     info!("DBUS API is now available");
-
+                    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
+                    get_engine_listener_list_mut().register_listener(event_handler);
                     // Register all the pools with dbus
                     for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
                         libstratis::dbus_api::register_pool(
-                            &handle.connection,
+                            &handle.connection.borrow(),
                             &handle.context,
                             &mut handle.tree,
                             pool_uuid,
@@ -412,7 +518,14 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                     }
 
                     // Add dbus FD to fds as dbus is now available.
-                    fds.extend(handle.connection.watch_fds().iter().map(|w| w.to_pollfd()));
+                    fds.extend(
+                        handle
+                            .connection
+                            .borrow()
+                            .watch_fds()
+                            .iter()
+                            .map(|w| w.to_pollfd()),
+                    );
                     dbus_handle = Some(handle);
                 }
             }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -207,7 +207,7 @@ fn register_pool_dbus(
 
 /// Returned data from when you connect a stratis engine to dbus.
 pub struct DbusConnectionData<'a> {
-    pub connection: Connection,
+    pub connection: Rc<RefCell<Connection>>,
     pub tree: Tree<MTFn<TData>, TData>,
     pub path: dbus::Path<'a>,
     pub context: DbusContext,
@@ -221,7 +221,7 @@ pub fn connect<'a>(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData<'a>
     tree.set_registered(&c, true)?;
     c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32)?;
     Ok(DbusConnectionData {
-        connection: c,
+        connection: Rc::new(RefCell::new(c)),
         tree,
         path: object_path,
         context: dbus_context,

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Pool Properties
+pub const POOL_NAME_PROP: &str = "Name";
+
+// Filesystem Properties
+pub const FILESYSTEM_NAME_PROP: &str = "Name";
+pub const FILESYSTEM_USED_PROP: &str = "Used";
+
+// Blockdev Properties
+pub const BLOCKDEV_STATE_PROP: &str = "State";

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -12,8 +12,9 @@ use dbus::Message;
 
 use uuid::Uuid;
 
-use super::super::engine::{filesystem_mount_path, Filesystem, Name, RenameAction};
+use super::super::engine::{filesystem_mount_path, Filesystem, MaybeDbusPath, Name, RenameAction};
 
+use super::consts;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::{
@@ -40,9 +41,9 @@ pub fn create_dbus_filesystem<'a>(
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_filesystem_devnode);
 
-    let name_property = f.property::<&str, _>("Name", ())
+    let name_property = f.property::<&str, _>(consts::FILESYSTEM_NAME_PROP, ())
         .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
+        .emits_changed(EmitsChangedSignal::True)
         .on_get(get_filesystem_name);
 
     let pool_property = f.property::<&dbus::Path, _>("Pool", ())
@@ -60,9 +61,9 @@ pub fn create_dbus_filesystem<'a>(
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_filesystem_created);
 
-    let used_property = f.property::<&str, _>("Used", ())
+    let used_property = f.property::<&str, _>(consts::FILESYSTEM_USED_PROP, ())
         .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
+        .emits_changed(EmitsChangedSignal::True)
         .on_get(get_filesystem_used);
 
     let object_name = format!(
@@ -88,7 +89,7 @@ pub fn create_dbus_filesystem<'a>(
 
     let path = object_path.get_name().to_owned();
     dbus_context.actions.borrow_mut().push_add(object_path);
-    filesystem.set_dbus_path(path.clone());
+    filesystem.set_dbus_path(MaybeDbusPath(Some(path.clone())));
     path
 }
 

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -7,9 +7,11 @@ mod macros;
 
 mod api;
 mod blockdev;
+pub mod consts;
 mod filesystem;
 mod pool;
 mod types;
 mod util;
 
 pub use self::api::{connect, handle, register_pool, DbusConnectionData};
+pub use self::util::prop_changed_dispatch;

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -17,9 +17,10 @@ use uuid::Uuid;
 
 use devicemapper::Sectors;
 
-use super::super::engine::{BlockDevTier, Name, Pool, RenameAction};
+use super::super::engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction};
 
 use super::blockdev::create_dbus_blockdev;
+use super::consts;
 use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
@@ -399,9 +400,9 @@ pub fn create_dbus_pool<'a>(
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
-    let name_property = f.property::<&str, _>("Name", ())
+    let name_property = f.property::<&str, _>(consts::POOL_NAME_PROP, ())
         .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
+        .emits_changed(EmitsChangedSignal::True)
         .on_get(get_pool_name);
 
     let total_physical_size_property = f.property::<&str, _>("TotalPhysicalSize", ())
@@ -445,6 +446,6 @@ pub fn create_dbus_pool<'a>(
 
     let path = object_path.get_name().to_owned();
     dbus_context.actions.borrow_mut().push_add(object_path);
-    pool.set_dbus_path(path.clone());
+    pool.set_dbus_path(MaybeDbusPath(Some(path.clone())));
     path
 }

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -5,8 +5,11 @@
 use std::error::Error;
 
 use dbus;
-use dbus::arg::{ArgType, Iter, IterAppend};
+use dbus::arg::{ArgType, Iter, IterAppend, RefArg, Variant};
+use dbus::stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged;
 use dbus::tree::{MTFn, MethodErr, PropInfo};
+use dbus::Connection;
+use dbus::SignalArgs;
 
 use super::super::stratis::{ErrorEnum, StratisError};
 
@@ -97,5 +100,25 @@ pub fn get_parent(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Resul
         .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
 
     i.append(data.parent.clone());
+    Ok(())
+}
+
+/// Place a property changed signal on the D-Bus.
+pub fn prop_changed_dispatch<T: 'static>(
+    conn: &Connection,
+    prop_name: &str,
+    new_value: T,
+    path: &dbus::Path,
+) -> Result<(), ()>
+where
+    T: RefArg,
+{
+    let mut prop_changed: PropertiesPropertiesChanged = Default::default();
+    prop_changed
+        .changed_properties
+        .insert(prop_name.into(), Variant(Box::new(new_value)));
+
+    conn.send(prop_changed.to_emit_message(path))?;
+
     Ok(())
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -2,9 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#[cfg(feature = "dbus_enabled")]
-use dbus;
-
 use std::fmt::Debug;
 use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
@@ -15,7 +12,8 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Device, Sectors};
 
 use super::types::{
-    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, Name, PoolUuid, RenameAction,
+    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+    RenameAction,
 };
 use stratis::StratisResult;
 
@@ -32,12 +30,10 @@ pub trait Filesystem: Debug {
     fn used(&self) -> StratisResult<Bytes>;
 
     /// Set dbus path associated with the Pool.
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> ();
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();
 
     /// Get dbus path associated with the Pool.
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>>;
+    fn get_dbus_path(&self) -> &MaybeDbusPath;
 }
 
 pub trait BlockDev: Debug {
@@ -61,12 +57,10 @@ pub trait BlockDev: Debug {
     fn state(&self) -> BlockDevState;
 
     /// Set dbus path associated with the BlockDev.
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> ();
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();
 
     /// Get dbus path associated with the BlockDev.
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>>;
+    fn get_dbus_path(&self) -> &MaybeDbusPath;
 }
 
 pub trait Pool: Debug {
@@ -180,12 +174,10 @@ pub trait Pool: Debug {
     ) -> StratisResult<bool>;
 
     /// Set dbus path associated with the Pool.
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> ();
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();
 
     /// Get dbus path associated with the Pool.
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>>;
+    fn get_dbus_path(&self) -> &MaybeDbusPath;
 }
 
 pub trait Engine: Debug {

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use devicemapper::Bytes;
+
+use std::fmt::Debug;
+use std::sync::{Once, ONCE_INIT};
+
+use super::types::{BlockDevState, MaybeDbusPath};
+
+static INIT: Once = ONCE_INIT;
+static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;
+
+#[derive(Debug, Clone)]
+pub enum EngineEvent<'a> {
+    BlockdevStateChanged {
+        dbus_path: &'a MaybeDbusPath,
+        state: BlockDevState,
+    },
+    FilesystemRenamed {
+        dbus_path: &'a MaybeDbusPath,
+        from: &'a str,
+        to: &'a str,
+    },
+    FilesystemUsedChanged {
+        dbus_path: &'a MaybeDbusPath,
+        used: Bytes,
+    },
+    PoolRenamed {
+        dbus_path: &'a MaybeDbusPath,
+        from: &'a str,
+        to: &'a str,
+    },
+}
+
+pub trait EngineListener: Debug {
+    fn notify(&self, event: &EngineEvent);
+}
+
+#[derive(Debug)]
+pub struct EngineListenerList {
+    listeners: Vec<Box<EngineListener>>,
+}
+
+impl EngineListenerList {
+    /// Create a new EngineListenerList.
+    pub fn new() -> EngineListenerList {
+        EngineListenerList {
+            listeners: Vec::new(),
+        }
+    }
+
+    /// Add a listener.
+    // This code is marked dead because it is called only by bin/stratisd.rs
+    #[allow(dead_code)]
+    pub fn register_listener(&mut self, listener: Box<EngineListener>) {
+        self.listeners.push(listener);
+    }
+
+    /// Notify a listener.
+    pub fn notify(&self, event: &EngineEvent) {
+        for listener in self.listeners.iter() {
+            listener.notify(&event);
+        }
+    }
+}
+
+impl Default for EngineListenerList {
+    fn default() -> EngineListenerList {
+        EngineListenerList::new()
+    }
+}
+
+pub fn get_engine_listener_list() -> &'static EngineListenerList {
+    unsafe {
+        INIT.call_once(|| ENGINE_LISTENER_LIST = Some(EngineListenerList::new()));
+        match ENGINE_LISTENER_LIST {
+            Some(ref mut ell) => ell,
+            _ => panic!("ENGINE_LISTENER_LIST is None"),
+        }
+    }
+}
+
+pub fn get_engine_listener_list_mut() -> &'static mut EngineListenerList {
+    unsafe {
+        INIT.call_once(|| ENGINE_LISTENER_LIST = Some(EngineListenerList::new()));
+        match ENGINE_LISTENER_LIST {
+            Some(ref mut ell) => ell,
+            _ => panic!("ENGINE_LISTENER_LIST is None"),
+        }
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -11,6 +11,8 @@ pub use self::engine::Engine;
 pub use self::engine::Filesystem;
 pub use self::engine::Pool;
 
+pub use self::event::{get_engine_listener_list_mut, EngineEvent, EngineListener};
+
 pub use self::sim_engine::SimEngine;
 pub use self::strat_engine::StratEngine;
 
@@ -18,6 +20,7 @@ pub use self::types::BlockDevState;
 pub use self::types::BlockDevTier;
 pub use self::types::DevUuid;
 pub use self::types::FilesystemUuid;
+pub use self::types::MaybeDbusPath;
 pub use self::types::Name;
 pub use self::types::PoolUuid;
 pub use self::types::Redundancy;
@@ -29,6 +32,7 @@ mod macros;
 mod devlinks;
 #[allow(module_inception)]
 mod engine;
+mod event;
 mod sim_engine;
 mod strat_engine;
 mod structures;

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -2,9 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#[cfg(feature = "dbus_enabled")]
-use dbus;
-
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -15,7 +12,7 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Sectors, IEC};
 
 use super::super::engine::BlockDev;
-use super::super::types::BlockDevState;
+use super::super::types::{BlockDevState, MaybeDbusPath};
 
 use super::randomization::Randomizer;
 
@@ -27,8 +24,7 @@ pub struct SimDev {
     user_info: Option<String>,
     hardware_info: Option<String>,
     initialization_time: u64,
-    #[cfg(feature = "dbus_enabled")]
-    dbus_path: Option<dbus::Path<'static>>,
+    dbus_path: MaybeDbusPath,
 }
 
 impl BlockDev for SimDev {
@@ -56,13 +52,11 @@ impl BlockDev for SimDev {
         BlockDevState::InUse
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
-        self.dbus_path = Some(path)
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {
+        self.dbus_path = path
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+    fn get_dbus_path(&self) -> &MaybeDbusPath {
         &self.dbus_path
     }
 }
@@ -78,8 +72,7 @@ impl SimDev {
                 user_info: None,
                 hardware_info: None,
                 initialization_time: Utc::now().timestamp() as u64,
-                #[cfg(feature = "dbus_enabled")]
-                dbus_path: None,
+                dbus_path: MaybeDbusPath(None),
             },
         )
     }

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -3,8 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use chrono::{DateTime, Utc};
-#[cfg(feature = "dbus_enabled")]
-use dbus;
 
 use rand;
 
@@ -13,6 +11,7 @@ use std::path::PathBuf;
 use devicemapper::Bytes;
 
 use super::super::engine::Filesystem;
+use super::super::types::MaybeDbusPath;
 
 use stratis::StratisResult;
 
@@ -20,8 +19,7 @@ use stratis::StratisResult;
 pub struct SimFilesystem {
     rand: u32,
     created: DateTime<Utc>,
-    #[cfg(feature = "dbus_enabled")]
-    dbus_path: Option<dbus::Path<'static>>,
+    dbus_path: MaybeDbusPath,
 }
 
 impl SimFilesystem {
@@ -29,8 +27,7 @@ impl SimFilesystem {
         SimFilesystem {
             rand: rand::random::<u32>(),
             created: Utc::now(),
-            #[cfg(feature = "dbus_enabled")]
-            dbus_path: None,
+            dbus_path: MaybeDbusPath(None),
         }
     }
 }
@@ -50,13 +47,11 @@ impl Filesystem for SimFilesystem {
         Ok(Bytes(12345678))
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
-        self.dbus_path = Some(path)
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {
+        self.dbus_path = path
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+    fn get_dbus_path(&self) -> &MaybeDbusPath {
         &self.dbus_path
     }
 }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -2,9 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#[cfg(feature = "dbus_enabled")]
-use dbus;
-
 use std::cell::RefCell;
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet};
@@ -22,7 +19,7 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::structures::Table;
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, Name, PoolUuid, Redundancy, RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction,
 };
 
 use super::blockdev::SimDev;
@@ -36,8 +33,7 @@ pub struct SimPool {
     filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
-    #[cfg(feature = "dbus_enabled")]
-    dbus_path: Option<dbus::Path<'static>>,
+    dbus_path: MaybeDbusPath,
 }
 
 impl SimPool {
@@ -56,8 +52,7 @@ impl SimPool {
                 filesystems: Table::default(),
                 redundancy,
                 rdm: Rc::clone(rdm),
-                #[cfg(feature = "dbus_enabled")]
-                dbus_path: None,
+                dbus_path: MaybeDbusPath(None),
             },
         )
     }
@@ -282,13 +277,11 @@ impl Pool for SimPool {
         )
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
-        self.dbus_path = Some(path)
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {
+        self.dbus_path = path
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+    fn get_dbus_path(&self) -> &MaybeDbusPath {
         &self.dbus_path
     }
 }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::clone::Clone;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -11,6 +12,7 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::devlinks;
 use super::super::engine::{Engine, Eventable, Pool};
+use super::super::event::{get_engine_listener_list, EngineEvent};
 use super::super::structures::Table;
 use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
 
@@ -255,6 +257,12 @@ impl Engine for StratEngine {
             self.pools.insert(old_name, uuid, pool);
             Err(err)
         } else {
+            get_engine_listener_list().notify(&EngineEvent::PoolRenamed {
+                dbus_path: pool.get_dbus_path(),
+                from: &*old_name,
+                to: &*new_name,
+            });
+
             self.pools.insert(new_name.clone(), uuid, pool);
             devlinks::pool_renamed(&old_name, &new_name)?;
             Ok(RenameAction::Renamed)

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,9 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#[cfg(feature = "dbus_enabled")]
-use dbus;
-
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
@@ -15,12 +12,11 @@ use uuid::Uuid;
 
 use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
-
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, Name, PoolUuid, Redundancy, RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction,
 };
+use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::backstore::{Backstore, MIN_MDA_SECTORS};
 use super::serde_structs::{FlexDevsSave, PoolSave, Recordable};
@@ -113,8 +109,7 @@ pub struct StratPool {
     backstore: Backstore,
     redundancy: Redundancy,
     thin_pool: ThinPool,
-    #[cfg(feature = "dbus_enabled")]
-    dbus_path: Option<dbus::Path<'static>>,
+    dbus_path: MaybeDbusPath,
 }
 
 impl StratPool {
@@ -152,8 +147,7 @@ impl StratPool {
             backstore,
             redundancy,
             thin_pool: thinpool,
-            #[cfg(feature = "dbus_enabled")]
-            dbus_path: None,
+            dbus_path: MaybeDbusPath(None),
         };
 
         pool.write_metadata(&Name::new(name.to_owned()))?;
@@ -190,8 +184,7 @@ impl StratPool {
             backstore,
             redundancy: Redundancy::NONE,
             thin_pool: thinpool,
-            #[cfg(feature = "dbus_enabled")]
-            dbus_path: None,
+            dbus_path: MaybeDbusPath(None),
         };
 
         let pool_name = &metadata.name;
@@ -422,13 +415,11 @@ impl Pool for StratPool {
         }
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
-        self.dbus_path = Some(path)
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {
+        self.dbus_path = path
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+    fn get_dbus_path(&self) -> &MaybeDbusPath {
         &self.dbus_path
     }
 }
@@ -524,7 +515,9 @@ mod tests {
     /// space required.
     fn test_empty_pool(paths: &[&Path]) -> () {
         assert_eq!(paths.len(), 0);
-        assert!(StratPool::initialize("stratis_test_pool", paths, Redundancy::NONE, true).is_err());
+        assert!(
+            StratPool::initialize("stratis_test_pool", paths, Redundancy::NONE, true,).is_err()
+        );
     }
 
     #[test]

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -3,8 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use chrono::{DateTime, TimeZone, Utc};
-#[cfg(feature = "dbus_enabled")]
-use dbus;
 use uuid::Uuid;
 
 use std::fs::File;
@@ -24,7 +22,8 @@ use tempfile;
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::engine::Filesystem;
-use super::super::super::types::{FilesystemUuid, Name, PoolUuid};
+use super::super::super::event::{get_engine_listener_list, EngineEvent};
+use super::super::super::types::{FilesystemUuid, MaybeDbusPath, Name, PoolUuid};
 
 use super::super::cmd::{create_fs, set_uuid, xfs_growfs};
 use super::super::dm::get_dm;
@@ -43,8 +42,7 @@ pub const FILESYSTEM_LOWATER: Sectors = Sectors(256 * IEC::Mi / (SECTOR_SIZE as 
 pub struct StratFilesystem {
     thin_dev: ThinDev,
     created: DateTime<Utc>,
-    #[cfg(feature = "dbus_enabled")]
-    dbus_path: Option<dbus::Path<'static>>,
+    dbus_path: MaybeDbusPath,
 }
 
 pub enum FilesystemStatus {
@@ -79,8 +77,7 @@ impl StratFilesystem {
             StratFilesystem {
                 thin_dev,
                 created: Utc::now(),
-                #[cfg(feature = "dbus_enabled")]
-                dbus_path: None,
+                dbus_path: MaybeDbusPath(None),
             },
         ))
     }
@@ -103,8 +100,7 @@ impl StratFilesystem {
         Ok(StratFilesystem {
             thin_dev,
             created: Utc.timestamp(fssave.created as i64, 0),
-            #[cfg(feature = "dbus_enabled")]
-            dbus_path: None,
+            dbus_path: MaybeDbusPath(None),
         })
     }
 
@@ -162,8 +158,7 @@ impl StratFilesystem {
                 Ok(StratFilesystem {
                     thin_dev,
                     created: Utc::now(),
-                    #[cfg(feature = "dbus_enabled")]
-                    dbus_path: None,
+                    dbus_path: MaybeDbusPath(None),
                 })
             }
             Err(e) => Err(StratisError::Engine(
@@ -195,6 +190,10 @@ impl StratFilesystem {
                             return Ok(FilesystemStatus::XfsGrowFailed);
                         }
                     }
+                    get_engine_listener_list().notify(&EngineEvent::FilesystemUsedChanged {
+                        dbus_path: self.get_dbus_path(),
+                        used: fs_total_used_bytes,
+                    });
                 }
                 // TODO: do anything when filesystem is not mounted?
                 // TODO: periodically kick off fstrim?
@@ -304,13 +303,11 @@ impl Filesystem for StratFilesystem {
         }
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn set_dbus_path(&mut self, path: dbus::Path<'static>) -> () {
-        self.dbus_path = Some(path)
+    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {
+        self.dbus_path = path
     }
 
-    #[cfg(feature = "dbus_enabled")]
-    fn get_dbus_path(&self) -> &Option<dbus::Path<'static>> {
+    fn get_dbus_path(&self) -> &MaybeDbusPath {
         &self.dbus_path
     }
 }

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -20,6 +20,7 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::super::super::devlinks;
 use super::super::super::engine::Filesystem;
+use super::super::super::event::{get_engine_listener_list, EngineEvent};
 use super::super::super::structures::Table;
 use super::super::super::types::{FilesystemUuid, Name, PoolUuid, RenameAction};
 
@@ -930,6 +931,11 @@ impl ThinPool {
             self.filesystems.insert(old_name, uuid, filesystem);
             Err(err)
         } else {
+            get_engine_listener_list().notify(&EngineEvent::FilesystemRenamed {
+                dbus_path: filesystem.get_dbus_path(),
+                from: &*old_name,
+                to: &*new_name,
+            });
             self.filesystems.insert(new_name.clone(), uuid, filesystem);
             devlinks::filesystem_renamed(pool_name, &old_name, &new_name)?;
             Ok(RenameAction::Renamed)


### PR DESCRIPTION
Framework for issuing dbus signals based on engine events

Make a global engine event listener list.  The main loop uses the list to
register as a listener - the engine uses the list to send notifications.

Implement an EngineListener to translate engine events to the appropriate
dbus signals/handle as required.

Events implemented:
   BlockdevStateChanged
   FilesystemRenamed
   FilesystemUsedChanged
   PoolRenamed

Wrap Option\<dbus::Path\> in MaybeDbusPath.  This lets the conditional code
move inside the MaybeDbusPath struct definition, and keeps it out of the
rest of the Engine code.