### PR TITLE
Boot hang: Handle missing udev 'add' events

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -103,10 +103,12 @@ fn initialize_log(debug: bool) -> buff_log::Handle<env_logger::Logger> {
     }
 }
 
-/// Given a udev event check to see if it's an add and if it is return the device node and
-/// devicemapper::Device.
-fn handle_udev_add(event: &libudev::Event) -> Option<(Device, PathBuf)> {
-    if event.event_type() == libudev::EventType::Add {
+/// Given a udev event check to see if it's an add or change and if it is return the device node
+/// and devicemapper::Device.
+fn handle_udev_event(event: &libudev::Event) -> Option<(Device, PathBuf)> {
+    if event.event_type() == libudev::EventType::Add
+        || event.event_type() == libudev::EventType::Change
+    {
         let device = event.device();
         return device.devnode().and_then(|devnode| {
             device
@@ -283,7 +285,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
             while let Some(event) = udev.receive_event() {
-                if let Some((device, devnode)) = handle_udev_add(&event) {
+                if let Some((device, devnode)) = handle_udev_event(&event) {
                     // If block evaluate returns an error we are going to ignore it as
                     // there is nothing we can do for a device we are getting errors with.
                     #[cfg(not(feature = "dbus_enabled"))]

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -194,7 +194,7 @@ impl Engine for StratEngine {
                 // TODO: Handle the case where we have found a device for an already active pool
                 // ref. https://github.com/stratis-storage/stratisd/issues/748
                 warn!(
-                    "udev add: pool {} is already known, ignoring device {:?}!",
+                    "pool {} is already known, ignoring device {:?}!",
                     pool_uuid, dev_node
                 );
                 None
@@ -210,7 +210,7 @@ impl Engine for StratEngine {
                         Some(pool_uuid)
                     }
                     Err(err) => {
-                        warn!("udev add: no pool set up, reason: {:?}", err);
+                        warn!("no pool set up, reason: {:?}", err);
                         self.incomplete_pools.insert(pool_uuid, devices);
                         None
                     }


### PR DESCRIPTION
The block devices get 1 or more 'change' events too.  Lets give
ourselves the opportunity to interrogate the devices for these so
that we don't miss bringing up a pool if the 'add' event is never
encountered.

Fixes: https://github.com/stratis-storage/stratisd/issues/1130  ... well I've booted a few times and we have come up cleanly every time :smiley: 

**Another option is to walk the udev db when we fail to bring up a pool to see if we can find the missing device(s)**

Signed-off-by: Tony Asleson <tasleson@redhat.com>