### PR TITLE
Add support for periodic maintenance callback and fstrim()

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -243,6 +243,9 @@ pub trait Engine: Debug {
 
     /// Notify the engine that an event has occurred on the Eventable.
     fn evented(&mut self) -> StratisResult<()>;
+
+    /// Notify the engine to perform any periodic maintenance tasks.
+    fn maintenance(&mut self) -> StratisResult<()>;
 }
 
 /// Allows an Engine to include a fd in the event loop. See

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -135,6 +135,10 @@ impl Engine for SimEngine {
     fn evented(&mut self) -> StratisResult<()> {
         Ok(())
     }
+
+    fn maintenance(&mut self) -> StratisResult<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -42,6 +42,7 @@ const THIN_CHECK: &str = "thin_check";
 const THIN_REPAIR: &str = "thin_repair";
 const XFS_ADMIN: &str = "xfs_admin";
 const XFS_GROWFS: &str = "xfs_growfs";
+const FSTRIM: &str = "fstrim";
 
 lazy_static! {
     static ref BINARIES: HashMap<String, Option<PathBuf>> = [
@@ -50,6 +51,7 @@ lazy_static! {
         (THIN_REPAIR.to_string(), find_binary(THIN_REPAIR)),
         (XFS_ADMIN.to_string(), find_binary(XFS_ADMIN)),
         (XFS_GROWFS.to_string(), find_binary(XFS_GROWFS)),
+        (FSTRIM.to_string(), find_binary(FSTRIM)),
     ].iter()
         .cloned()
         .collect();
@@ -152,6 +154,11 @@ pub fn thin_repair(meta_dev: &Path, new_meta_dev: &Path) -> StratisResult<()> {
             .arg("-o")
             .arg(new_meta_dev),
     )
+}
+
+/// Call fstrim on a mounted filesystem
+pub fn fstrim(mounted_fs: &Path) -> StratisResult<()> {
+    execute_cmd(Command::new(get_executable(FSTRIM).as_os_str()).arg(mounted_fs))
 }
 
 /// Call udevadm settle

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -315,6 +315,13 @@ impl Engine for StratEngine {
 
         Ok(())
     }
+
+    fn maintenance(&mut self) -> StratisResult<()> {
+        for (pool_name, pool_uuid, pool) in &mut self.pools {
+            pool.maintenance(pool_name, *pool_uuid)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -246,6 +246,10 @@ impl StratPool {
         Ok(())
     }
 
+    pub fn maintenance(&mut self, pool_name: &Name, _pool_uuid: PoolUuid) -> StratisResult<()> {
+        self.thin_pool.fstrim(pool_name)
+    }
+
     pub fn record(&self, name: &str) -> PoolSave {
         PoolSave {
             name: name.to_owned(),

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -49,7 +49,8 @@ pub struct FilesystemSave {
     pub uuid: FilesystemUuid,
     pub thin_id: ThinDevId,
     pub size: Sectors,
-    pub created: u64, // Unix timestamp
+    pub created: u64,     // Unix timestamp
+    pub last_fstrim: u64, // Unix timestamp
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use chrono::{DateTime, TimeZone, Utc};
 #[cfg(feature = "dbus_enabled")]
 use dbus;
 use uuid::Uuid;
@@ -10,6 +9,8 @@ use uuid::Uuid;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, TimeZone, Utc};
 
 use devicemapper::{
     Bytes, DmDevice, DmName, DmUuid, Sectors, ThinDev, ThinDevId, ThinPoolDev, ThinStatus, IEC,
@@ -45,6 +46,7 @@ pub struct StratFilesystem {
     created: DateTime<Utc>,
     #[cfg(feature = "dbus_enabled")]
     dbus_path: Option<dbus::Path<'static>>,
+    pub last_fstrim: DateTime<Utc>,
 }
 
 pub enum FilesystemStatus {
@@ -81,6 +83,7 @@ impl StratFilesystem {
                 created: Utc::now(),
                 #[cfg(feature = "dbus_enabled")]
                 dbus_path: None,
+                last_fstrim: Utc::now(),
             },
         ))
     }
@@ -105,6 +108,7 @@ impl StratFilesystem {
             created: Utc.timestamp(fssave.created as i64, 0),
             #[cfg(feature = "dbus_enabled")]
             dbus_path: None,
+            last_fstrim: Utc.timestamp(fssave.last_fstrim as i64, 0),
         })
     }
 
@@ -164,6 +168,7 @@ impl StratFilesystem {
                     created: Utc::now(),
                     #[cfg(feature = "dbus_enabled")]
                     dbus_path: None,
+                    last_fstrim: self.last_fstrim,
                 })
             }
             Err(e) => Err(StratisError::Engine(
@@ -230,6 +235,7 @@ impl StratFilesystem {
             thin_id: self.thin_dev.id(),
             size: self.thin_dev.size(),
             created: self.created.timestamp() as u64,
+            last_fstrim: self.last_fstrim.timestamp() as u64,
         }
     }
 


### PR DESCRIPTION
Add `cmd::fstrim`.

Add a second interval timer that triggers daily for periodic maintenance tasks.

Add an Engine method called `maintenance()`, which in StratPool then calls `StratPool::maintenance()`, which then calls `ThinPool::fstrim`, which then calls `StratFilesystem::fstrim`. fstrim works only on mounted filesystems so unmounted ones are skipped.

Aside from the maintenance interval, each filesystem also now keeps track of the last time it was trimmed, to decouple fstrim interval from maintenance callback interval, and also ensure that rebooting or restarting the daemon doesn't lead to fstrims more frequently than desired.