### PR TITLE
Ignore incomplete udev entries during enumeration

### DIFF
--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -39,6 +39,7 @@ pub fn get_udev_block_device(
 
     let result = enumerator
         .scan_devices()?
+        .filter(|dev| dev.is_initialized())
         .find(|x| x.devnode().map_or(false, |d| canonical == d))
         .and_then(|dev| Some(device_as_map(&dev)));
     Ok(result)
@@ -59,6 +60,7 @@ fn get_all_empty_devices() -> StratisResult<Vec<PathBuf>> {
 
     Ok(enumerator
         .scan_devices()?
+        .filter(|dev| dev.is_initialized())
         .filter(|dev| {
             dev.property_value("DM_MULTIPATH_DEVICE_PATH").is_none()
                 && !((dev.property_value("ID_PART_TABLE_TYPE").is_some()
@@ -78,6 +80,7 @@ pub fn get_stratis_block_devices() -> StratisResult<Vec<PathBuf>> {
 
     let devices: Vec<PathBuf> = enumerator
         .scan_devices()?
+        .filter(|dev| dev.is_initialized())
         .filter(|dev| dev.property_value("DM_MULTIPATH_DEVICE_PATH").is_none())
         .filter_map(|i| i.devnode().map(|d| d.into()))
         .collect();


### PR DESCRIPTION
When we start up we walk the udev db to see what is available.  When
we do this at early boot we have udev entries that exist, but are not
complete as the udev processing has not completed.  Thus we need to
ignore these db entries until they become complete.  When they do
become complete we will process it in the event handler for udev
events.

Signed-off-by: Tony Asleson <tasleson@redhat.com>