### PR TITLE
Remove a FIXME

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -734,8 +734,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(length < request);
-        // FIXME: change to Sector operation once implemented in devicemapper
-        assert_eq!(*length % *modulus, 0);
+        assert_eq!(length % modulus, Sectors(0));
         assert_eq!(backstore.next, old_next + length);
         assert_eq!(start, old_next);
 


### PR DESCRIPTION
Update to devicemapper version 0.24.0 allows % operator on Sectors.

Signed-off-by: mulhern <amulhern@redhat.com>