### PR TITLE
Export the pool state as a dbus property

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -239,6 +239,22 @@ impl EngineListener for EventHandler {
                     });
                 }
             }
+            &EngineEvent::PoolStateChanged { dbus_path, state } => {
+                if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_STATE_PROP,
+                        state.to_dbus_value(),
+                        &dbus_path,
+                    ).unwrap_or_else(|()| {
+                        error!(
+                            "PoolStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path,
+                            state.to_dbus_value(),
+                        );
+                    });
+                }
+            }
         }
     }
 }

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -4,6 +4,7 @@
 
 // Pool Properties
 pub const POOL_NAME_PROP: &str = "Name";
+pub const POOL_STATE_PROP: &str = "State";
 
 // Filesystem Properties
 pub const FILESYSTEM_NAME_PROP: &str = "Name";

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -353,6 +353,10 @@ fn get_pool_total_physical_size(
     })
 }
 
+fn get_pool_state(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<(), MethodErr> {
+    get_pool_property(i, p, |(_, _, pool)| Ok(pool.state().to_dbus_value()))
+}
+
 pub fn create_dbus_pool<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
@@ -420,6 +424,11 @@ pub fn create_dbus_pool<'a>(
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_uuid);
 
+    let state_property = f.property::<u16, _>(consts::POOL_STATE_PROP, ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::True)
+        .on_get(get_pool_state);
+
     let object_name = format!(
         "{}/{}",
         STRATIS_BASE_PATH,
@@ -441,7 +450,8 @@ pub fn create_dbus_pool<'a>(
                 .add_p(name_property)
                 .add_p(total_physical_size_property)
                 .add_p(total_physical_used_property)
-                .add_p(uuid_property),
+                .add_p(uuid_property)
+                .add_p(state_property),
         );
 
     let path = object_path.get_name().to_owned();

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Device, Sectors};
 
 use super::types::{
-    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolState, PoolUuid,
     RenameAction,
 };
 use stratis::StratisResult;
@@ -172,6 +172,9 @@ pub trait Pool: Debug {
         uuid: DevUuid,
         user_info: Option<&str>,
     ) -> StratisResult<bool>;
+
+    /// The current state of the Pool.
+    fn state(&self) -> PoolState;
 
     /// Set dbus path associated with the Pool.
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -5,7 +5,7 @@
 use std::fmt::Debug;
 use std::sync::{Once, ONCE_INIT};
 
-use super::types::{BlockDevState, MaybeDbusPath};
+use super::types::{BlockDevState, MaybeDbusPath, PoolState};
 
 static INIT: Once = ONCE_INIT;
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;
@@ -25,6 +25,10 @@ pub enum EngineEvent<'a> {
         dbus_path: &'a MaybeDbusPath,
         from: &'a str,
         to: &'a str,
+    },
+    PoolStateChanged {
+        dbus_path: &'a MaybeDbusPath,
+        state: PoolState,
     },
 }
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -19,7 +19,8 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::structures::Table;
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolState, PoolUuid, Redundancy,
+    RenameAction,
 };
 
 use super::blockdev::SimDev;
@@ -33,6 +34,7 @@ pub struct SimPool {
     filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
+    pool_state: PoolState,
     dbus_path: MaybeDbusPath,
 }
 
@@ -52,6 +54,7 @@ impl SimPool {
                 filesystems: Table::default(),
                 redundancy,
                 rdm: Rc::clone(rdm),
+                pool_state: PoolState::Good,
                 dbus_path: MaybeDbusPath(None),
             },
         )
@@ -275,6 +278,10 @@ impl Pool for SimPool {
             },
             |(_, b)| Ok(b.set_user_info(user_info)),
         )
+    }
+
+    fn state(&self) -> PoolState {
+        self.pool_state
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -14,7 +14,8 @@ use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolState, PoolUuid, Redundancy,
+    RenameAction,
 };
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
@@ -416,6 +417,10 @@ impl Pool for StratPool {
         } else {
             Ok(false)
         }
+    }
+
+    fn state(&self) -> PoolState {
+        self.thin_pool.state()
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -424,6 +424,7 @@ impl Pool for StratPool {
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {
+        self.thin_pool.set_dbus_path(path.clone());
         self.dbus_path = path
     }
 

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -22,7 +22,9 @@ use super::super::super::devlinks;
 use super::super::super::engine::Filesystem;
 use super::super::super::event::{get_engine_listener_list, EngineEvent};
 use super::super::super::structures::Table;
-use super::super::super::types::{FilesystemUuid, Name, PoolUuid, RenameAction};
+use super::super::super::types::{
+    FilesystemUuid, FreeSpaceState, Name, PoolState, PoolUuid, RenameAction,
+};
 
 use super::super::backstore::Backstore;
 use super::super::cmd::{thin_check, thin_repair};
@@ -200,19 +202,6 @@ impl Default for ThinPoolSizeParams {
             mdv_size: INITIAL_MDV_SIZE,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum PoolState {
-    Good,
-    Bad,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FreeSpaceState {
-    Good,
-    Warn,
-    Crit,
 }
 
 /// A ThinPool struct contains the thinpool itself, the spare
@@ -938,6 +927,10 @@ impl ThinPool {
             },
             None => Ok(()),
         }
+    }
+
+    pub fn state(&self) -> PoolState {
+        self.pool_state
     }
 
     /// Rename a filesystem within the thin pool.

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -22,6 +22,28 @@ pub enum RenameAction {
     Renamed,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PoolState {
+    Good,
+    Bad,
+}
+
+impl PoolState {
+    pub fn to_dbus_value(&self) -> u16 {
+        match *self {
+            PoolState::Good => 0,
+            PoolState::Bad => 1,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FreeSpaceState {
+    Good,
+    Warn,
+    Crit,
+}
+
 /// See Design Doc section 10.2.1 for more details.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockDevState {


### PR DESCRIPTION
Send PoolStateChanged event to listeners on state change.

Move PoolState and FreeSpaceState up to the top level types to be shared
with the SimEngine.
