### PR TITLE
Ref for destroy final

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -278,7 +278,7 @@ dependencies = [
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "devicemapper 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "devicemapper 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -747,7 +747,7 @@ dependencies = [
 "checksum crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc1914fae6f18ae347320f0ba5e4fc270e17c037ea621fe41ec7e8adf67d11b0"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b2c58aab20dd6637871e6e03cb6122f00b496a91eb65b688639c940012d8710"
-"checksum devicemapper 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46d226713a0e19208ad0d8b3f2815291ce110c185bb05c016e179a0b9ab608cb"
+"checksum devicemapper 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ce391c2502b3156ec55a54f1a953722cb981aa1a337594bfaeca42f2535188d"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.com>"]
 dbus = {version = "0.6.1", optional = true}
 clap = "2"
 nix = "0.11"
-devicemapper = "0.24.0"
+devicemapper = "0.25.0"
 crc = "1"
 byteorder = "1"
 chrono = "0.4"

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -92,7 +92,7 @@ pub trait Pool: Debug {
     /// Destroy the pool.
     /// Precondition: All filesystems belonging to this pool must be
     /// unmounted.
-    fn destroy(self) -> StratisResult<()>;
+    fn destroy(&mut self) -> StratisResult<()>;
 
     /// Ensures that all designated filesystems are gone from pool.
     /// Returns a list of the filesystems found, and actually destroyed.

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -127,7 +127,7 @@ impl Pool for SimPool {
         Ok(ret_uuids)
     }
 
-    fn destroy(self) -> StratisResult<()> {
+    fn destroy(&mut self) -> StratisResult<()> {
         // Nothing to do here.
         Ok(())
     }

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -459,16 +459,17 @@ impl Backstore {
     }
 
     /// Destroy the entire store.
-    pub fn destroy(self) -> StratisResult<()> {
+    pub fn destroy(&mut self) -> StratisResult<()> {
         match self.cache {
-            Some(cache) => {
+            Some(ref mut cache) => {
                 cache.teardown(get_dm())?;
                 self.cache_tier
+                    .as_mut()
                     .expect("if dm_device is cache, cache tier exists")
                     .destroy()?;
             }
             None => {
-                if let Some(linear) = self.linear {
+                if let Some(ref mut linear) = self.linear {
                     linear.teardown(get_dm())?;
                 }
             }
@@ -478,10 +479,10 @@ impl Backstore {
 
     /// Teardown the DM devices in the backstore.
     #[cfg(test)]
-    pub fn teardown(self) -> StratisResult<()> {
+    pub fn teardown(&mut self) -> StratisResult<()> {
         match self.cache {
-            Some(cache) => cache.teardown(get_dm()),
-            None => if let Some(linear) = self.linear {
+            Some(ref mut cache) => cache.teardown(get_dm()),
+            None => if let Some(ref mut linear) = self.linear {
                 linear.teardown(get_dm())
             } else {
                 Ok(())
@@ -801,7 +802,7 @@ mod tests {
         cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
-        let backstore =
+        let mut backstore =
             Backstore::setup(pool_uuid, &backstore_save, &map, None, Sectors(0)).unwrap();
         invariant(&backstore);
 
@@ -814,7 +815,7 @@ mod tests {
         cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = map.get(&pool_uuid).unwrap();
-        let backstore =
+        let mut backstore =
             Backstore::setup(pool_uuid, &backstore_save, &map, None, Sectors(0)).unwrap();
         invariant(&backstore);
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -213,7 +213,7 @@ impl BlockDevMgr {
         Ok(bdev_uuids)
     }
 
-    pub fn destroy_all(self) -> StratisResult<()> {
+    pub fn destroy_all(&mut self) -> StratisResult<()> {
         wipe_blockdevs(&self.block_devs)
     }
 
@@ -727,7 +727,7 @@ mod tests {
     /// them releases all.
     fn test_ownership(paths: &[&Path]) -> () {
         let pool_uuid = Uuid::new_v4();
-        let bd_mgr = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
+        let mut bd_mgr = BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
 
         cmd::udev_settle().unwrap();
 

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -135,7 +135,7 @@ impl CacheTier {
     }
 
     /// Destroy the tier. Wipe its blockdevs.
-    pub fn destroy(self) -> StratisResult<()> {
+    pub fn destroy(&mut self) -> StratisResult<()> {
         self.block_mgr.destroy_all()
     }
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -120,7 +120,7 @@ impl DataTier {
     }
 
     /// Destroy the store. Wipe its blockdevs.
-    pub fn destroy(self) -> StratisResult<()> {
+    pub fn destroy(&mut self) -> StratisResult<()> {
         self.block_mgr.destroy_all()
     }
 

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -13,7 +13,7 @@ use super::pool::StratPool;
 /// Teardown pools.
 pub fn teardown_pools(pools: Table<StratPool>) -> StratisResult<()> {
     let mut untorndown_pools = Vec::new();
-    for (_, uuid, pool) in pools {
+    for (_, uuid, mut pool) in pools {
         pool.teardown()
             .unwrap_or_else(|_| untorndown_pools.push(uuid));
     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -236,7 +236,7 @@ impl Engine for StratEngine {
             return Ok(false);
         }
 
-        let (pool_name, pool) = self.pools
+        let (pool_name, mut pool) = self.pools
             .remove_by_uuid(uuid)
             .expect("Must succeed since self.pools.get_by_uuid() returned a value");
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -204,7 +204,7 @@ impl StratPool {
 
     /// Teardown a pool.
     #[cfg(test)]
-    pub fn teardown(self) -> StratisResult<()> {
+    pub fn teardown(&mut self) -> StratisResult<()> {
         self.thin_pool.teardown()?;
         self.backstore.teardown()
     }
@@ -303,7 +303,7 @@ impl Pool for StratPool {
         bdev_info
     }
 
-    fn destroy(self) -> StratisResult<()> {
+    fn destroy(&mut self) -> StratisResult<()> {
         self.thin_pool.teardown()?;
         self.backstore.destroy()?;
         Ok(())
@@ -458,14 +458,14 @@ mod tests {
         let (paths1, paths2) = paths.split_at(paths.len() / 2);
 
         let name1 = "name1";
-        let (uuid1, pool1) =
+        let (uuid1, mut pool1) =
             StratPool::initialize(&name1, paths1, Redundancy::NONE, false).unwrap();
         invariant(&pool1, &name1);
 
         let metadata1 = pool1.record(name1);
 
         let name2 = "name2";
-        let (uuid2, pool2) =
+        let (uuid2, mut pool2) =
             StratPool::initialize(&name2, paths2, Redundancy::NONE, false).unwrap();
         invariant(&pool2, &name2);
 

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -45,7 +45,7 @@ impl RealTestDev {
     /// Teardown a real test dev
     fn teardown(self) -> () {
         wipe_sectors(&self.as_path(), Sectors(0), Bytes(IEC::Mi).sectors()).unwrap();
-        if let Some(ld) = self.dev.right() {
+        if let Some(mut ld) = self.dev.right() {
             ld.teardown(get_dm()).unwrap();
         }
     }

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -211,13 +211,13 @@ impl StratFilesystem {
     }
 
     /// Tear down the filesystem.
-    pub fn teardown(self) -> StratisResult<()> {
+    pub fn teardown(&mut self) -> StratisResult<()> {
         self.thin_dev.teardown(get_dm())?;
         Ok(())
     }
 
     /// Destroy the filesystem.
-    pub fn destroy(self, thin_pool: &ThinPoolDev) -> StratisResult<()> {
+    pub fn destroy(&mut self, thin_pool: &ThinPoolDev) -> StratisResult<()> {
         self.thin_dev.destroy(get_dm(), thin_pool)?;
         Ok(())
     }

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -197,7 +197,7 @@ impl MetadataVol {
     }
 
     /// Tear down a Metadata Volume.
-    pub fn teardown(self) -> StratisResult<()> {
+    pub fn teardown(&mut self) -> StratisResult<()> {
         self.dev.teardown(get_dm())?;
 
         Ok(())

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -418,6 +418,8 @@ impl ThinPool {
         for (name, uuid, fs) in filesystems {
             let evicted = fs_table.insert(name, uuid, fs);
             if evicted.is_some() {
+                // TODO: Recover here. Failing the entire pool setup because
+                // of this is too harsh.
                 let err_msg = "filesystems with duplicate UUID or name specified in metadata";
                 return Err(StratisError::Engine(ErrorEnum::Invalid, err_msg.into()));
             }

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -663,10 +663,10 @@ impl ThinPool {
 
     /// Tear down the components managed here: filesystems, the MDV,
     /// and the actual thinpool device itself.
-    pub fn teardown(self) -> StratisResult<()> {
+    pub fn teardown(&mut self) -> StratisResult<()> {
         // Must succeed in tearing down all filesystems before the
         // thinpool..
-        for (_, _, fs) in self.filesystems {
+        for (_, _, ref mut fs) in &mut self.filesystems {
             fs.teardown()?;
         }
         self.thin_pool.teardown(get_dm())?;
@@ -900,7 +900,7 @@ impl ThinPool {
         pool_name: &str,
         uuid: FilesystemUuid,
     ) -> StratisResult<()> {
-        if let Some((fs_name, fs)) = self.filesystems.remove_by_uuid(uuid) {
+        if let Some((fs_name, mut fs)) = self.filesystems.remove_by_uuid(uuid) {
             fs.destroy(&self.thin_pool)?;
             self.mdv.rm_fs(uuid)?;
             devlinks::filesystem_removed(pool_name, &fs_name)?;
@@ -1088,7 +1088,7 @@ fn setup_metadev(
 /// and return the new meta device.
 fn attempt_thin_repair(
     pool_uuid: PoolUuid,
-    meta_dev: LinearDev,
+    mut meta_dev: LinearDev,
     device: Device,
     spare_segments: &[(Sectors, Sectors)],
 ) -> StratisResult<LinearDev> {


### PR DESCRIPTION
Final PR, based on work PR #1151.

Make use of the new &mut self argument for destroy() in devicemapper 0.25.0 to recover from fs.destroy() failing for a mounted filesystem. There are also some other problems around filesystem setup/destroy that this PR tries to improve.