### PR TITLE
Remove warn! for pool already known

### DIFF
--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -123,9 +123,9 @@ pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
 
 /// Determine if devnode is a Stratis device. Return the device's Stratis
 /// pool UUID if it belongs to Stratis.
-pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<PoolUuid>> {
+pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<(PoolUuid, DevUuid)>> {
     match identify(devnode)? {
-        DevOwnership::Ours(pool_uuid, _) => Ok(Some(pool_uuid)),
+        DevOwnership::Ours(pool_uuid, dev_uuid) => Ok(Some((pool_uuid, dev_uuid))),
         _ => Ok(None),
     }
 }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -200,15 +200,16 @@ impl Engine for StratEngine {
                 // TODO: Handle the case where we have found a device for an already active pool
                 // ref. https://github.com/stratis-storage/stratisd/issues/748
 
-                if let Some((name, pool)) = self.pools.get_by_uuid(pool_uuid) {
-                    if pool.get_blockdev(device_uuid).is_none() {
-                        error!(
-                            "we have a block device {:?} with pool {}, uuid = {} device uuid = {} \
-                             which believes it belongs in this pool, but existing active pool has \
-                             no knowledge of it",
-                            dev_node, name, pool_uuid, device_uuid
-                        );
-                    }
+                let (name, pool) = self.pools
+                    .get_by_uuid(pool_uuid)
+                    .expect("pools.contains_uuid(pool_uuid)");
+                if pool.get_blockdev(device_uuid).is_none() {
+                    error!(
+                        "we have a block device {:?} with pool {}, uuid = {} device uuid = {} \
+                         which believes it belongs in this pool, but existing active pool has \
+                         no knowledge of it",
+                        dev_node, name, pool_uuid, device_uuid
+                    );
                 }
                 None
             } else {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -203,7 +203,7 @@ impl Engine for StratEngine {
                 if let Some((name, pool)) = self.pools.get_by_uuid(pool_uuid) {
                     if !pool.blockdevs()
                         .iter()
-                        .find(|(block_uuid, _)| *block_uuid == device_uuid)
+                        .find(|blkdev_info| blkdev_info.0 == device_uuid)
                         .is_some()
                     {
                         error!(

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -191,14 +191,29 @@ impl Engine for StratEngine {
         device: Device,
         dev_node: PathBuf,
     ) -> StratisResult<Option<PoolUuid>> {
-        let pool_uuid = if let Some(pool_uuid) = is_stratis_device(&dev_node)? {
+        let pool_uuid = if let Some((pool_uuid, device_uuid)) = is_stratis_device(&dev_node)? {
             if self.pools.contains_uuid(pool_uuid) {
+                // We can get udev events for devices that are already in the pool.  Lets check
+                // to see if this block device is already in this existing pool.  If it is, then all
+                // is well.  If it's not then we have what is documented below.
+                //
                 // TODO: Handle the case where we have found a device for an already active pool
                 // ref. https://github.com/stratis-storage/stratisd/issues/748
-                warn!(
-                    "pool {} is already known, ignoring device {:?}!",
-                    pool_uuid, dev_node
-                );
+
+                if let Some((name, pool)) = self.pools.get_by_uuid(pool_uuid) {
+                    if !pool.blockdevs()
+                        .iter()
+                        .find(|(block_uuid, _)| *block_uuid == device_uuid)
+                        .is_some()
+                    {
+                        error!(
+                            "we have a block device {:?} with pool {}, uuid = {} device uuid = {} \
+                             which believes it belongs in this pool, but existing active pool has \
+                             no knowledge of it",
+                            dev_node, name, pool_uuid, device_uuid
+                        );
+                    }
+                }
                 None
             } else {
                 let mut devices = self.incomplete_pools

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -201,11 +201,7 @@ impl Engine for StratEngine {
                 // ref. https://github.com/stratis-storage/stratisd/issues/748
 
                 if let Some((name, pool)) = self.pools.get_by_uuid(pool_uuid) {
-                    if !pool.blockdevs()
-                        .iter()
-                        .find(|blkdev_info| blkdev_info.0 == device_uuid)
-                        .is_some()
-                    {
+                    if pool.get_blockdev(device_uuid).is_none() {
                         error!(
                             "we have a block device {:?} with pool {}, uuid = {} device uuid = {} \
                              which believes it belongs in this pool, but existing active pool has \


### PR DESCRIPTION
This message gets printed often and is expected with us monitoring
both 'add' and 'change' udev events.  Add additional check for the
more hideous issue of having a device which thinks it belongs in a
pool, but the existing active pool has no knowledge of it.

Removes the `warn` but does not fully address what we should do for https://github.com/stratis-storage/stratisd/issues/748

Signed-off-by: Tony Asleson <tasleson@redhat.com>