### PR TITLE
Change error return if fs.destroy() failed with EBUSY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "devicemapper"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/agrover/devicemapper-rs?branch=fix-error-msg#5a5dc4ba2c8bc113f13b63dcd09d1110e535090f"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -278,7 +278,7 @@ dependencies = [
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "devicemapper 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "devicemapper 0.25.0 (git+https://github.com/agrover/devicemapper-rs?branch=fix-error-msg)",
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -747,7 +747,7 @@ dependencies = [
 "checksum crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc1914fae6f18ae347320f0ba5e4fc270e17c037ea621fe41ec7e8adf67d11b0"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum dbus 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b2c58aab20dd6637871e6e03cb6122f00b496a91eb65b688639c940012d8710"
-"checksum devicemapper 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ce391c2502b3156ec55a54f1a953722cb981aa1a337594bfaeca42f2535188d"
+"checksum devicemapper 0.25.0 (git+https://github.com/agrover/devicemapper-rs?branch=fix-error-msg)" = "<none>"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.com>"]
 dbus = {version = "0.6.1", optional = true}
 clap = "2"
 nix = "0.11"
-devicemapper = "0.25.0"
+devicemapper = { git = "https://github.com/agrover/devicemapper-rs", branch="fix-error-msg" }
 crc = "1"
 byteorder = "1"
 chrono = "0.4"

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -7,13 +7,13 @@
 use std;
 use std::borrow::BorrowMut;
 
+use nix::errno::Errno;
 use uuid::Uuid;
 
-use devicemapper as dm;
 use devicemapper::{
-    device_exists, Bytes, DataBlocks, Device, DmDevice, DmName, DmNameBuf, FlakeyTargetParams,
-    LinearDev, LinearDevTargetParams, LinearTargetParams, MetaBlocks, Sectors, TargetLine,
-    ThinDevId, ThinPoolDev, ThinPoolStatusSummary, IEC,
+    self as dm, device_exists, Bytes, DataBlocks, Device, DmDevice, DmError, DmName, DmNameBuf,
+    FlakeyTargetParams, LinearDev, LinearDevTargetParams, LinearTargetParams, MetaBlocks, Sectors,
+    TargetLine, ThinDevId, ThinPoolDev, ThinPoolStatusSummary, IEC,
 };
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
@@ -933,7 +933,15 @@ impl ThinPool {
                 }
                 Err(err) => {
                     self.filesystems.insert(fs_name, uuid, fs);
-                    Err(err)
+
+                    // Catch EBUSY and return a nicer error
+                    match err {
+                        StratisError::DM(DmError::Core(dm::errors::Error(
+                            dm::errors::ErrorKind::IoctlError(_, Some(Errno::EBUSY)),
+                            _,
+                        ))) => Err(StratisError::Error("Filesystem is in use".into())),
+                        _ => Err(err),
+                    }
                 }
             },
             None => Ok(()),


### PR DESCRIPTION
Using newly-included errno value, match on EBUSY and return a StratisError::Error instead, with a relevant message.

fixes #1160