### PR TITLE
 Remove warn! for pool already known (Final)

### DIFF
--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -123,9 +123,9 @@ pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
 
 /// Determine if devnode is a Stratis device. Return the device's Stratis
 /// pool UUID if it belongs to Stratis.
-pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<PoolUuid>> {
+pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<(PoolUuid, DevUuid)>> {
     match identify(devnode)? {
-        DevOwnership::Ours(pool_uuid, _) => Ok(Some(pool_uuid)),
+        DevOwnership::Ours(pool_uuid, dev_uuid) => Ok(Some((pool_uuid, dev_uuid))),
         _ => Ok(None),
     }
 }

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -16,6 +16,7 @@ mod setup;
 mod util;
 
 pub use self::backstore::Backstore;
+pub use self::blockdev::StratBlockDev;
 pub use self::device::blkdev_size;
 pub use self::device::is_stratis_device;
 pub use self::metadata::MIN_MDA_SECTORS;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -18,7 +18,7 @@ use super::super::types::{
 };
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::backstore::{Backstore, MIN_MDA_SECTORS};
+use super::backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS};
 use super::serde_structs::{FlexDevsSave, PoolSave, Recordable};
 use super::thinpool::{ThinPool, ThinPoolSizeParams};
 
@@ -247,6 +247,10 @@ impl StratPool {
             thinpool_dev: self.thin_pool.record(),
         }
     }
+
+    pub fn get_strat_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &StratBlockDev)> {
+        self.backstore.get_blockdev_by_uuid(uuid)
+    }
 }
 
 impl Pool for StratPool {
@@ -390,8 +394,7 @@ impl Pool for StratPool {
     }
 
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)> {
-        self.backstore
-            .get_blockdev_by_uuid(uuid)
+        self.get_strat_blockdev(uuid)
             .map(|(t, b)| (t, b as &BlockDev))
     }
 


### PR DESCRIPTION
 Remove warn! for pool already known

This message gets printed often and is expected with us monitoring
both 'add' and 'change' udev events.  Add additional check for the
more hideous issue of having a device which thinks it belongs in a
pool, but the existing active pool has no knowledge of it.

Signed-off-by: Tony Asleson <tasleson@redhat.com>