### PR TITLE
Make pool.total_physical_used never return an error

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -137,7 +137,7 @@ pub trait Pool: Debug {
     /// The number of Sectors in this pool that are currently in use by the
     /// pool for some purpose, be it to store metadata, to store user data,
     /// or to reserve for some other purpose.
-    fn total_physical_used(&self) -> StratisResult<Sectors>;
+    fn total_physical_used(&mut self) -> Sectors;
 
     /// Get all the filesystems belonging to this pool.
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)>;

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -201,8 +201,8 @@ impl Pool for SimPool {
         Sectors(IEC::Ei)
     }
 
-    fn total_physical_used(&self) -> StratisResult<Sectors> {
-        Ok(Sectors(0))
+    fn total_physical_used(&mut self) -> Sectors {
+        Sectors(0)
     }
 
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)> {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -111,6 +111,7 @@ pub struct StratPool {
     redundancy: Redundancy,
     thin_pool: ThinPool,
     dbus_path: MaybeDbusPath,
+    last_phys_used: Sectors,
 }
 
 impl StratPool {
@@ -144,11 +145,14 @@ impl StratPool {
 
         thinpool.check(pool_uuid, &mut backstore)?;
 
+        let last_phys_used = Self::try_total_physical_used(&thinpool, &backstore)?;
+
         let mut pool = StratPool {
             backstore,
             redundancy,
             thin_pool: thinpool,
             dbus_path: MaybeDbusPath(None),
+            last_phys_used,
         };
 
         pool.write_metadata(&Name::new(name.to_owned()))?;
@@ -181,11 +185,14 @@ impl StratPool {
 
         let changed = thinpool.check(uuid, &mut backstore)?;
 
+        let last_phys_used = Self::try_total_physical_used(&thinpool, &backstore)?;
+
         let mut pool = StratPool {
             backstore,
             redundancy: Redundancy::NONE,
             thin_pool: thinpool,
             dbus_path: MaybeDbusPath(None),
+            last_phys_used,
         };
 
         let pool_name = &metadata.name;
@@ -212,6 +219,15 @@ impl StratPool {
 
     pub fn has_filesystems(&self) -> bool {
         self.thin_pool.has_filesystems()
+    }
+
+    fn try_total_physical_used(
+        thin_pool: &ThinPool,
+        backstore: &Backstore,
+    ) -> StratisResult<Sectors> {
+        thin_pool
+            .total_physical_used()
+            .and_then(|v| Ok(v + backstore.datatier_metadata_size()))
     }
 
     /// The names of DM devices belonging to this pool that may generate events
@@ -352,10 +368,21 @@ impl Pool for StratPool {
         self.backstore.datatier_current_capacity()
     }
 
-    fn total_physical_used(&self) -> StratisResult<Sectors> {
-        self.thin_pool
-            .total_physical_used()
-            .and_then(|v| Ok(v + self.backstore.datatier_metadata_size()))
+    fn total_physical_used(&mut self) -> Sectors {
+        match Self::try_total_physical_used(&self.thin_pool, &self.backstore) {
+            Ok(val) => {
+                self.last_phys_used = val;
+                val
+            }
+            Err(err) => {
+                error!(
+                    "try_total_physical_used failed, should never happen: {}",
+                    err
+                );
+                self.thin_pool.set_state(PoolState::Bad);
+                self.last_phys_used
+            }
+        }
     }
 
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)> {

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -582,7 +582,7 @@ impl ThinPool {
         Ok(should_save)
     }
 
-    fn set_state(&mut self, new_state: PoolState) {
+    pub fn set_state(&mut self, new_state: PoolState) {
         if self.state() != new_state {
             self.pool_state = new_state;
             get_engine_listener_list().notify(&EngineEvent::PoolStateChanged {


### PR DESCRIPTION
Having a property included in GetManagedObjects fail is very bad because
if it does then the client gets no info.

Since total_physical_used() makes an ioctl call, theoretically it can
fail. Cover this by caching the last value and returning that if the
ioctl fails. Since this requires changing StratPool, some things in
the dbus code need to use mut refs instead of just refs.
