### PR TITLE
Set throttling in all directories under /sys/fs/cgroup/blkio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "timerfd 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -518,6 +519,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +704,16 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +736,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "winapi-i686-pc-windows-gnu"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -794,6 +821,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "ce67a48047802238bfc88687272de48fd6d7af256b0097f110e968b0017235a5"
 "checksum serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "10552fad5500771f3902d0c5ba187c5881942b811b7ba0d8fbbfbf84d80806d3"
@@ -817,9 +845,11 @@ dependencies = [
 "checksum uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8630752f979f1b6b87c49830a5e3784082545de63920d59fbaac252474319447"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "af464bc7be7b785c7ac72e266a6b67c4c9070155606f51655a650a6686204e35"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ error-chain = "0.12"
 libudev = "0.2.0"
 lazy_static = "1.0.0"
 timerfd = "1.0.0"
+walkdir = "2.2.5"
 
 [dependencies.uuid]
 version = "0.6"

--- a/src/engine/strat_engine/throttle.rs
+++ b/src/engine/strat_engine/throttle.rs
@@ -2,10 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::{self, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::Write;
 
 use devicemapper::{Bytes, Device};
+use walkdir::WalkDir;
 
 use stratis::StratisResult;
 
@@ -16,30 +17,19 @@ const THROTTLE_BPS_PATH: &str = "blkio.throttle.write_bps_device";
 /// throttling by passing `None` for `bytes_per_sec`.
 // The underlying APIs here are... in flux. Hierarchical blkio throttling
 // doesn't work on all configs. What we're doing for the moment is setting the
-// throttle in *all* cgroups if they are present, but if not, then trying to
-// do it at the root level.
+// throttle in *all* cgroups that are present.
 pub fn set_write_throttling(device: Device, bytes_per_sec: Option<Bytes>) -> StratisResult<()> {
     // Setting to u64::max_value() removes throttling.
     let value = bytes_per_sec.unwrap_or_else(|| Bytes(u64::max_value()));
 
-    // Find all cgroup subdirectories
-    let mut cg_dirs = fs::read_dir(CGROUP_PATH)?
+    for mut cg_entry in WalkDir::new(CGROUP_PATH)
         .into_iter()
-        .filter_map(|entry| entry.ok())
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect::<Vec<_>>();
-
-    // If there are no subdirs, get the root cgroup
-    if cg_dirs.is_empty() {
-        cg_dirs.push(CGROUP_PATH.into());
-    }
-
-    for mut cg_dir in cg_dirs {
-        cg_dir.push(THROTTLE_BPS_PATH);
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_str() == Some(THROTTLE_BPS_PATH))
+    {
         OpenOptions::new()
             .write(true)
-            .open(cg_dir)
+            .open(cg_entry.path())
             .and_then(|mut f| f.write_all(format!("{} {}", device, *value).as_bytes()))?;
     }
 
@@ -56,7 +46,7 @@ mod tests {
 
     use super::*;
 
-    use std::fs::OpenOptions;
+    use std::fs::{self, OpenOptions};
     use std::io::Read;
     use std::os::unix::fs::MetadataExt;
     use std::path::Path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate log;
 extern crate libudev;
+extern crate walkdir;
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
What we were doing previously did not work in all cases. Using this code
I was able to see blkio throttling on a development machine where
previously it did not work.

Use the "walkdir" crate to iterate through the entire directory hierarchy
and set the throttle in all files that match the filename.

Signed-off-by: Andy Grover <agrover@redhat.com>