### PR TITLE
Change backstore.available() to include space not yet allocated to the cap device

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -317,7 +317,7 @@ impl Backstore {
         sizes: &[Sectors],
     ) -> StratisResult<Option<Vec<(Sectors, Sectors)>>> {
         let total_required = sizes.iter().cloned().sum();
-        let available = self.available();
+        let available = self.available_in_cap();
         if available < total_required {
             if self.data_tier.alloc(total_required - available) {
                 self.extend_cap_device(pool_uuid)?;
@@ -373,7 +373,7 @@ impl Backstore {
             return Ok(None);
         }
 
-        let available = self.available();
+        let available = self.available_in_cap();
         if available < internal_request {
             let mut allocated = false;
             while !allocated && internal_request != Sectors(0) {
@@ -384,7 +384,7 @@ impl Backstore {
             if allocated {
                 self.extend_cap_device(pool_uuid)?;
 
-                let return_amt = cmp::min(request, self.available());
+                let return_amt = cmp::min(request, self.available_in_cap());
                 let return_amt = (return_amt / modulus) * modulus;
                 self.next += return_amt;
                 Ok(Some((self.next - return_amt, return_amt)))
@@ -442,8 +442,8 @@ impl Backstore {
             .unwrap_or(Sectors(0))
     }
 
-    /// The available number of Sectors.
-    pub fn available(&self) -> Sectors {
+    /// The available number of Sectors in the cap device.
+    pub fn available_in_cap(&self) -> Sectors {
         let size = self.size();
         // It is absolutely essential for correct operation that the assertion
         // be true. If it is false, the result will be incorrect, and space

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -458,6 +458,9 @@ impl Backstore {
         size - self.next
     }
 
+    /// The available number of Sectors in the Backstore. (Note: future
+    /// changes may change the semantics of this value, or may make it
+    /// impossible to calculate.)
     pub fn available(&self) -> Sectors {
         self.datatier_current_capacity() - self.next
     }

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -458,6 +458,10 @@ impl Backstore {
         size - self.next
     }
 
+    pub fn available(&self) -> Sectors {
+        self.datatier_current_capacity() - self.next
+    }
+
     /// Destroy the entire store.
     pub fn destroy(&mut self) -> StratisResult<()> {
         match self.cache {

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -134,13 +134,11 @@ fn coalesce_segs(
 /// Calculate new low water based on the current thinpool data device size
 /// and the amount of unused sectors available for further extension.
 /// Postcondition:
-/// result == max(M * (data_dev_size + available) - available, L)
+/// result == max(M * (data_dev_size + available) - available, DATA_LOWATER)
 /// equivalently:
-/// result == max(M * data_dev_size - (1 - M) * available, L)
+/// result == max(M * data_dev_size - (1 - M) * available, DATA_LOWATER)
 /// where M <= (100 - SPACE_WARN_PCT)/100 if self.free_space_state == Good
 ///            (100 - SPACE_CRIT_PCT)/100  if self.free_space_state != Good
-///       L = DATA_LOWATER if self.free_space_state == Good
-///           throttle rate if self.free_space_state != Good
 // TODO: Use proptest to verify the behavior of this method.
 fn calc_lowater(
     data_dev_size: DataBlocks,

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -555,7 +555,8 @@ impl ThinPool {
                 // Update pool space state
                 self.free_space_state = self.free_space_check(
                     usage.used_data,
-                    current_total - usage.used_data + sectors_to_datablocks(backstore.available()),
+                    (current_total - usage.used_data)
+                        + sectors_to_datablocks(backstore.available()),
                 )?;
 
                 // Trigger next event depending on pool space state

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -125,8 +125,14 @@ fn coalesce_segs(
     segments
 }
 
+/// Use the lowater event for two purposes: extending the data dev and also
+/// getting an event when a FreeSpaceState threshold is crossed.
+/// Most of the time, this results in just DATA_LOWATER. The two times it
+/// doesn't is 1) right before a FreeSpaceState threshold (but the threshold
+/// is still above DATA_LOWATER) and 2) If the data dev is already extended
+/// far beyond its current usage -- past the next freespace threshold.
 /// Calculate new low water based on the current thinpool data device size
-/// and the amount of unused sectors available in the cap device.
+/// and the amount of unused sectors available for further extension.
 /// Postcondition:
 /// result == max(M * (data_dev_size + available) - available, L)
 /// equivalently:

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -315,7 +315,7 @@ impl ThinPool {
             data_block_size,
             calc_lowater(
                 sectors_to_datablocks(data_dev_size),
-                sectors_to_datablocks(backstore.available_in_cap()),
+                sectors_to_datablocks(backstore.available()),
                 free_space_state,
             ),
         )?;
@@ -382,7 +382,7 @@ impl ThinPool {
             thin_pool_save.data_block_size,
             calc_lowater(
                 sectors_to_datablocks(data_dev_size),
-                sectors_to_datablocks(backstore.available_in_cap()),
+                sectors_to_datablocks(backstore.available()),
                 free_space_state,
             ),
         )?;
@@ -555,14 +555,13 @@ impl ThinPool {
                 // Update pool space state
                 self.free_space_state = self.free_space_check(
                     usage.used_data,
-                    current_total + sectors_to_datablocks(backstore.available_in_cap())
-                        - usage.used_data,
+                    current_total - usage.used_data + sectors_to_datablocks(backstore.available()),
                 )?;
 
                 // Trigger next event depending on pool space state
                 let lowater = calc_lowater(
                     current_total,
-                    sectors_to_datablocks(backstore.available_in_cap()),
+                    sectors_to_datablocks(backstore.available()),
                     self.free_space_state,
                 );
 

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -315,7 +315,7 @@ impl ThinPool {
             data_block_size,
             calc_lowater(
                 sectors_to_datablocks(data_dev_size),
-                sectors_to_datablocks(backstore.available()),
+                sectors_to_datablocks(backstore.available_in_cap()),
                 free_space_state,
             ),
         )?;
@@ -382,7 +382,7 @@ impl ThinPool {
             thin_pool_save.data_block_size,
             calc_lowater(
                 sectors_to_datablocks(data_dev_size),
-                sectors_to_datablocks(backstore.available()),
+                sectors_to_datablocks(backstore.available_in_cap()),
                 free_space_state,
             ),
         )?;
@@ -555,13 +555,14 @@ impl ThinPool {
                 // Update pool space state
                 self.free_space_state = self.free_space_check(
                     usage.used_data,
-                    current_total + sectors_to_datablocks(backstore.available()) - usage.used_data,
+                    current_total + sectors_to_datablocks(backstore.available_in_cap())
+                        - usage.used_data,
                 )?;
 
                 // Trigger next event depending on pool space state
                 let lowater = calc_lowater(
                     current_total,
-                    sectors_to_datablocks(backstore.available()),
+                    sectors_to_datablocks(backstore.available_in_cap()),
                     self.free_space_state,
                 );
 

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -147,24 +147,23 @@ fn calc_lowater(
     available: DataBlocks,
     free_space_state: FreeSpaceState,
 ) -> DataBlocks {
-    // Calculate the low water. dev_low_water and action_pct are the device
-    // low water and the percent used at which an action should be taken for
-    // a particular free space state.
+    // Calculate the low water. action_pct is the the percent used at which an
+    // action should be taken for a particular free space state.
     //
     // Postcondition:
-    // result == max(M * data_dev_size - (1 - M) * available, dev_low_water)
+    // result == max(M * data_dev_size - (1 - M) * available, DATA_LOWATER)
     // where M <= (100 - action_pct)/100
-    let calc_lowater_internal = |dev_low_water: DataBlocks, action_pct: u8| -> DataBlocks {
+    let calc_lowater_internal = |action_pct: u8| -> DataBlocks {
         let total = data_dev_size + available;
 
         assert!(action_pct <= 100);
         let low_water = total - ((total * action_pct) / 100u8);
-        assert!(DataBlocks(std::u64::MAX) - available >= dev_low_water);
+        assert!(DataBlocks(std::u64::MAX) - available >= DATA_LOWATER);
 
         // WARNING: Do not alter this if-expression to a max-expression.
         // Doing so would invalidate the assertion below.
-        if dev_low_water + available > low_water {
-            dev_low_water
+        if DATA_LOWATER + available > low_water {
+            DATA_LOWATER
         } else {
             assert!(low_water >= available);
             low_water - available
@@ -172,8 +171,8 @@ fn calc_lowater(
     };
 
     match free_space_state {
-        FreeSpaceState::Good => calc_lowater_internal(DATA_LOWATER, SPACE_WARN_PCT),
-        _ => calc_lowater_internal(THROTTLE_BLOCKS_PER_SEC, SPACE_CRIT_PCT),
+        FreeSpaceState::Good => calc_lowater_internal(SPACE_WARN_PCT),
+        _ => calc_lowater_internal(SPACE_CRIT_PCT),
     }
 }
 


### PR DESCRIPTION
We are making incorrect calculations around FreeSpaceState because `backstore available()` is returning 0, meaning that no extra space is left in the cap device, but this ignores all the unallocated space available in the data tier.

The first commit renames `available()` to `available_in_cap()`. The second creates a new `available()` function that includes cap space but also other free space in the data tier. Using this in thinpool results in correct calculations for free space percentage.