### PR TITLE
Setup symbolic links on event driven pool bringup

### DIFF
--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -32,89 +32,115 @@ pub fn setup_dev_path() -> StratisResult<()> {
 /// or filesystem.
 // Don't just remove and recreate everything in case there are processes
 // (e.g. user shells) with the current working directory within the tree.
-pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(
-    pools: I,
-) -> StratisResult<()> {
-    let mut existing_dirs = fs::read_dir(DEV_PATH)?
-        .map(|dir_e| dir_e.and_then(|d| Ok(d.file_name().into_string().expect("Unix is utf-8"))))
-        .collect::<Result<HashSet<_>, _>>()?;
-
-    for &(ref pool_name, _, pool) in pools {
-        if !existing_dirs.remove(&pool_name.to_owned()) {
-            pool_added(pool_name)?;
-        }
-
-        let pool_path = pool_directory(pool_name);
-
-        let mut existing_files = fs::read_dir(pool_path)?
+pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(pools: I) -> () {
+    match || -> StratisResult<()> {
+        let mut existing_dirs = fs::read_dir(DEV_PATH)?
             .map(|dir_e| {
                 dir_e.and_then(|d| Ok(d.file_name().into_string().expect("Unix is utf-8")))
             })
             .collect::<Result<HashSet<_>, _>>()?;
 
-        for (fs_name, _, fs) in pool.filesystems() {
-            filesystem_added(pool_name, &fs_name, &fs.devnode())?;
-            existing_files.remove(&fs_name.to_owned());
+        for &(ref pool_name, _, pool) in pools {
+            if !existing_dirs.remove(&pool_name.to_owned()) {
+                pool_added(pool_name);
+            }
+
+            let pool_path = pool_directory(pool_name);
+
+            let mut existing_files = fs::read_dir(pool_path)?
+                .map(|dir_e| {
+                    dir_e.and_then(|d| Ok(d.file_name().into_string().expect("Unix is utf-8")))
+                })
+                .collect::<Result<HashSet<_>, _>>()?;
+
+            for (fs_name, _, fs) in pool.filesystems() {
+                filesystem_added(pool_name, &fs_name, &fs.devnode());
+                existing_files.remove(&fs_name.to_owned());
+            }
+
+            for leftover in existing_files {
+                filesystem_removed(pool_name, &leftover);
+            }
         }
 
-        for leftover in existing_files {
-            filesystem_removed(pool_name, &leftover)?;
+        for leftover in existing_dirs {
+            pool_removed(&Name::new(leftover));
         }
-    }
 
-    for leftover in existing_dirs {
-        pool_removed(&Name::new(leftover))?
-    }
-
-    Ok(())
+        Ok(())
+    }() {
+        Err(e) => {
+            warn!("setup_devlinks failed, reason {:?}", e);
+            ()
+        }
+        Ok(_) => (),
+    };
 }
 
 /// Create a directory when a pool is added.
-pub fn pool_added(pool: &str) -> StratisResult<()> {
+pub fn pool_added(pool: &str) -> () {
     let p = pool_directory(pool);
-    fs::create_dir(&p)?;
-    Ok(())
+    if let Err(e) = fs::create_dir(&p) {
+        warn!("unable to create pool directory {:?}, reason {:?}", p, e);
+    }
 }
 
 /// Remove the directory and its contents when the pool is removed.
-pub fn pool_removed(pool: &str) -> StratisResult<()> {
+pub fn pool_removed(pool: &str) -> () {
     let p = pool_directory(pool);
-    fs::remove_dir_all(&p)?;
-    Ok(())
+    if let Err(e) = fs::remove_dir_all(&p) {
+        warn!("unable to remove pool directory {:?}, reason {:?}", p, e);
+    }
 }
 
 /// Rename the directory to match the pool's new name.
-pub fn pool_renamed(old_name: &str, new_name: &str) -> StratisResult<()> {
+pub fn pool_renamed(old_name: &str, new_name: &str) -> () {
     let old = pool_directory(old_name);
     let new = pool_directory(new_name);
-    fs::rename(&old, &new)?;
-    Ok(())
+    if let Err(e) = fs::rename(&old, &new) {
+        warn!(
+            "unable to rename pool directory old {:?}, new {:?}, reason {:?}",
+            old, new, e
+        );
+    }
 }
 
 /// Create a symlink to the new filesystem's block device within its pool's
 /// directory.
-pub fn filesystem_added(pool_name: &str, fs_name: &str, devnode: &Path) -> StratisResult<()> {
+pub fn filesystem_added(pool_name: &str, fs_name: &str, devnode: &Path) -> () {
     let p = filesystem_mount_path(pool_name, fs_name);
 
     // Remove existing and recreate to ensure it points to the correct devnode
     let _ = fs::remove_file(&p);
-    symlink(devnode, &p)?;
-    Ok(())
+    if let Err(e) = symlink(devnode, &p) {
+        warn!(
+            "unable to create symlink for {:?} -> {:?}, reason {:?}",
+            devnode, p, e
+        );
+    }
 }
 
 /// Remove the symlink when the filesystem is destroyed.
-pub fn filesystem_removed(pool_name: &str, fs_name: &str) -> StratisResult<()> {
+pub fn filesystem_removed(pool_name: &str, fs_name: &str) -> () {
     let p = filesystem_mount_path(pool_name, fs_name);
-    fs::remove_file(&p)?;
-    Ok(())
+    if let Err(e) = fs::remove_file(&p) {
+        warn!(
+            "unable to remove symlink for filesystem {:?}, reason {:?}",
+            p, e
+        );
+    }
 }
 
 /// Rename the symlink to track the filesystem's new name.
-pub fn filesystem_renamed(pool_name: &str, old_name: &str, new_name: &str) -> StratisResult<()> {
+pub fn filesystem_renamed(pool_name: &str, old_name: &str, new_name: &str) -> () {
     let old = filesystem_mount_path(pool_name, old_name);
     let new = filesystem_mount_path(pool_name, new_name);
-    fs::rename(&old, &new)?;
-    Ok(())
+    if let Err(e) = fs::rename(&old, &new) {
+        warn!(
+            "unable to rename filesystem symlink for {:?} -> {:?}, reason {:?}",
+            old, new, e
+        );
+    }
 }
 
 /// Given a pool name, synthesize a pool directory name for storing filesystem

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -236,6 +236,7 @@ impl Engine for StratEngine {
                 devices.insert(device, dev_node);
                 match setup_pool(pool_uuid, &devices, &self.pools) {
                     Ok((pool_name, pool)) => {
+                        devlinks::setup_pool_devlinks(&pool_name, &pool);
                         self.pools.insert(pool_name, pool_uuid, pool);
                         Some(pool_uuid)
                     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -145,7 +145,7 @@ impl StratEngine {
             watched_dev_last_event_nrs: HashMap::new(),
         };
 
-        devlinks::setup_devlinks(engine.pools().iter())?;
+        devlinks::setup_devlinks(engine.pools().iter());
 
         Ok(engine)
     }
@@ -174,7 +174,7 @@ impl Engine for StratEngine {
         let (uuid, pool) = StratPool::initialize(name, blockdev_paths, redundancy, force)?;
 
         let name = Name::new(name.to_owned());
-        devlinks::pool_added(&name)?;
+        devlinks::pool_added(&name);
         self.pools.insert(name, uuid, pool);
         Ok(uuid)
     }
@@ -269,7 +269,7 @@ impl Engine for StratEngine {
             .expect("Must succeed since self.pools.get_by_uuid() returned a value");
 
         pool.destroy()?;
-        devlinks::pool_removed(&pool_name)?;
+        devlinks::pool_removed(&pool_name);
         Ok(true)
     }
 
@@ -292,7 +292,7 @@ impl Engine for StratEngine {
             });
 
             self.pools.insert(new_name.clone(), uuid, pool);
-            devlinks::pool_renamed(&old_name, &new_name)?;
+            devlinks::pool_renamed(&old_name, &new_name);
             Ok(RenameAction::Renamed)
         }
     }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -547,10 +547,10 @@ mod tests {
         let (paths1, paths2) = paths.split_at(paths.len() / 2);
 
         let name = "stratis-test-pool";
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let (uuid, mut pool) =
             StratPool::initialize(&name, paths2, Redundancy::NONE, false).unwrap();
-        devlinks::pool_added(&name).unwrap();
+        devlinks::pool_added(&name);
         invariant(&pool, &name);
 
         let metadata1 = pool.record(name);

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -858,7 +858,7 @@ impl ThinPool {
             StratFilesystem::initialize(pool_uuid, &self.thin_pool, size, self.id_gen.new_id()?)?;
         let name = Name::new(name.to_owned());
         self.mdv.save_fs(&name, fs_uuid, &new_filesystem)?;
-        devlinks::filesystem_added(pool_name, &name, &new_filesystem.devnode())?;
+        devlinks::filesystem_added(pool_name, &name, &new_filesystem.devnode());
         self.filesystems.insert(name, fs_uuid, new_filesystem);
 
         Ok(fs_uuid)
@@ -897,7 +897,7 @@ impl ThinPool {
         let new_fs_name = Name::new(snapshot_name.to_owned());
         self.mdv
             .save_fs(&new_fs_name, snapshot_fs_uuid, &new_filesystem)?;
-        devlinks::filesystem_added(pool_name, &new_fs_name, &new_filesystem.devnode())?;
+        devlinks::filesystem_added(pool_name, &new_fs_name, &new_filesystem.devnode());
         self.filesystems
             .insert(new_fs_name, snapshot_fs_uuid, new_filesystem);
         Ok((
@@ -927,13 +927,7 @@ impl ThinPool {
                                pool_name,
                                err);
                     }
-                    if let Err(err) = devlinks::filesystem_removed(pool_name, &fs_name) {
-                        error!("Could not remove devlinks for fs with UUID {} and name {} belonging to pool {}, reason: {:?}",
-                               uuid,
-                               fs_name,
-                               pool_name,
-                               err);
-                    }
+                    devlinks::filesystem_removed(pool_name, &fs_name);
                     Ok(())
                 }
                 Err(err) => {
@@ -974,7 +968,7 @@ impl ThinPool {
                 to: &*new_name,
             });
             self.filesystems.insert(new_name.clone(), uuid, filesystem);
-            devlinks::filesystem_renamed(pool_name, &old_name, &new_name)?;
+            devlinks::filesystem_renamed(pool_name, &old_name, &new_name);
             Ok(RenameAction::Renamed)
         }
     }
@@ -1185,7 +1179,7 @@ mod tests {
     fn test_full_pool(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
         devlinks::setup_dev_path().unwrap();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let (first_path, remaining_paths) = paths.split_at(1);
         let mut backstore =
             Backstore::initialize(pool_uuid, &first_path, MIN_MDA_SECTORS, false).unwrap();
@@ -1197,7 +1191,7 @@ mod tests {
         ).unwrap();
 
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, "stratis_test_filesystem", None)
             .unwrap();
         let write_buf = &[8u8; BYTES_PER_WRITE];
@@ -1284,7 +1278,7 @@ mod tests {
     /// Verify a snapshot has the same files and same contents as the origin.
     fn test_filesystem_snapshot(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1295,7 +1289,7 @@ mod tests {
         ).unwrap();
 
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, "stratis_test_filesystem", None)
             .unwrap();
 
@@ -1389,7 +1383,7 @@ mod tests {
         let name2 = "name2";
 
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1400,7 +1394,7 @@ mod tests {
         ).unwrap();
 
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, &name1, None)
             .unwrap();
 
@@ -1436,7 +1430,7 @@ mod tests {
     /// some data on it.
     fn test_pool_setup(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1447,7 +1441,7 @@ mod tests {
         ).unwrap();
 
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, "fsname", None)
             .unwrap();
 
@@ -1496,7 +1490,7 @@ mod tests {
     /// same thin id and verifying that it fails.
     fn test_thindev_destroy(paths: &[&Path]) -> () {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1506,7 +1500,7 @@ mod tests {
             &mut backstore,
         ).unwrap();
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, &fs_name, None)
             .unwrap();
@@ -1605,7 +1599,7 @@ mod tests {
     /// have been expanded.
     fn test_thinpool_expand(paths: &[&Path]) -> () {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1615,7 +1609,7 @@ mod tests {
             &mut backstore,
         ).unwrap();
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, fs_name, None)
             .unwrap();
@@ -1667,7 +1661,7 @@ mod tests {
     /// compared to the original size.
     fn test_xfs_expand(paths: &[&Path]) -> () {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1682,7 +1676,7 @@ mod tests {
         let fs_size = FILESYSTEM_LOWATER + Bytes(IEC::Mi).sectors();
 
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, fs_name, Some(fs_size))
             .unwrap();
@@ -1741,7 +1735,7 @@ mod tests {
     /// to check idempotency.
     fn test_suspend_resume(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1752,7 +1746,7 @@ mod tests {
         ).unwrap();
 
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         pool.create_filesystem(pool_uuid, pool_name, "stratis_test_filesystem", None)
             .unwrap();
 
@@ -1788,7 +1782,7 @@ mod tests {
         let (paths1, paths2) = paths.split_at(paths.len() / 2);
 
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter()).unwrap();
+        devlinks::setup_devlinks(Vec::new().into_iter());
         let mut backstore =
             Backstore::initialize(pool_uuid, paths2, MIN_MDA_SECTORS, false).unwrap();
         let mut pool = ThinPool::new(
@@ -1799,7 +1793,7 @@ mod tests {
         ).unwrap();
 
         let pool_name = "stratis_test_pool";
-        devlinks::pool_added(&pool_name).unwrap();
+        devlinks::pool_added(&pool_name);
         let fs_uuid = pool.create_filesystem(pool_uuid, pool_name, "stratis_test_filesystem", None)
             .unwrap();
 


### PR DESCRIPTION
Previously the code was only building up symbolic links for pools
that exist when the daemon starts.  At boot when the device(s)
haven't been discovered or are not ready in udev, the pool(s)
were not present and thus we failed to create the symbolic links
in /dev/stratis for them.  With this change we will setup the
pool directory and filesystem symbolic links as needed when the
pool is assembled when all the devices become available.

Signed-off-by: Tony Asleson <tasleson@redhat.com>

Fixes: https://github.com/stratis-storage/stratisd/issues/1175 https://github.com/stratis-storage/stratisd/issues/1176