### PR TITLE
Unpublicize a few things that shouldn't be publicized

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -21,9 +21,7 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 
 use super::backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS};
 use super::serde_structs::{FlexDevsSave, PoolSave, Recordable};
-use super::thinpool::{ThinPool, ThinPoolSizeParams};
-
-pub use super::thinpool::{DATA_BLOCK_SIZE, INITIAL_DATA_SIZE};
+use super::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
 
 /// Get the index which indicates the start of unallocated space in the cap
 /// device.

--- a/src/engine/strat_engine/thinpool/mod.rs
+++ b/src/engine/strat_engine/thinpool/mod.rs
@@ -8,4 +8,4 @@ mod thinids;
 #[allow(module_inception)]
 mod thinpool;
 
-pub use self::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE, INITIAL_DATA_SIZE};
+pub use self::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -45,7 +45,7 @@ const DATA_LOWATER: DataBlocks = DataBlocks(512);
 const META_LOWATER_FALLBACK: MetaBlocks = MetaBlocks(512);
 
 const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4 * IEC::Ki);
-pub const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);
+const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);
 const INITIAL_MDV_SIZE: Sectors = Sectors(32 * IEC::Ki); // 16 MiB
 
 const SPACE_WARN_PCT: u8 = 90;


### PR DESCRIPTION
These are probably artifacts from some previous testing or from
when thinpool had not yet been separated from Pool.

Signed-off-by: mulhern <amulhern@redhat.com>