### PR TITLE
update pool states

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -255,6 +255,22 @@ impl EngineListener for EventHandler {
                     });
                 }
             }
+            &EngineEvent::PoolSpaceStateChanged { dbus_path, state } => {
+                if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_SPACE_STATE_PROP,
+                        state.to_dbus_value(),
+                        &dbus_path,
+                    ).unwrap_or_else(|()| {
+                        error!(
+                            "PoolSpaceStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path,
+                            state.to_dbus_value(),
+                        );
+                    });
+                }
+            }
             &EngineEvent::PoolStateChanged { dbus_path, state } => {
                 if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
                     prop_changed_dispatch(

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -220,6 +220,22 @@ impl EngineListener for EventHandler {
                     });
                 }
             }
+            &EngineEvent::PoolExtendStateChanged { dbus_path, state } => {
+                if let &MaybeDbusPath(Some(ref dbus_path)) = dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_EXTEND_STATE_PROP,
+                        state.to_dbus_value(),
+                        &dbus_path,
+                    ).unwrap_or_else(|()| {
+                        error!(
+                            "PoolExtendStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path,
+                            state.to_dbus_value(),
+                        );
+                    });
+                }
+            }
             &EngineEvent::PoolRenamed {
                 dbus_path,
                 from,

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -6,6 +6,7 @@
 pub const POOL_NAME_PROP: &str = "Name";
 pub const POOL_STATE_PROP: &str = "State";
 pub const POOL_EXTEND_STATE_PROP: &str = "ExtendState";
+pub const POOL_SPACE_STATE_PROP: &str = "SpaceState";
 
 // Filesystem Properties
 pub const FILESYSTEM_NAME_PROP: &str = "Name";

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -5,6 +5,7 @@
 // Pool Properties
 pub const POOL_NAME_PROP: &str = "Name";
 pub const POOL_STATE_PROP: &str = "State";
+pub const POOL_EXTEND_STATE_PROP: &str = "ExtendState";
 
 // Filesystem Properties
 pub const FILESYSTEM_NAME_PROP: &str = "Name";

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -357,6 +357,13 @@ fn get_pool_state(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Resul
     get_pool_property(i, p, |(_, _, pool)| Ok(pool.state().to_dbus_value()))
 }
 
+fn get_pool_extend_state(
+    i: &mut IterAppend,
+    p: &PropInfo<MTFn<TData>, TData>,
+) -> Result<(), MethodErr> {
+    get_pool_property(i, p, |(_, _, pool)| Ok(pool.extend_state().to_dbus_value()))
+}
+
 pub fn create_dbus_pool<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
@@ -429,6 +436,11 @@ pub fn create_dbus_pool<'a>(
         .emits_changed(EmitsChangedSignal::True)
         .on_get(get_pool_state);
 
+    let extend_state_property = f.property::<u16, _>(consts::POOL_EXTEND_STATE_PROP, ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::True)
+        .on_get(get_pool_extend_state);
+
     let object_name = format!(
         "{}/{}",
         STRATIS_BASE_PATH,
@@ -451,7 +463,8 @@ pub fn create_dbus_pool<'a>(
                 .add_p(total_physical_size_property)
                 .add_p(total_physical_used_property)
                 .add_p(uuid_property)
-                .add_p(state_property),
+                .add_p(state_property)
+                .add_p(extend_state_property),
         );
 
     let path = object_path.get_name().to_owned();

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -364,6 +364,12 @@ fn get_pool_extend_state(
     get_pool_property(i, p, |(_, _, pool)| Ok(pool.extend_state().to_dbus_value()))
 }
 
+fn get_space_state(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<(), MethodErr> {
+    get_pool_property(i, p, |(_, _, pool)| {
+        Ok(pool.free_space_state().to_dbus_value())
+    })
+}
+
 pub fn create_dbus_pool<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
@@ -441,6 +447,11 @@ pub fn create_dbus_pool<'a>(
         .emits_changed(EmitsChangedSignal::True)
         .on_get(get_pool_extend_state);
 
+    let space_state_property = f.property::<u16, _>(consts::POOL_SPACE_STATE_PROP, ())
+        .access(Access::Read)
+        .emits_changed(EmitsChangedSignal::True)
+        .on_get(get_space_state);
+
     let object_name = format!(
         "{}/{}",
         STRATIS_BASE_PATH,
@@ -464,6 +475,7 @@ pub fn create_dbus_pool<'a>(
                 .add_p(total_physical_used_property)
                 .add_p(uuid_property)
                 .add_p(state_property)
+                .add_p(space_state_property)
                 .add_p(extend_state_property),
         );
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -176,7 +176,7 @@ pub trait Pool: Debug {
     /// The current state of the Pool.
     fn state(&self) -> PoolState;
 
-    /// The current state of the Pool.
+    /// The current extend state of the Pool.
     fn extend_state(&self) -> PoolExtendState;
 
     /// Set dbus path associated with the Pool.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Device, Sectors};
 
 use super::types::{
-    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolExtendState,
-    PoolState, PoolUuid, RenameAction,
+    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
+    PoolExtendState, PoolState, PoolUuid, RenameAction,
 };
 use stratis::StratisResult;
 
@@ -178,6 +178,9 @@ pub trait Pool: Debug {
 
     /// The current extend state of the Pool.
     fn extend_state(&self) -> PoolExtendState;
+
+    /// The current space state of the Pool.
+    fn free_space_state(&self) -> FreeSpaceState;
 
     /// Set dbus path associated with the Pool.
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Device, Sectors};
 
 use super::types::{
-    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolState, PoolUuid,
-    RenameAction,
+    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolExtendState,
+    PoolState, PoolUuid, RenameAction,
 };
 use stratis::StratisResult;
 
@@ -175,6 +175,9 @@ pub trait Pool: Debug {
 
     /// The current state of the Pool.
     fn state(&self) -> PoolState;
+
+    /// The current state of the Pool.
+    fn extend_state(&self) -> PoolExtendState;
 
     /// Set dbus path associated with the Pool.
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -5,7 +5,7 @@
 use std::fmt::Debug;
 use std::sync::{Once, ONCE_INIT};
 
-use super::types::{BlockDevState, MaybeDbusPath, PoolState};
+use super::types::{BlockDevState, MaybeDbusPath, PoolExtendState, PoolState};
 
 static INIT: Once = ONCE_INIT;
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;
@@ -20,6 +20,10 @@ pub enum EngineEvent<'a> {
         dbus_path: &'a MaybeDbusPath,
         from: &'a str,
         to: &'a str,
+    },
+    PoolExtendStateChanged {
+        dbus_path: &'a MaybeDbusPath,
+        state: PoolExtendState,
     },
     PoolRenamed {
         dbus_path: &'a MaybeDbusPath,

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -5,7 +5,7 @@
 use std::fmt::Debug;
 use std::sync::{Once, ONCE_INIT};
 
-use super::types::{BlockDevState, MaybeDbusPath, PoolExtendState, PoolState};
+use super::types::{BlockDevState, FreeSpaceState, MaybeDbusPath, PoolExtendState, PoolState};
 
 static INIT: Once = ONCE_INIT;
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;
@@ -29,6 +29,10 @@ pub enum EngineEvent<'a> {
         dbus_path: &'a MaybeDbusPath,
         from: &'a str,
         to: &'a str,
+    },
+    PoolSpaceStateChanged {
+        dbus_path: &'a MaybeDbusPath,
+        state: FreeSpaceState,
     },
     PoolStateChanged {
         dbus_path: &'a MaybeDbusPath,

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -19,8 +19,8 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::structures::Table;
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolExtendState, PoolState,
-    PoolUuid, Redundancy, RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState,
+    PoolState, PoolUuid, Redundancy, RenameAction,
 };
 
 use super::blockdev::SimDev;
@@ -36,6 +36,7 @@ pub struct SimPool {
     rdm: Rc<RefCell<Randomizer>>,
     pool_state: PoolState,
     pool_extend_state: PoolExtendState,
+    free_space_state: FreeSpaceState,
     dbus_path: MaybeDbusPath,
 }
 
@@ -57,6 +58,7 @@ impl SimPool {
                 rdm: Rc::clone(rdm),
                 pool_state: PoolState::Initializing,
                 pool_extend_state: PoolExtendState::Good,
+                free_space_state: FreeSpaceState::Good,
                 dbus_path: MaybeDbusPath(None),
             },
         )
@@ -288,6 +290,10 @@ impl Pool for SimPool {
 
     fn extend_state(&self) -> PoolExtendState {
         self.pool_extend_state
+    }
+
+    fn free_space_state(&self) -> FreeSpaceState {
+        self.free_space_state
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -54,7 +54,7 @@ impl SimPool {
                 filesystems: Table::default(),
                 redundancy,
                 rdm: Rc::clone(rdm),
-                pool_state: PoolState::Good,
+                pool_state: PoolState::Initializing,
                 dbus_path: MaybeDbusPath(None),
             },
         )

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -19,8 +19,8 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::structures::Table;
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolState, PoolUuid, Redundancy,
-    RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolExtendState, PoolState,
+    PoolUuid, Redundancy, RenameAction,
 };
 
 use super::blockdev::SimDev;
@@ -35,6 +35,7 @@ pub struct SimPool {
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
     pool_state: PoolState,
+    pool_extend_state: PoolExtendState,
     dbus_path: MaybeDbusPath,
 }
 
@@ -55,6 +56,7 @@ impl SimPool {
                 redundancy,
                 rdm: Rc::clone(rdm),
                 pool_state: PoolState::Initializing,
+                pool_extend_state: PoolExtendState::Good,
                 dbus_path: MaybeDbusPath(None),
             },
         )
@@ -282,6 +284,10 @@ impl Pool for SimPool {
 
     fn state(&self) -> PoolState {
         self.pool_state
+    }
+
+    fn extend_state(&self) -> PoolExtendState {
+        self.pool_extend_state
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -14,8 +14,8 @@ use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolExtendState, PoolState,
-    PoolUuid, Redundancy, RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState,
+    PoolState, PoolUuid, Redundancy, RenameAction,
 };
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
@@ -424,6 +424,10 @@ impl Pool for StratPool {
 
     fn extend_state(&self) -> PoolExtendState {
         self.thin_pool.extend_state()
+    }
+
+    fn free_space_state(&self) -> FreeSpaceState {
+        self.thin_pool.free_space_state()
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -14,8 +14,8 @@ use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
 use super::super::engine::{BlockDev, Filesystem, Pool};
 use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolState, PoolUuid, Redundancy,
-    RenameAction,
+    BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolExtendState, PoolState,
+    PoolUuid, Redundancy, RenameAction,
 };
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
@@ -420,6 +420,10 @@ impl Pool for StratPool {
 
     fn state(&self) -> PoolState {
         self.thin_pool.state()
+    }
+
+    fn extend_state(&self) -> PoolExtendState {
+        self.thin_pool.extend_state()
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> () {

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -618,6 +618,10 @@ impl ThinPool {
         }
         if self.extend_state() != new_state {
             self.pool_extend_state = new_state;
+            get_engine_listener_list().notify(&EngineEvent::PoolExtendStateChanged {
+                dbus_path: self.get_dbus_path(),
+                state: new_state,
+            });
         }
     }
 

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -54,6 +54,15 @@ impl PoolState {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PoolExtendState {
+    Initializing,
+    Good,
+    DataFailed,
+    MetaFailed,
+    MetaAndDataFailed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FreeSpaceState {
     Good,
     Warn,

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -62,6 +62,18 @@ pub enum PoolExtendState {
     MetaAndDataFailed,
 }
 
+impl PoolExtendState {
+    pub fn to_dbus_value(&self) -> u16 {
+        match *self {
+            PoolExtendState::Initializing => 1,
+            PoolExtendState::Good => 2,
+            PoolExtendState::DataFailed => 3,
+            PoolExtendState::MetaFailed => 4,
+            PoolExtendState::MetaAndDataFailed => 5,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FreeSpaceState {
     Good,

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -81,6 +81,16 @@ pub enum FreeSpaceState {
     Crit,
 }
 
+impl FreeSpaceState {
+    pub fn to_dbus_value(&self) -> u16 {
+        match *self {
+            FreeSpaceState::Good => 1,
+            FreeSpaceState::Warn => 2,
+            FreeSpaceState::Crit => 3,
+        }
+    }
+}
+
 /// See Design Doc section 10.2.1 for more details.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockDevState {


### PR DESCRIPTION
Update the PoolState to mirror the DM state of a pool.  DM pools run in 4 possible modes (PM_OUT_OF_METADATA_SPACE and PM_READ_ONLY are reported as the same to user space).

DM mode enum:

```
        PM_WRITE,               /* metadata may be changed */
        PM_OUT_OF_DATA_SPACE,   /* metadata may be changed, though data may not be allocated */
        /*
         * Like READ_ONLY, except may switch back to WRITE on metadata resize. Reported as READ_ONLY.
         */
        PM_OUT_OF_METADATA_SPACE,
        PM_READ_ONLY,           /* metadata may not be changed */

        PM_FAIL,  
``` 
We add two additional modes to the pool for Initializing and Stopping.

Add publishing the mode on dbus with signals to indicate changes.

PoolExtendState added to allow an API user to track any problems with extending the data or meta data devices.

Publish the FreeSpaceState on dbus and associated change signal.
