### PR TITLE
Clearer names for size-related functions in backstore (final)

### DIFF
--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -229,7 +229,7 @@ fn get_blockdev_physical_size(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,
 ) -> Result<(), MethodErr> {
-    get_blockdev_property(i, p, |_, p| Ok(format!("{}", *p.total_size())))
+    get_blockdev_property(i, p, |_, p| Ok(format!("{}", *p.size())))
 }
 
 fn get_blockdev_state(

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -50,8 +50,8 @@ pub trait BlockDev: Debug {
     /// to the nearest second.
     fn initialization_time(&self) -> DateTime<Utc>;
 
-    /// The usable size of the device, not counting Stratis overhead.
-    fn total_size(&self) -> Sectors;
+    /// The total size of the device, including space not usable for data.
+    fn size(&self) -> Sectors;
 
     /// The current state of the blockdev.
     fn state(&self) -> BlockDevState;

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -44,7 +44,7 @@ impl BlockDev for SimDev {
         Utc.timestamp(self.initialization_time as i64, 0)
     }
 
-    fn total_size(&self) -> Sectors {
+    fn size(&self) -> Sectors {
         Bytes(IEC::Gi).sectors()
     }
 

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -424,8 +424,8 @@ impl Backstore {
     }
 
     /// The current capacity of all the blockdevs in the data tier.
-    pub fn datatier_current_capacity(&self) -> Sectors {
-        self.data_tier.current_capacity()
+    pub fn datatier_size(&self) -> Sectors {
+        self.data_tier.size()
     }
 
     /// The size of the cap device.

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -423,7 +423,7 @@ impl Backstore {
         }
     }
 
-    /// The current capacity of all the blockdevs in the data tier.
+    /// The current size of all the blockdevs in the data tier.
     pub fn datatier_size(&self) -> Sectors {
         self.data_tier.size()
     }
@@ -583,7 +583,7 @@ mod tests {
     /// Assert some invariants of the backstore
     /// * backstore.cache_tier.is_some() <=> backstore.cache.is_some() &&
     ///   backstore.cache_tier.is_some() => backstore.linear.is_none()
-    /// * backstore's data tier capacity is equal to the size of the cap device
+    /// * backstore's data tier allocated is equal to the size of the cap device
     /// * backstore's next index is always less than the size of the cap
     ///   device
     fn invariant(backstore: &Backstore) -> () {
@@ -594,7 +594,7 @@ mod tests {
                     && backstore.linear.is_none())
         );
         assert_eq!(
-            backstore.data_tier.capacity(),
+            backstore.data_tier.allocated(),
             match (&backstore.linear, &backstore.cache) {
                 (None, None) => Sectors(0),
                 (&None, &Some(ref cache)) => cache.size(),

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -317,7 +317,7 @@ impl Backstore {
         sizes: &[Sectors],
     ) -> StratisResult<Option<Vec<(Sectors, Sectors)>>> {
         let total_required = sizes.iter().cloned().sum();
-        let available = self.available();
+        let available = self.available_in_cap();
         if available < total_required {
             if self.data_tier.alloc(total_required - available) {
                 self.extend_cap_device(pool_uuid)?;
@@ -373,7 +373,7 @@ impl Backstore {
             return Ok(None);
         }
 
-        let available = self.available();
+        let available = self.available_in_cap();
         if available < internal_request {
             let mut allocated = false;
             while !allocated && internal_request != Sectors(0) {
@@ -384,7 +384,7 @@ impl Backstore {
             if allocated {
                 self.extend_cap_device(pool_uuid)?;
 
-                let return_amt = cmp::min(request, self.available());
+                let return_amt = cmp::min(request, self.available_in_cap());
                 let return_amt = (return_amt / modulus) * modulus;
                 self.next += return_amt;
                 Ok(Some((self.next - return_amt, return_amt)))
@@ -442,8 +442,15 @@ impl Backstore {
             .unwrap_or(Sectors(0))
     }
 
+    /// The total number of unallocated usable sectors in the
+    /// backstore. Includes both in the cap but unallocated as well as not yet
+    /// added to cap.
+    pub fn available_in_backstore(&self) -> Sectors {
+        self.data_tier.usable_size() - self.next
+    }
+
     /// The available number of Sectors.
-    pub fn available(&self) -> Sectors {
+    fn available_in_cap(&self) -> Sectors {
         let size = self.size();
         // It is absolutely essential for correct operation that the assertion
         // be true. If it is false, the result will be incorrect, and space

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -119,14 +119,7 @@ impl StratBlockDev {
         result
     }
 
-    // ALL SIZE METHODS
-    /// The actual size of the device now.
-    pub fn size(&self) -> Sectors {
-        let size = self.used.size();
-        assert_eq!(self.bda.dev_size(), size);
-        size
-    }
-
+    // ALL SIZE METHODS (except size(), which is in BlockDev impl.)
     /// The number of Sectors on this device used by Stratis for metadata
     pub fn metadata_size(&self) -> Sectors {
         self.bda.size()
@@ -171,11 +164,10 @@ impl BlockDev for StratBlockDev {
         Utc.timestamp(self.bda.initialization_time() as i64, 0)
     }
 
-    fn total_size(&self) -> Sectors {
-        let start = self.metadata_size();
-        let size = self.size();
-        assert!(start <= size);
-        size - start
+    fn size(&self) -> Sectors {
+        let size = self.used.size();
+        assert_eq!(self.bda.dev_size(), size);
+        size
     }
 
     fn state(&self) -> BlockDevState {

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -105,7 +105,7 @@ impl StratBlockDev {
     }
 
     /// Find some sector ranges that could be allocated. If more
-    /// sectors are needed than our capacity, return partial results.
+    /// sectors are needed than are available, return partial results.
     /// If all sectors are desired, use available() method to get all.
     pub fn request_space(&mut self, size: Sectors) -> (Sectors, Vec<(Sectors, Sectors)>) {
         let prev_state = self.state();
@@ -122,7 +122,7 @@ impl StratBlockDev {
     // ALL SIZE METHODS
     /// The actual size of the device now.
     pub fn size(&self) -> Sectors {
-        let size = self.used.capacity();
+        let size = self.used.size();
         assert_eq!(self.bda.dev_size(), size);
         size
     }

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -121,7 +121,7 @@ impl StratBlockDev {
 
     // ALL SIZE METHODS
     /// The actual size of the device now.
-    pub fn current_capacity(&self) -> Sectors {
+    pub fn size(&self) -> Sectors {
         let size = self.used.capacity();
         assert_eq!(self.bda.dev_size(), size);
         size
@@ -133,7 +133,7 @@ impl StratBlockDev {
     }
 
     /// The number of Sectors on this device not allocated for any purpose.
-    /// self.current_capacity() - self.metadata_size() >= self.available()
+    /// self.size() - self.metadata_size() >= self.available()
     pub fn available(&self) -> Sectors {
         self.used.available()
     }
@@ -173,7 +173,7 @@ impl BlockDev for StratBlockDev {
 
     fn total_size(&self) -> Sectors {
         let start = self.metadata_size();
-        let size = self.current_capacity();
+        let size = self.size();
         assert!(start <= size);
         size - start
     }

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -326,15 +326,15 @@ impl BlockDevMgr {
         self.block_devs.iter().map(|bd| bd.available()).sum()
     }
 
-    /// The current capacity of all the blockdevs.
-    /// self.current_capacity() > self.avail_space() because some sectors
-    /// are certainly allocated for Stratis metadata
-    pub fn current_capacity(&self) -> Sectors {
-        self.block_devs.iter().map(|b| b.current_capacity()).sum()
+    /// The current size of all the blockdevs.
+    /// self.size() > self.avail_space() because some sectors are certainly
+    /// allocated for Stratis metadata
+    pub fn size(&self) -> Sectors {
+        self.block_devs.iter().map(|b| b.size()).sum()
     }
 
     /// The number of sectors given over to Stratis metadata
-    /// self.current_capacity() - self.metadata_size() >= self.avail_space()
+    /// self.size() - self.metadata_size() >= self.avail_space()
     pub fn metadata_size(&self) -> Sectors {
         self.block_devs.iter().map(|bd| bd.metadata_size()).sum()
     }
@@ -502,22 +502,19 @@ mod tests {
     }
 
     /// Verify that initially,
-    /// current_capacity() - metadata_size() = avail_space().
+    /// size() - metadata_size() = avail_space().
     /// After 2 Sectors have been allocated, that amount must also be included
     /// in balance.
     fn test_blockdevmgr_used(paths: &[&Path]) -> () {
         let mut mgr =
             BlockDevMgr::initialize(Uuid::new_v4(), paths, MIN_MDA_SECTORS, false).unwrap();
-        assert_eq!(
-            mgr.avail_space() + mgr.metadata_size(),
-            mgr.current_capacity()
-        );
+        assert_eq!(mgr.avail_space() + mgr.metadata_size(), mgr.size());
 
         let allocated = Sectors(2);
         mgr.alloc_space(&[allocated]).unwrap();
         assert_eq!(
             mgr.avail_space() + allocated + mgr.metadata_size(),
-            mgr.current_capacity()
+            mgr.size()
         );
     }
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -19,6 +19,7 @@ use devicemapper::{
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
 
+use super::super::super::engine::BlockDev;
 use super::super::super::types::{DevUuid, PoolUuid};
 
 use super::super::serde_structs::{BlockDevSave, Recordable};

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -201,14 +201,14 @@ mod tests {
 
         let mut metadata_size = cache_tier.block_mgr.metadata_size();
         let mut size = cache_tier.block_mgr.size();
-        let mut capacity = cache_tier
+        let mut allocated = cache_tier
             .cache_segments
             .iter()
             .map(|x| x.segment.length)
             .sum::<Sectors>();
 
         assert_eq!(cache_tier.block_mgr.avail_space(), Sectors(0));
-        assert_eq!(size - metadata_size, capacity + cache_metadata_size);
+        assert_eq!(size - metadata_size, allocated + cache_metadata_size);
 
         let (_, (cache, meta)) = cache_tier.add(pool_uuid, paths2, false).unwrap();
         // TODO: Ultimately, it should be the case that meta can be true.
@@ -221,12 +221,12 @@ mod tests {
 
         metadata_size = cache_tier.block_mgr.metadata_size();
         size = cache_tier.block_mgr.size();
-        capacity = cache_tier
+        allocated = cache_tier
             .cache_segments
             .iter()
             .map(|x| x.segment.length)
             .sum::<Sectors>();
-        assert_eq!(size - metadata_size, capacity + cache_metadata_size);
+        assert_eq!(size - metadata_size, allocated + cache_metadata_size);
 
         cache_tier.destroy().unwrap();
     }

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -200,7 +200,7 @@ mod tests {
             .sum::<Sectors>();
 
         let mut metadata_size = cache_tier.block_mgr.metadata_size();
-        let mut current_capacity = cache_tier.block_mgr.current_capacity();
+        let mut size = cache_tier.block_mgr.size();
         let mut capacity = cache_tier
             .cache_segments
             .iter()
@@ -208,10 +208,7 @@ mod tests {
             .sum::<Sectors>();
 
         assert_eq!(cache_tier.block_mgr.avail_space(), Sectors(0));
-        assert_eq!(
-            current_capacity - metadata_size,
-            capacity + cache_metadata_size
-        );
+        assert_eq!(size - metadata_size, capacity + cache_metadata_size);
 
         let (_, (cache, meta)) = cache_tier.add(pool_uuid, paths2, false).unwrap();
         // TODO: Ultimately, it should be the case that meta can be true.
@@ -219,20 +216,17 @@ mod tests {
         assert!(!meta);
 
         assert_eq!(cache_tier.block_mgr.avail_space(), Sectors(0));
-        assert!(cache_tier.block_mgr.current_capacity() > current_capacity);
+        assert!(cache_tier.block_mgr.size() > size);
         assert!(cache_tier.block_mgr.metadata_size() > metadata_size);
 
         metadata_size = cache_tier.block_mgr.metadata_size();
-        current_capacity = cache_tier.block_mgr.current_capacity();
+        size = cache_tier.block_mgr.size();
         capacity = cache_tier
             .cache_segments
             .iter()
             .map(|x| x.segment.length)
             .sum::<Sectors>();
-        assert_eq!(
-            current_capacity - metadata_size,
-            capacity + cache_metadata_size
-        );
+        assert_eq!(size - metadata_size, capacity + cache_metadata_size);
 
         cache_tier.destroy().unwrap();
     }

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -102,7 +102,7 @@ impl DataTier {
     /// The sum of the lengths of all the sectors that have been mapped to an
     /// upper device.
     #[cfg(test)]
-    pub fn capacity(&self) -> Sectors {
+    pub fn allocated(&self) -> Sectors {
         self.segments
             .iter()
             .map(|x| x.segment.length)
@@ -183,8 +183,8 @@ mod tests {
 
         // A data_tier w/ some devices but nothing allocated
         let mut size = data_tier.size();
-        let mut capacity = data_tier.capacity();
-        assert_eq!(capacity, Sectors(0));
+        let mut allocated = data_tier.allocated();
+        assert_eq!(allocated, Sectors(0));
         assert!(size != Sectors(0));
         assert_eq!(paths1.len(), data_tier.blockdevs().len());
 
@@ -196,22 +196,22 @@ mod tests {
         assert!(data_tier.alloc(request_amount));
 
         // A data tier w/ some amount allocated
-        assert!(data_tier.capacity() >= request_amount);
+        assert!(data_tier.allocated() >= request_amount);
         assert_eq!(data_tier.size(), size);
-        capacity = data_tier.capacity();
+        allocated = data_tier.allocated();
 
         data_tier.add(pool_uuid, paths2, false).unwrap();
 
         // A data tier w/ additional blockdevs added
         assert!(data_tier.size() > size);
-        assert_eq!(data_tier.capacity(), capacity);
+        assert_eq!(data_tier.allocated(), allocated);
         assert_eq!(paths1.len() + paths2.len(), data_tier.blockdevs().len());
         size = data_tier.size();
 
         // Allocate enough to get into the newly added block devices
         assert!(data_tier.alloc(last_request_amount));
 
-        assert!(data_tier.capacity() >= request_amount + last_request_amount);
+        assert!(data_tier.allocated() >= request_amount + last_request_amount);
         assert_eq!(data_tier.size(), size);
 
         data_tier.destroy().unwrap();

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -110,8 +110,8 @@ impl DataTier {
     }
 
     /// The total size of all the blockdevs combined
-    pub fn current_capacity(&self) -> Sectors {
-        self.block_mgr.current_capacity()
+    pub fn size(&self) -> Sectors {
+        self.block_mgr.size()
     }
 
     /// The number of sectors used for metadata by all the blockdevs
@@ -182,13 +182,13 @@ mod tests {
         let mut data_tier = DataTier::new(mgr);
 
         // A data_tier w/ some devices but nothing allocated
-        let mut current_capacity = data_tier.current_capacity();
+        let mut size = data_tier.size();
         let mut capacity = data_tier.capacity();
         assert_eq!(capacity, Sectors(0));
-        assert!(current_capacity != Sectors(0));
+        assert!(size != Sectors(0));
         assert_eq!(paths1.len(), data_tier.blockdevs().len());
 
-        let last_request_amount = current_capacity;
+        let last_request_amount = size;
 
         let request_amount = data_tier.block_mgr.avail_space() / 2usize;
         assert!(request_amount != Sectors(0));
@@ -197,22 +197,22 @@ mod tests {
 
         // A data tier w/ some amount allocated
         assert!(data_tier.capacity() >= request_amount);
-        assert_eq!(data_tier.current_capacity(), current_capacity);
+        assert_eq!(data_tier.size(), size);
         capacity = data_tier.capacity();
 
         data_tier.add(pool_uuid, paths2, false).unwrap();
 
         // A data tier w/ additional blockdevs added
-        assert!(data_tier.current_capacity() > current_capacity);
+        assert!(data_tier.size() > size);
         assert_eq!(data_tier.capacity(), capacity);
         assert_eq!(paths1.len() + paths2.len(), data_tier.blockdevs().len());
-        current_capacity = data_tier.current_capacity();
+        size = data_tier.size();
 
         // Allocate enough to get into the newly added block devices
         assert!(data_tier.alloc(last_request_amount));
 
         assert!(data_tier.capacity() >= request_amount + last_request_amount);
-        assert_eq!(data_tier.current_capacity(), current_capacity);
+        assert_eq!(data_tier.size(), size);
 
         data_tier.destroy().unwrap();
     }

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -119,6 +119,11 @@ impl DataTier {
         self.block_mgr.metadata_size()
     }
 
+    /// The total usable size of all the blockdevs combined
+    pub fn usable_size(&self) -> Sectors {
+        self.size() - self.metadata_size()
+    }
+
     /// Destroy the store. Wipe its blockdevs.
     pub fn destroy(&mut self) -> StratisResult<()> {
         self.block_mgr.destroy_all()

--- a/src/engine/strat_engine/backstore/range_alloc.rs
+++ b/src/engine/strat_engine/backstore/range_alloc.rs
@@ -31,8 +31,8 @@ impl RangeAllocator {
         Ok(allocator)
     }
 
-    /// The capacity of this manager
-    pub fn capacity(&self) -> Sectors {
+    /// The maximum allocation from this manager
+    pub fn size(&self) -> Sectors {
         self.limit
     }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -347,7 +347,7 @@ impl Pool for StratPool {
     }
 
     fn total_physical_size(&self) -> Sectors {
-        self.backstore.datatier_current_capacity()
+        self.backstore.datatier_size()
     }
 
     fn total_physical_used(&self) -> StratisResult<Sectors> {


### PR DESCRIPTION
Final, squashed PR of #1183. 

`capacity` and `current_capacity` both existing is confusing. Instead, use `size()` to mean the total quantity of the resources being managed. Replace available() with `available_in_cap()` and `available_in_backstore()`, since various code needs both of these.

This is split-out and extended from #1174.