### PR TITLE
Put devlinks::setup_pool_devlinks in setup_pool

### DIFF
--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -63,12 +63,11 @@ pub fn setup_pool_devlinks(pool_name: &str, pool: &Pool) -> () {
     };
 }
 
-/// Set up directories and symlinks under /stratis based on current
-/// config. Clear out any directory or file that doesn't correspond to a pool
-/// or filesystem.
-// Don't just remove and recreate everything in case there are processes
+/// Clean up directories and symlinks under /stratis based on current
+/// config. Clear out any directory or file that doesn't correspond to a pool.
+// Don't just remove everything in case there are processes
 // (e.g. user shells) with the current working directory within the tree.
-pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(pools: I) -> () {
+pub fn cleanup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(pools: I) -> () {
     if let Err(err) = || -> StratisResult<()> {
         let mut existing_dirs = fs::read_dir(DEV_PATH)?
             .map(|dir_e| {
@@ -76,9 +75,8 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(po
             })
             .collect::<Result<HashSet<_>, _>>()?;
 
-        for &(ref pool_name, _, pool) in pools {
+        for &(ref pool_name, _, _) in pools {
             existing_dirs.remove(&pool_name.to_owned());
-            setup_pool_devlinks(&pool_name, pool);
         }
 
         for leftover in existing_dirs {
@@ -87,7 +85,7 @@ pub fn setup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(po
 
         Ok(())
     }() {
-        warn!("setup_devlinks failed, reason {:?}", err);
+        warn!("cleanup_devlinks failed, reason {:?}", err);
     }
 }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -85,6 +85,10 @@ pub fn setup_pool(
                 Err(StratisError::Engine(ErrorEnum::Error, err_msg))
             })
         })
+        .and_then(|(pool_name, pool)| {
+            devlinks::setup_pool_devlinks(&pool_name, &pool);
+            Ok((pool_name, pool))
+        })
 }
 
 #[derive(Debug)]
@@ -131,7 +135,6 @@ impl StratEngine {
         for (pool_uuid, devices) in pools {
             match setup_pool(pool_uuid, &devices, &table) {
                 Ok((pool_name, pool)) => {
-                    devlinks::setup_pool_devlinks(&pool_name, &pool);
                     table.insert(pool_name, pool_uuid, pool);
                 }
                 Err(err) => {
@@ -239,7 +242,6 @@ impl Engine for StratEngine {
                 devices.insert(device, dev_node);
                 match setup_pool(pool_uuid, &devices, &self.pools) {
                     Ok((pool_name, pool)) => {
-                        devlinks::setup_pool_devlinks(&pool_name, &pool);
                         self.pools.insert(pool_name, pool_uuid, pool);
                         Some(pool_uuid)
                     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -131,6 +131,7 @@ impl StratEngine {
         for (pool_uuid, devices) in pools {
             match setup_pool(pool_uuid, &devices, &table) {
                 Ok((pool_name, pool)) => {
+                    devlinks::setup_pool_devlinks(&pool_name, &pool);
                     table.insert(pool_name, pool_uuid, pool);
                 }
                 Err(err) => {
@@ -146,7 +147,7 @@ impl StratEngine {
             watched_dev_last_event_nrs: HashMap::new(),
         };
 
-        devlinks::setup_devlinks(engine.pools().iter());
+        devlinks::cleanup_devlinks(engine.pools().iter());
 
         Ok(engine)
     }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -587,7 +587,7 @@ mod tests {
         let (paths1, paths2) = paths.split_at(paths.len() / 2);
 
         let name = "stratis-test-pool";
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let (uuid, mut pool) = StratPool::initialize(&name, paths2, Redundancy::NONE).unwrap();
         devlinks::pool_added(&name);
         invariant(&pool, &name);
@@ -703,7 +703,7 @@ mod tests {
         let (paths1, paths2) = paths.split_at(1);
 
         let name = "stratis-test-pool";
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let (pool_uuid, mut pool) = StratPool::initialize(&name, paths1, Redundancy::NONE).unwrap();
         devlinks::pool_added(&name);
         invariant(&pool, &name);

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1279,7 +1279,7 @@ mod tests {
     fn test_full_pool(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
         devlinks::setup_dev_path().unwrap();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let (first_path, remaining_paths) = paths.split_at(1);
         let mut backstore = Backstore::initialize(pool_uuid, &first_path, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
@@ -1388,7 +1388,7 @@ mod tests {
     /// Verify a snapshot has the same files and same contents as the origin.
     fn test_filesystem_snapshot(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1495,7 +1495,7 @@ mod tests {
         let name2 = "name2";
 
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1541,7 +1541,7 @@ mod tests {
     /// some data on it.
     fn test_pool_setup(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1600,7 +1600,7 @@ mod tests {
     /// same thin id and verifying that it fails.
     fn test_thindev_destroy(paths: &[&Path]) -> () {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1707,7 +1707,7 @@ mod tests {
     /// have been expanded.
     fn test_thinpool_expand(paths: &[&Path]) -> () {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1769,7 +1769,7 @@ mod tests {
     /// compared to the original size.
     fn test_xfs_expand(paths: &[&Path]) -> () {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1842,7 +1842,7 @@ mod tests {
     /// to check idempotency.
     fn test_suspend_resume(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1888,7 +1888,7 @@ mod tests {
         let (paths1, paths2) = paths.split_at(paths.len() / 2);
 
         let pool_uuid = Uuid::new_v4();
-        devlinks::setup_devlinks(Vec::new().into_iter());
+        devlinks::cleanup_devlinks(Vec::new().into_iter());
         let mut backstore = Backstore::initialize(pool_uuid, paths2, MIN_MDA_SECTORS).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,


### PR DESCRIPTION
The idea is to make setting up the pools devlinks part of the other actions of setting up a pool. There is a bit more clarity and consistency and slightly less code duplication.