### PR TITLE
Check value of DM_MULTIPATH_DEVICE_PATH

### DIFF
--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -57,7 +57,9 @@ pub enum DevOwnership {
 /// Returns true if a device has no signature and is not one of the paths of a multipath device,
 /// yes this is a bit convoluted.  Logic gleaned from blivet library.
 fn empty(device: &HashMap<String, String>) -> bool {
-    !device.contains_key("DM_MULTIPATH_DEVICE_PATH")
+    device
+        .get("DM_MULTIPATH_DEVICE_PATH")
+        .map_or(true, |v| v != "1")
         && !((device.contains_key("ID_PART_TABLE_TYPE")
             && !device.contains_key("ID_PART_ENTRY_DISK"))
             || device.contains_key("ID_FS_USAGE"))
@@ -91,7 +93,10 @@ pub fn identify(devnode: &Path) -> StratisResult<DevOwnership> {
             } else {
                 Ok(DevOwnership::Unowned)
             }
-        } else if device.contains_key("DM_MULTIPATH_DEVICE_PATH") {
+        } else if device
+            .get("DM_MULTIPATH_DEVICE_PATH")
+            .map_or(false, |v| v == "1")
+        {
             Ok(DevOwnership::Theirs(String::from("multipath path")))
         } else if device.contains_key("ID_FS_TYPE") && device["ID_FS_TYPE"] == "stratis" {
             // Device is ours, but we don't get everything we need from udev db, lets go to disk.

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -62,7 +62,8 @@ fn get_all_empty_devices() -> StratisResult<Vec<PathBuf>> {
         .scan_devices()?
         .filter(|dev| dev.is_initialized())
         .filter(|dev| {
-            dev.property_value("DM_MULTIPATH_DEVICE_PATH").is_none()
+            dev.property_value("DM_MULTIPATH_DEVICE_PATH")
+                .map_or(true, |v| v != "1")
                 && !((dev.property_value("ID_PART_TABLE_TYPE").is_some()
                     && dev.property_value("ID_PART_ENTRY_DISK").is_none())
                     || dev.property_value("ID_FS_USAGE").is_some())
@@ -81,7 +82,10 @@ pub fn get_stratis_block_devices() -> StratisResult<Vec<PathBuf>> {
     let devices: Vec<PathBuf> = enumerator
         .scan_devices()?
         .filter(|dev| dev.is_initialized())
-        .filter(|dev| dev.property_value("DM_MULTIPATH_DEVICE_PATH").is_none())
+        .filter(|dev| {
+            dev.property_value("DM_MULTIPATH_DEVICE_PATH")
+                .map_or(true, |v| v != "1")
+        })
         .filter_map(|i| i.devnode().map(|d| d.into()))
         .collect();
 


### PR DESCRIPTION
Previously, just whether or not the property was set
was checked. Now require the value to be set and equal to "1"
to mean true, everything else means false.

Signed-off-by: mulhern <amulhern@redhat.com>

Resolves: #1187.