### PR TITLE
Add versions to Sigblock, metadata header, and metadata

### DIFF
--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -847,9 +847,15 @@ mod mda {
         use super::*;
 
         #[test]
-        /// Verify that default MDAHeader is all 0s except for CRC.
+        /// Verify that default MDAHeader is all 0s except for CRC and versions.
         fn test_default_mda_header() {
-            assert!(MDAHeader::default().to_buf()[4..].iter().all(|x| *x == 0u8));
+            let buf = MDAHeader::default().to_buf();
+
+            // First 4 bytes is CRC. Then:
+            assert!(buf[4..28].iter().all(|x| *x == 0u8));
+            assert_eq!(buf[28], STRAT_REGION_HDR_VERSION);
+            assert_eq!(buf[29], STRAT_METADATA_VERSION);
+            assert!(buf[30..].iter().all(|x| *x == 0u8));
         }
 
         #[test]

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -619,6 +619,14 @@ mod mda {
                 None => return Ok(None),
                 Some(ref mda) => mda,
             };
+
+            if mda.metadata_version != STRAT_METADATA_VERSION {
+                return Err(StratisError::Engine(
+                    ErrorEnum::Invalid,
+                    format!("Unknown metadata version: {}", mda.metadata_version),
+                ));
+            }
+
             let region_size = self.region_size.bytes();
 
             // Load the metadata region specified by index.
@@ -786,12 +794,6 @@ mod mda {
                 ));
             }
 
-            if self.metadata_version != STRAT_METADATA_VERSION {
-                return Err(StratisError::Engine(
-                    ErrorEnum::Invalid,
-                    format!("Unknown metadata version: {}", self.metadata_version),
-                ));
-            }
             Ok(data_buf)
         }
     }


### PR DESCRIPTION
Use previously unused bytes as version fields. All are currently version 1. Check when reading that value is as expected, and write proper value.

Corresponding doc update is: https://github.com/stratis-storage/stratis-docs/pull/98

Signed-off-by: Andy Grover <agrover@redhat.com>