### PR TITLE
Wipe only the first 4K of each metadata device

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -50,7 +50,11 @@ fn make_cache(
 
     if new {
         // See comment in ThinPool::new() method
-        wipe_sectors(&meta.devnode(), Sectors(0), meta.size())?;
+        wipe_sectors(
+            &meta.devnode(),
+            Sectors(0),
+            cmp::min(Sectors(8), meta.size()),
+        )?;
     }
 
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);


### PR DESCRIPTION
Related: #1188 .

If we only need to zero out the first 4K of the metadata device, we might as well do that instead of zeroing out the whole thing. That's not a complete fix to the problem of #1188, but it will go a long way to making it less obvious and unpleasant. Note that the current metadata device size in the backstore is 1 MiS where S stands for Sectors, i.e., 512 MiB.