### PR TITLE
Eliminate Backstore::add_blockdevs

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -303,15 +303,14 @@ impl Pool for StratPool {
             // If adding cache devices, must suspend the pool, since the cache
             // must be augmeneted with the new devices.
             self.thin_pool.suspend()?;
-            let bdev_info = self.backstore.add_blockdevs(pool_uuid, paths, tier)?;
+            let bdev_info = self.backstore.add_cachedevs(pool_uuid, paths)?;
             self.thin_pool.set_device(self.backstore.device().expect("Since thin pool exists, space must have been allocated from the backstore, so backstore must have a cap device"))?;
             self.thin_pool.resume()?;
             Ok(bdev_info)
         } else {
             // If just adding data devices, no need to suspend the pool.
             // No action will be taken on the DM devices.
-            let bdev_info = self.backstore
-                .add_blockdevs(pool_uuid, paths, BlockDevTier::Data)?;
+            let bdev_info = self.backstore.add_datadevs(pool_uuid, paths)?;
 
             // Adding data devices does not change the state of the thin
             // pool at all. However, if the thin pool is in a state

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1217,8 +1217,6 @@ mod tests {
 
     use devicemapper::{Bytes, SECTOR_SIZE};
 
-    use super::super::super::super::types::BlockDevTier;
-
     use super::super::super::backstore::MIN_MDA_SECTORS;
     use super::super::super::cmd;
     use super::super::super::device::SyncAll;
@@ -1304,9 +1302,7 @@ mod tests {
         cmd::udev_settle().unwrap();
 
         // Add block devices to the pool and run check() to extend
-        backstore
-            .add_blockdevs(pool_uuid, &remaining_paths, BlockDevTier::Data)
-            .unwrap();
+        backstore.add_datadevs(pool_uuid, &remaining_paths).unwrap();
         pool.check(pool_uuid, &mut backstore).unwrap();
         // Verify the pool is back in a Good state
         match pool.thin_pool.status(get_dm()).unwrap() {
@@ -1896,9 +1892,7 @@ mod tests {
         let old_device = backstore
             .device()
             .expect("Space already allocated from backstore, backstore must have device");
-        backstore
-            .add_blockdevs(pool_uuid, paths1, BlockDevTier::Cache)
-            .unwrap();
+        backstore.add_cachedevs(pool_uuid, paths1).unwrap();
         let new_device = backstore
             .device()
             .expect("Space already allocated from backstore, backstore must have device");


### PR DESCRIPTION
This function made sense when add_datadevs and add_cachedevs did the same
thing. But now that they are so radically different, the shared function
is just no help at all.

Signed-off-by: mulhern <amulhern@redhat.com>