### PR TITLE
Temporarily allow a Travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ addons:
 language: rust
 
 matrix:
+    allow_failures:
+        # Temporarily allow failure until Travis bug is fixed.
+        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         # Verify formatting of Rust code
         - rust: stable


### PR DESCRIPTION
The failure is actually due to a problem w/ Travis, so the best thing is to
allow a failure until it is fixed.

Signed-off-by: mulhern <amulhern@redhat.com>