### PR TITLE
Revert "Temporarily allow a Travis failure"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ addons:
 language: rust
 
 matrix:
-    allow_failures:
-        # Temporarily allow failure until Travis bug is fixed.
-        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         # Verify formatting of Rust code
         - rust: stable


### PR DESCRIPTION
This reverts commit e172439f92d68d632c4874251a246563c6e2df13.

It seems that Travis problem is taken care of now.