### PR TITLE
Settle after failed fs create

### DIFF
--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -155,7 +155,6 @@ pub fn thin_repair(meta_dev: &Path, new_meta_dev: &Path) -> StratisResult<()> {
 }
 
 /// Call udevadm settle
-#[cfg(test)]
 pub fn udev_settle() -> StratisResult<()> {
     execute_cmd(Command::new("udevadm").arg("settle"))
 }

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -24,7 +24,7 @@ use stratis::{ErrorEnum, StratisError, StratisResult};
 use super::super::super::engine::Filesystem;
 use super::super::super::types::{FilesystemUuid, MaybeDbusPath, Name, PoolUuid};
 
-use super::super::cmd::{create_fs, set_uuid, xfs_growfs};
+use super::super::cmd::{create_fs, set_uuid, udev_settle, xfs_growfs};
 use super::super::dm::get_dm;
 use super::super::names::{format_thin_ids, ThinRole};
 use super::super::serde_structs::FilesystemSave;
@@ -71,6 +71,7 @@ impl StratFilesystem {
         )?;
 
         if let Err(err) = create_fs(&thin_dev.devnode(), fs_uuid) {
+            udev_settle()?;
             thin_dev.destroy(get_dm(), thinpool_dev)?;
             return Err(err);
         }


### PR DESCRIPTION
Uses `udev_settle()` to resolve #1254, and then attempts to DTRT if *that* fails as well (which it never should, right?) in a follow-on commit.