### PR TITLE
Update parameters that control thinpool/filesystem expansion as data/meta data is consumed 

### DIFF
--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -11,7 +11,6 @@ use std::path::{Path, PathBuf};
 
 use devicemapper::{
     Bytes, DmDevice, DmName, DmUuid, Sectors, ThinDev, ThinDevId, ThinPoolDev, ThinStatus, IEC,
-    SECTOR_SIZE,
 };
 
 use libmount;
@@ -28,14 +27,15 @@ use super::super::cmd::{create_fs, set_uuid, xfs_growfs};
 use super::super::dm::get_dm;
 use super::super::names::{format_thin_ids, ThinRole};
 use super::super::serde_structs::FilesystemSave;
+use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER};
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
 const TEMP_MNT_POINT_PREFIX: &str = "stratis_mp_";
 
-/// TODO: confirm that 256 MiB leaves enough time for stratisd to respond and extend before
-/// the filesystem is out of space.
-pub const FILESYSTEM_LOWATER: Sectors = Sectors(256 * IEC::Mi / (SECTOR_SIZE as u64)); // = 256 MiB
+/// Set the low water mark on the filesystem at 4 times the data low water.  The filesystem
+/// expansion check is triggered by crossing the data low water mark for the thin pool.
+pub const FILESYSTEM_LOWATER: Sectors = Sectors(4 * (DATA_LOWATER.0 * DATA_BLOCK_SIZE.0));
 
 #[derive(Debug)]
 pub struct StratFilesystem {

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -43,7 +43,7 @@ use super::mdv::MetadataVol;
 use super::thinids::ThinDevIdPool;
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
-const DATA_LOWATER: DataBlocks = DataBlocks(512);
+pub const DATA_LOWATER: DataBlocks = DataBlocks(512);
 const META_LOWATER_FALLBACK: MetaBlocks = MetaBlocks(512);
 
 const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4 * IEC::Ki);

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -6,15 +6,16 @@
 
 use std;
 use std::borrow::BorrowMut;
-use std::cmp::min;
-
+use std::cmp::{max, min};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use uuid::Uuid;
 
 use devicemapper as dm;
 use devicemapper::{
-    device_exists, Bytes, DataBlocks, Device, DmDevice, DmName, DmNameBuf, FlakeyTargetParams,
-    LinearDev, LinearDevTargetParams, LinearTargetParams, MetaBlocks, Sectors, TargetLine,
-    ThinDevId, ThinPoolDev, ThinPoolStatusSummary, IEC,
+    device_exists, DataBlocks, Device, DmDevice, DmName, DmNameBuf, FlakeyTargetParams, LinearDev,
+    LinearDevTargetParams, LinearTargetParams, MetaBlocks, Sectors, TargetLine, ThinDevId,
+    ThinPoolDev, ThinPoolStatusSummary, IEC,
 };
 
 use stratis::{ErrorEnum, StratisError, StratisResult};
@@ -44,6 +45,7 @@ use super::thinids::ThinDevIdPool;
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
 pub const DATA_LOWATER: DataBlocks = DataBlocks(512);
+const DATA_EXPAND_SIZE: Sectors = Sectors(16 * IEC::Mi); // 8 GiB
 const META_LOWATER_FALLBACK: MetaBlocks = MetaBlocks(512);
 
 const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4 * IEC::Ki);
@@ -62,6 +64,40 @@ fn sectors_to_datablocks(sectors: Sectors) -> DataBlocks {
 
 fn datablocks_to_sectors(data_blocks: DataBlocks) -> Sectors {
     *data_blocks * DATA_BLOCK_SIZE
+}
+
+/// Get the value for the "Dirty" key in /proc/meminfo in Sectors.
+/// Return an error if "Dirty" key is not found, value can not be parsed,
+/// or there is some error reading /proc/meminfo.
+fn current_dirty_mem() -> StratisResult<Sectors> {
+    for line in BufReader::new(File::open("/proc/meminfo")?).lines() {
+        let line = line?;
+        let mut iter = line.split_whitespace();
+        if iter.next().map_or(false, |key| key == "Dirty") {
+            return if let Some(value) = iter.next() {
+                match value.parse::<u64>() {
+                    // multiply by 2 for KB to # of sectors conversion
+                    Ok(dirty_mem_size) => Ok(Sectors(dirty_mem_size * 2)),
+                    Err(_) => Err(StratisError::Engine(
+                        ErrorEnum::Invalid,
+                        format!(
+                            "Failed to parse value for \"Dirty\" key from /proc/meminfo : {:?}",
+                            value
+                        ),
+                    )),
+                }
+            } else {
+                Err(StratisError::Engine(
+                    ErrorEnum::Invalid,
+                    "No value found for \"Dirty\" key in /proc/meminfo".into(),
+                ))
+            };
+        }
+    }
+    Err(StratisError::Engine(
+        ErrorEnum::Invalid,
+        "\"Dirty\" key not found in /prop/meminfo".into(),
+    ))
 }
 
 /// Transform a list of segments belonging to a single device into a
@@ -468,7 +504,10 @@ impl ThinPool {
             let remaining = total - used;
             if remaining <= low_water {
                 Some(if data {
-                    Bytes(IEC::Gi).sectors()
+                    match current_dirty_mem() {
+                        Ok(dirty_mem_size) => max(dirty_mem_size, DATA_EXPAND_SIZE),
+                        Err(_) => DATA_EXPAND_SIZE,
+                    }
                 } else {
                     INITIAL_META_SIZE.sectors()
                 })

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -44,7 +44,7 @@ use super::mdv::MetadataVol;
 use super::thinids::ThinDevIdPool;
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
-pub const DATA_LOWATER: DataBlocks = DataBlocks(512);
+pub const DATA_LOWATER: DataBlocks = DataBlocks(2048); // 2 GiB
 const DATA_EXPAND_SIZE: Sectors = Sectors(16 * IEC::Mi); // 8 GiB
 const META_LOWATER_FALLBACK: MetaBlocks = MetaBlocks(512);
 

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -46,7 +46,7 @@ use super::thinids::ThinDevIdPool;
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
 pub const DATA_LOWATER: DataBlocks = DataBlocks(2048); // 2 GiB
 const DATA_EXPAND_SIZE: Sectors = Sectors(16 * IEC::Mi); // 8 GiB
-const META_LOWATER_FALLBACK: MetaBlocks = MetaBlocks(512);
+const META_LOWATER_FALLBACK: MetaBlocks = MetaBlocks(1024);
 
 const INITIAL_META_SIZE: MetaBlocks = MetaBlocks(4 * IEC::Ki);
 const INITIAL_DATA_SIZE: DataBlocks = DataBlocks(768);

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1722,19 +1722,17 @@ mod tests {
             // Write 1 more sector than is initially allocated to a pool
             let write_size = datablocks_to_sectors(INITIAL_DATA_SIZE) + Sectors(1);
             let buf = &[1u8; SECTOR_SIZE];
-            for i in 0..*write_size {
+            for _ in 0..*write_size {
                 f.write_all(buf).unwrap();
-                // Simulate handling a DM event by extending the pool when
-                // the amount of free space in pool has decreased to the
-                // DATA_LOWATER value.
-                if i == *(datablocks_to_sectors(INITIAL_DATA_SIZE - DATA_LOWATER)) {
-                    pool.extend_thin_data_device(
-                        pool_uuid,
-                        &mut backstore,
-                        datablocks_to_sectors(INITIAL_DATA_SIZE),
-                    ).unwrap();
-                }
             }
+            // Simulate handling a DM event by extending the pool when
+            // the amount of free space in pool has decreased to the
+            // DATA_LOWATER value.
+            pool.extend_thin_data_device(
+                pool_uuid,
+                &mut backstore,
+                datablocks_to_sectors(INITIAL_DATA_SIZE),
+            ).unwrap();
         }
     }
 


### PR DESCRIPTION
For very fast devices that can consume 2 GiB per second (NVMe) - the data and meta devices need
to be expanded sooner. Update the constants that control data/meta/filesystem expansion.