### PR TITLE
Call udev_settle() after failed fs create

### DIFF
--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -155,7 +155,6 @@ pub fn thin_repair(meta_dev: &Path, new_meta_dev: &Path) -> StratisResult<()> {
 }
 
 /// Call udevadm settle
-#[cfg(test)]
 pub fn udev_settle() -> StratisResult<()> {
     execute_cmd(Command::new("udevadm").arg("settle"))
 }


### PR DESCRIPTION
Final PR, based on work PR #1295.

If any step in creating a fs fails (after mkfs), we need to possibly wait
for udev to finish before we can remove the thindev. Since this can
happen in both StratFilesystem::initialize (if create_fs fails) or in
ThinPool::create_filesystem (if save_fs fails), add a helper fn called
fs_settle() that does this.

Ok so now we're calling udev_settle. What if *that* fails? We're really
getting out on a limb of cascading failures here. But try to just sleep
to give time to free the device and keep going. There's definitely room
to improve this further.

If thin_dev.destroy() fails at this point, I don't know what else there
is to do. Emit to the log and add a TODO.

fixes #1274
fixes #1254

Signed-off-by: Andy Grover <agrover@redhat.com>