### PR TITLE
Run test_buffering by itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ test-travis:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test travis_
 
 test:
-	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_ --skip travis_
+	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_ --skip travis_ --skip test_buffering
+	# Wants to be run by itself.
+	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test test_buffering
 
 docs: stratisd.8 docs-rust
 


### PR DESCRIPTION
Previous tests must be setting the logger, so that when test_buffering
is run, it cannot set the buffer like it needs to.

Signed-off-by: Andy Grover <agrover@redhat.com>