### PR TITLE
Remove some unnecessary calls to join

### DIFF
--- a/tests/client-dbus/tests/dbus/_misc.py
+++ b/tests/client-dbus/tests/dbus/_misc.py
@@ -46,7 +46,7 @@ class _Service():
         """
         Start the stratisd daemon with the simulator.
         """
-        self._stratisd = subprocess.Popen([os.path.join(_STRATISD), '--sim'])
+        self._stratisd = subprocess.Popen([_STRATISD, '--sim'])
         time.sleep(1)
 
     def tearDown(self):

--- a/tests/client-dbus/tests/dbus/pool/test_udev.py
+++ b/tests/client-dbus/tests/dbus/pool/test_udev.py
@@ -122,8 +122,7 @@ class UdevAdd(unittest.TestCase):
 
         if self._service is None:
             dbus_interface_present = False
-            self._service = subprocess.Popen(
-                [os.path.join(_STRATISD), '--debug'])
+            self._service = subprocess.Popen([_STRATISD, '--debug'])
 
             limit = time.time() + 10.0
             while time.time() <= limit:


### PR DESCRIPTION
_STRATISD is a single path, it doesn't need to be joined with anything.

Signed-off-by: mulhern <amulhern@redhat.com>