### PR TITLE
Use non-debug UUID display

### DIFF
--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -282,8 +282,8 @@ pub fn get_blockdevs(
 
         if !duplicate_uuids.is_empty() {
             let err_msg = format!(
-                "The following list of Stratis UUIDs were each claimed by more than one Stratis device: {:?}",
-                duplicate_uuids
+                "The following list of Stratis UUIDs were each claimed by more than one Stratis device: {}",
+                duplicate_uuids.iter().map(|p| p.simple().to_string()).collect::<Vec<String>>().join(", ")
             );
             return Err(StratisError::Engine(ErrorEnum::Invalid, err_msg));
         }
@@ -291,9 +291,9 @@ pub fn get_blockdevs(
         let recorded_uuids: HashSet<_> = dev_map.keys().cloned().collect();
         if uuids != recorded_uuids {
             let err_msg = format!(
-                "UUIDs of devices found ({:?}) did not correspond with UUIDs specified in the metadata for this group of devices ({:?})",
-                uuids,
-                recorded_uuids
+                "UUIDs of devices found ({}) did not correspond with UUIDs specified in the metadata for this group of devices ({})",
+                uuids.iter().map(|p| p.simple().to_string()).collect::<Vec<String>>().join(", "),
+                recorded_uuids.iter().map(|p| p.simple().to_string()).collect::<Vec<String>>().join(", "),
             );
             return Err(StratisError::Engine(ErrorEnum::Invalid, err_msg));
         }


### PR DESCRIPTION
Changes:

```
WARN libstratis::engine::strat_engine::engine: no pool set up, reason: Engine(Error, "failed to set up pool for (pool UUID: 473b9763-a960-4e89-9b49-9658157d3373, devnodes: /dev/loop0): reason: Engine(Invalid, \"UUIDs of devices found ({Uuid { bytes: [248, 41, 194, 41, 207, 136, 64, 124, 171, 8, 28, 246, 83, 217, 190, 13] }}) did not correspond with UUIDs specified in the metadata for this group of devices ({Uuid { bytes: [73, 252, 208, 90, 95, 11, 77, 28, 184, 188, 45, 18, 33, 225, 134, 226] }, Uuid { bytes: [74, 179, 125, 254, 84, 224, 69, 131, 155, 116, 236, 33, 23, 144, 100, 101] }, Uuid { bytes: [248, 41, 194, 41, 207, 136, 64, 124, 171, 8, 28, 246, 83, 217, 190, 13] }})\")")
```

To

```
WARN libstratis::engine::strat_engine::engine: no pool set up, reason: Engine(Error, "failed to set up pool for (pool UUID: b41cceb0-fa37-4571-b2c7-9fab47cc3e2c, devnodes: /dev/loop1 ,/dev/loop0): reason: Engine(Invalid, \"UUIDs of devices found (38fe67a1-bf7f-4364-85c8-a24733459357, 7c3e0945-e0b4-4ae3-aa2d-ee67dcaaaa7c) did not correspond with UUIDs specified in the metadata for this group of devices (38fe67a1-bf7f-4364-85c8-a24733459357, 7c3e0945-e0b4-4ae3-aa2d-ee67dcaaaa7c, d7f03ac0-d103-4074-b109-0856dd600b4e)\")")
```

Signed-off-by: Tony Asleson <tasleson@redhat.com>