### PR TITLE
RFC: Possible way to capture error context

### DIFF
--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -65,8 +65,8 @@ impl BDA {
         where
             F: Read + Seek,
         {
-            f.seek(SeekFrom::Start(offset as u64))?;
-            f.read_exact(&mut buf)?;
+            tll!(f.seek(SeekFrom::Start(offset as u64)));
+            tll!(f.read_exact(&mut buf));
             Ok(())
         }
 
@@ -273,7 +273,7 @@ impl StaticHeader {
     where
         F: Read + Seek + SyncAll,
     {
-        let (buf_loc_1, buf_loc_2) = BDA::read(f)?;
+        let (buf_loc_1, buf_loc_2) = tll!(BDA::read(f));
 
         match (
             StaticHeader::sigblock_from_buf(&buf_loc_1),

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -30,13 +30,14 @@ use super::util::get_stratis_block_devices;
 pub fn find_all() -> StratisResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> {
     let mut pool_map = HashMap::new();
 
-    for devnode in get_stratis_block_devices()? {
-        match devnode_to_devno(&devnode)? {
+    for devnode in tll!(get_stratis_block_devices()) {
+        match tll!(devnode_to_devno(&devnode)) {
             None => continue,
             Some(devno) => {
-                if let Some((pool_uuid, _)) = StaticHeader::device_identifiers(
-                    &mut OpenOptions::new().read(true).open(&devnode)?,
-                )? {
+                if let Some((pool_uuid, _)) = tll!(StaticHeader::device_identifiers(&mut tll!(
+                    OpenOptions::new().read(true).open(&devnode)
+                ),))
+                {
                     pool_map
                         .entry(pool_uuid)
                         .or_insert_with(HashMap::new)

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -115,9 +115,9 @@ impl StratEngine {
     /// Returns an error if there was an error reading device nodes.
     /// Returns an error if the binaries on which it depends can not be found.
     pub fn initialize() -> StratisResult<StratEngine> {
-        let dm = get_dm_init()?;
-        verify_binaries()?;
-        let minor_dm_version = dm.version()?.1;
+        let dm = tll!(get_dm_init());
+        tll!(verify_binaries());
+        let minor_dm_version = tll!(dm.version()).1;
         if minor_dm_version < REQUIRED_DM_MINOR_VERSION {
             let err_msg = format!(
                 "Requires DM minor version {} but kernel only supports {}",
@@ -126,9 +126,9 @@ impl StratEngine {
             return Err(StratisError::Engine(ErrorEnum::Error, err_msg));
         }
 
-        devlinks::setup_dev_path()?;
+        tll!(devlinks::setup_dev_path());
 
-        let pools = find_all()?;
+        let pools = tll!(find_all());
 
         let mut table = Table::default();
         let mut incomplete_pools = HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,12 +39,12 @@ extern crate matches;
 #[macro_use]
 extern crate lazy_static;
 
+#[macro_use]
+pub mod util;
+
 pub mod engine;
 
 #[cfg(feature = "dbus_enabled")]
 pub mod dbus_api;
 
 pub mod stratis;
-
-#[macro_use]
-pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,6 @@ pub mod engine;
 pub mod dbus_api;
 
 pub mod stratis;
+
+#[macro_use]
+pub mod util;

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -1,0 +1,18 @@
+/// Try Log Location -> tll
+/// Used the same as try!, but also uses error! to log the file, line and error to allow us to
+/// know where the error occurred.
+#[macro_export]
+macro_rules! tll {
+    ($expr:expr) => {
+        match $expr {
+            ::std::result::Result::Ok(val) => val,
+            ::std::result::Result::Err(err) => {
+                error!("{} {} reason: {:?}", file!(), line!(), err);
+                return ::std::result::Result::Err(::std::convert::From::from(err));
+            }
+        }
+    };
+    ($expr:expr,) => {
+        tll!($expr)
+    };
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,2 @@
+#[macro_use]
+pub mod macros;


### PR DESCRIPTION
We have a lot of code that uses the `?` operator.  When an issue occurs deep in the call stack and bubbles up we can be left with a simple error message like the one seen in https://github.com/stratis-storage/stratisd/issues/1329 
`IO error: Invalid argument (os error 22)` . 

The call stack looked something like:
```
main 
  -> run 
    -> initialize 
      -> find_all 
        -> device_identifiers 
          -> setup 
            -> BDA::read 
              -> read_sector_at_offset 
                -> seek
``` 

But we had no idea that this is where the error occurred as there are a number of different paths that could of lead to this error of invalid argument.  Having the information about where an error occurs would be helpful and thus the motivation for this PR.  This would add some useful information, ideally it would be better to have which function and it's arguments when the failure occurs.

