### PR TITLE
Set interface name in propchanged signal

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -190,6 +190,7 @@ impl EngineListener for EventHandler {
                         consts::BLOCKDEV_STATE_PROP,
                         state as u16,
                         &dbus_path,
+                        consts::BLOCKDEV_INTERFACE_NAME,
                     ).unwrap_or_else(|()| {
                         error!(
                             "BlockdevStateChanged: {} state: {} failed to send dbus update.",
@@ -209,6 +210,7 @@ impl EngineListener for EventHandler {
                         consts::FILESYSTEM_NAME_PROP,
                         to.to_string(),
                         &dbus_path,
+                        consts::FILESYSTEM_INTERFACE_NAME,
                     ).unwrap_or_else(|()| {
                         error!(
                             "FilesystemRenamed: {} from: {} to: {} failed to send dbus update.",
@@ -224,6 +226,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_EXTEND_STATE_PROP,
                         state as u16,
                         &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
                     ).unwrap_or_else(|()| {
                         error!(
                             "PoolExtendStateChanged: {} state: {} failed to send dbus update.",
@@ -243,6 +246,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_NAME_PROP,
                         to.to_string(),
                         &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
                     ).unwrap_or_else(|()| {
                         error!(
                             "PoolRenamed: {} from: {} to: {} failed to send dbus update.",
@@ -258,6 +262,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_SPACE_STATE_PROP,
                         state as u16,
                         &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
                     ).unwrap_or_else(|()| {
                         error!(
                             "PoolSpaceStateChanged: {} state: {} failed to send dbus update.",
@@ -273,6 +278,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_STATE_PROP,
                         state as u16,
                         &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
                     ).unwrap_or_else(|()| {
                         error!(
                             "PoolStateChanged: {} state: {} failed to send dbus update.",

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -19,12 +19,12 @@ use super::super::engine::{Engine, Pool, PoolUuid};
 use super::super::stratis::VERSION;
 
 use super::blockdev::create_dbus_blockdev;
+use super::consts;
 use super::filesystem::create_dbus_filesystem;
 use super::pool::create_dbus_pool;
 use super::types::{ActionQueue, DbusContext, DbusErrorEnum, DeferredAction, TData};
 use super::util::{
     engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
-    STRATIS_BASE_PATH, STRATIS_BASE_SERVICE,
 };
 
 fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -170,13 +170,11 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>, db
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_version);
 
-    let interface_name = format!("{}.{}", STRATIS_BASE_SERVICE, "Manager");
-
-    let obj_path = f.object_path(STRATIS_BASE_PATH, None)
+    let obj_path = f.object_path(consts::STRATIS_BASE_PATH, None)
         .introspectable()
         .object_manager()
         .add(
-            f.interface(interface_name, ())
+            f.interface(consts::MANAGER_INTERFACE_NAME, ())
                 .add_m(create_pool_method)
                 .add_m(destroy_pool_method)
                 .add_m(configure_simulator_method)
@@ -217,7 +215,10 @@ pub fn connect<'a>(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData<'a>
     let (tree, object_path) = get_base_tree(DbusContext::new(engine));
     let dbus_context = tree.get_data().clone();
     tree.set_registered(&c, true)?;
-    c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32)?;
+    c.register_name(
+        consts::STRATIS_BASE_SERVICE,
+        NameFlag::ReplaceExisting as u32,
+    )?;
     Ok(DbusConnectionData {
         connection: Rc::new(RefCell::new(c)),
         tree,

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -18,7 +18,6 @@ use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, msg_code_ok, msg_string_ok,
-    STRATIS_BASE_PATH, STRATIS_BASE_SERVICE,
 };
 
 pub fn create_dbus_blockdev<'a>(
@@ -82,16 +81,14 @@ pub fn create_dbus_blockdev<'a>(
 
     let object_name = format!(
         "{}/{}",
-        STRATIS_BASE_PATH,
+        consts::STRATIS_BASE_PATH,
         dbus_context.get_next_id().to_string()
     );
-
-    let interface_name = format!("{}.{}", STRATIS_BASE_SERVICE, "blockdev");
 
     let object_path = f.object_path(object_name, Some(OPContext::new(parent, uuid)))
         .introspectable()
         .add(
-            f.interface(interface_name, ())
+            f.interface(consts::BLOCKDEV_INTERFACE_NAME, ())
                 .add_m(set_userid_method)
                 .add_p(devnode_property)
                 .add_p(hardware_info_property)

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -2,15 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Pool Properties
+pub const POOL_INTERFACE_NAME: &str = "org.storage.stratis1.pool";
 pub const POOL_NAME_PROP: &str = "Name";
 pub const POOL_STATE_PROP: &str = "State";
 pub const POOL_EXTEND_STATE_PROP: &str = "ExtendState";
 pub const POOL_SPACE_STATE_PROP: &str = "SpaceState";
 
-// Filesystem Properties
+pub const FILESYSTEM_INTERFACE_NAME: &str = "org.storage.stratis1.filesystem";
 pub const FILESYSTEM_NAME_PROP: &str = "Name";
 pub const FILESYSTEM_USED_PROP: &str = "Used";
 
-// Blockdev Properties
+pub const BLOCKDEV_INTERFACE_NAME: &str = "org.storage.stratis1.blockdev";
 pub const BLOCKDEV_STATE_PROP: &str = "State";

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -2,6 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+pub const STRATIS_BASE_PATH: &str = "/org/storage/stratis1";
+pub const STRATIS_BASE_SERVICE: &str = "org.storage.stratis1";
+
+pub const MANAGER_INTERFACE_NAME: &str = "org.storage.stratis1.Manager";
+
 pub const POOL_INTERFACE_NAME: &str = "org.storage.stratis1.pool";
 pub const POOL_NAME_PROP: &str = "Name";
 pub const POOL_STATE_PROP: &str = "State";

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -19,7 +19,6 @@ use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, msg_code_ok, msg_string_ok,
-    STRATIS_BASE_PATH, STRATIS_BASE_SERVICE,
 };
 
 pub fn create_dbus_filesystem<'a>(
@@ -68,16 +67,14 @@ pub fn create_dbus_filesystem<'a>(
 
     let object_name = format!(
         "{}/{}",
-        STRATIS_BASE_PATH,
+        consts::STRATIS_BASE_PATH,
         dbus_context.get_next_id().to_string()
     );
-
-    let interface_name = format!("{}.{}", STRATIS_BASE_SERVICE, "filesystem");
 
     let object_path = f.object_path(object_name, Some(OPContext::new(parent, uuid)))
         .introspectable()
         .add(
-            f.interface(interface_name, ())
+            f.interface(consts::FILESYSTEM_INTERFACE_NAME, ())
                 .add_m(rename_method)
                 .add_p(devnode_property)
                 .add_p(name_property)

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -24,10 +24,7 @@ use super::consts;
 use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
-use super::util::{
-    engine_to_dbus_err_tuple, get_next_arg, get_uuid, msg_code_ok, msg_string_ok,
-    STRATIS_BASE_PATH, STRATIS_BASE_SERVICE,
-};
+use super::util::{engine_to_dbus_err_tuple, get_next_arg, get_uuid, msg_code_ok, msg_string_ok};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
@@ -449,16 +446,14 @@ pub fn create_dbus_pool<'a>(
 
     let object_name = format!(
         "{}/{}",
-        STRATIS_BASE_PATH,
+        consts::STRATIS_BASE_PATH,
         dbus_context.get_next_id().to_string()
     );
-
-    let interface_name = format!("{}.{}", STRATIS_BASE_SERVICE, "pool");
 
     let object_path = f.object_path(object_name, Some(OPContext::new(parent, uuid)))
         .introspectable()
         .add(
-            f.interface(interface_name, ())
+            f.interface(consts::POOL_INTERFACE_NAME, ())
                 .add_m(create_filesystems_method)
                 .add_m(destroy_filesystems_method)
                 .add_m(snapshot_method)

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -17,9 +17,6 @@ use super::super::stratis::{ErrorEnum, StratisError};
 
 use super::types::{DbusErrorEnum, TData};
 
-pub const STRATIS_BASE_PATH: &str = "/org/storage/stratis1";
-pub const STRATIS_BASE_SERVICE: &str = "org.storage.stratis1";
-
 /// Convert a tuple as option to an Option type
 pub fn tuple_to_option<T>(value: (bool, T)) -> Option<T> {
     if value.0 {

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -115,6 +115,7 @@ pub fn prop_changed_dispatch<T: 'static>(
     prop_name: &str,
     new_value: T,
     path: &dbus::Path,
+    interface: &str,
 ) -> Result<(), ()>
 where
     T: RefArg,
@@ -123,6 +124,7 @@ where
     prop_changed
         .changed_properties
         .insert(prop_name.into(), Variant(Box::new(new_value)));
+    prop_changed.interface_name = interface.to_owned();
 
     conn.send(prop_changed.to_emit_message(path))?;
 


### PR DESCRIPTION
Apparently everyone does this, but we currently do not. This is useful for
filtering dbus signals.

Signed-off-by: Andy Grover <agrover@redhat.com>