### PR TITLE
Fix current_dirty_mem() parser

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -72,7 +72,7 @@ fn current_dirty_mem() -> StratisResult<Sectors> {
     for line in BufReader::new(File::open("/proc/meminfo")?).lines() {
         let line = line?;
         let mut iter = line.split_whitespace();
-        if iter.next().map_or(false, |key| key == "Dirty") {
+        if iter.next().map_or(false, |key| key == "Dirty:") {
             return if let Some(value) = iter.next() {
                 match value.parse::<u64>() {
                     // multiply by 2 for KB to # of sectors conversion


### PR DESCRIPTION
Key should be compared to "Dirty:" - not "Dirty".  Parsing the value is currently failing.

If we are going to delete this code witih  #1336 - we should fix this bug first.