### PR TITLE
RFC: Simplify main loop, remove some exiting daemon paths, fix clippy error

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::process::exit;
 use std::rc::Rc;
@@ -316,6 +316,14 @@ impl<'a> UdevMonitor<'a> {
             socket: monitor.listen()?,
         })
     }
+
+    fn as_raw_fd(&mut self) -> RawFd {
+        self.socket.as_raw_fd()
+    }
+
+    fn receive_event(&mut self) -> Option<libudev::Event> {
+        self.socket.receive_event()
+    }
 }
 
 // Process any pending signals, return true if we should exit.
@@ -441,7 +449,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.
     let context = libudev::Context::new()?;
-    let mut udev_events = UdevMonitor::create(&context)?;
+    let mut udev_monitor = UdevMonitor::create(&context)?;
 
     let engine: Rc<RefCell<Engine>> = {
         if matches.is_present("sim") {
@@ -483,7 +491,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut fds = Vec::new();
 
     fds.push(libc::pollfd {
-        fd: udev_events.socket.as_raw_fd(),
+        fd: udev_monitor.as_raw_fd(),
         revents: 0,
         events: libc::POLLIN,
     });
@@ -543,7 +551,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_events.socket.receive_event() {
+            while let Some(event) = udev_monitor.receive_event() {
                 if let Some(_pool_uuid) = handle_udev_event(&event, &engine) {
                     #[cfg(feature = "dbus_enabled")]
                     {

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -312,7 +312,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut dbus_handle: Option<libstratis::dbus_api::DbusConnectionData> = None;
 
     // Setup a udev listener before initializing the engine. A device may
-    // appear after the engine has read the /dev directory but before it has
+    // appear after the engine has processed the udev db, but before it has
     // completed initialization. Unless the udev event has been recorded, the
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -476,6 +476,23 @@ fn initialize_dbus(
     Ok(())
 }
 
+/// Handle blocking the event loop
+fn process_poll(poll_timeout: i32, fds: &mut Vec<libc::pollfd>) -> StratisResult<()> {
+    let r = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, poll_timeout) };
+
+    // TODO: refine this behavior.
+    // Different behaviors may be indicated, depending on the value of
+    // errno when return value is -1.
+    if r < 0 {
+        return Err(StratisError::Error(format!(
+            "poll command failed: number of fds: {}, timeout: {}",
+            fds.len(),
+            poll_timeout
+        )));
+    }
+    Ok(())
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -651,19 +668,8 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         // Default timeout is infinite
         #[cfg(not(feature = "dbus_enabled"))]
         let poll_timeout = -1;
-
-        let r = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, poll_timeout) };
-
-        // TODO: refine this behavior.
-        // Different behaviors may be indicated, depending on the value of
-        // errno when return value is -1.
-        if r < 0 {
-            return Err(StratisError::Error(format!(
-                "poll command failed: number of fds: {}, timeout: {}",
-                fds.len(),
-                poll_timeout
-            )));
-        }
+        // Block until we have something to handle
+        process_poll(poll_timeout, &mut fds)?;
     }
 }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -42,7 +42,7 @@ use timerfd::{SetTimeFlags, TimerFd, TimerState};
 use uuid::Uuid;
 
 #[cfg(feature = "dbus_enabled")]
-use dbus::{Connection, WatchEvent};
+use dbus::Connection;
 
 use devicemapper::Device;
 #[cfg(feature = "dbus_enabled")]
@@ -54,9 +54,6 @@ use libstratis::engine::{
 use libstratis::engine::{Engine, SimEngine, StratEngine};
 use libstratis::stratis::buff_log;
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
-
-#[cfg(feature = "dbus_enabled")]
-use libstratis::engine::Pool;
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
 
@@ -360,30 +357,10 @@ fn process_signal(
 #[cfg(feature = "dbus_enabled")]
 fn process_dbus(
     handle: &mut libstratis::dbus_api::DbusConnectionData,
-    engine: &Rc<RefCell<Engine>>,
     fds: &mut Vec<libc::pollfd>,
     dbus_client_index_start: usize,
 ) -> StratisResult<()> {
-    for pfd in fds[dbus_client_index_start..]
-        .iter()
-        .filter(|pfd| pfd.revents != 0)
-    {
-        for item in handle
-            .connection
-            .borrow()
-            .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
-        {
-            if let Err(r) = libstratis::dbus_api::handle(
-                &handle.connection.borrow(),
-                &item,
-                &mut handle.tree,
-                &handle.context,
-            ) {
-                log_engine_state(&*engine.borrow());
-                print_err(&From::from(r));
-            }
-        }
-    }
+    handle.handle(&fds[dbus_client_index_start..]);
 
     // Refresh list of dbus fds to poll for. This can change as
     // D-Bus clients come and go.
@@ -400,30 +377,6 @@ fn process_dbus(
     Ok(())
 }
 
-/// Handle registering the pool with the dbus library.  Wondering why the actual register_pool
-/// isn't implements with methods on the DbusConnectionData structure???
-#[cfg(feature = "dbus_enabled")]
-fn dbus_register_pool(
-    handle: &mut libstratis::dbus_api::DbusConnectionData,
-    pool_uuid: Uuid,
-    pool: &mut Pool,
-) -> StratisResult<()> {
-    if let Err(e) = libstratis::dbus_api::register_pool(
-        &handle.connection.borrow(),
-        &handle.context,
-        &mut handle.tree,
-        pool_uuid,
-        pool,
-        &handle.path,
-    ) {
-        error!(
-            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-            pool_uuid, pool, handle.path, e
-        );
-    }
-    Ok(())
-}
-
 /// Iterate through all the pools and register them with the dbus interface and update the vector
 /// of file poll file descriptors.
 #[cfg(feature = "dbus_enabled")]
@@ -437,7 +390,7 @@ fn initialize_dbus(
     get_engine_listener_list_mut().register_listener(event_handler);
     // Register all the pools with dbus
     for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-        dbus_register_pool(handle, pool_uuid, pool)?;
+        handle.register_pool(pool_uuid, pool)?;
     }
 
     // Add dbus FD to fds as dbus is now available.
@@ -603,7 +556,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                                 )
                                 .1;
 
-                            dbus_register_pool(handle, _pool_uuid, pool)?;
+                            handle.register_pool(_pool_uuid, pool)?;
                         }
                     }
                 }
@@ -642,8 +595,10 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         #[cfg(feature = "dbus_enabled")]
         {
             if let Some(ref mut handle) = dbus_handle {
-                process_dbus(handle, &engine, &mut fds, dbus_client_index_start)?;
-            } else if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
+                process_dbus(handle, &mut fds, dbus_client_index_start)?;
+            } else if let Ok(mut handle) =
+                libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(&engine))
+            {
                 initialize_dbus(&mut handle, &engine, &mut fds)?;
                 dbus_handle = Some(handle);
             }

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -301,13 +301,10 @@ impl MaybeDbusSupport {
         _engine: &Rc<RefCell<Engine>>,
         _fds: &mut Vec<libc::pollfd>,
         _dbus_client_index_start: usize,
-    ) -> StratisResult<()> {
-        Ok(())
+    ) {
     }
 
-    fn register_pool(&mut self, _pool_uuid: Uuid, _pool: &mut Pool) -> StratisResult<()> {
-        Ok(())
-    }
+    fn register_pool(&mut self, _pool_uuid: Uuid, _pool: &mut Pool) {}
 
     fn poll_timeout(&self) -> i32 {
         // Non-DBus timeout is infinite
@@ -322,7 +319,7 @@ impl MaybeDbusSupport {
     }
 
     /// Connect to D-Bus and register pools, if not already connected.
-    fn check_connect(&mut self, engine: &Rc<RefCell<Engine>>) -> StratisResult<bool> {
+    fn check_connect(&mut self, engine: &Rc<RefCell<Engine>>) -> bool {
         let mut connected = self.handle.is_some();
         if !connected {
             match libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(&engine)) {
@@ -336,14 +333,14 @@ impl MaybeDbusSupport {
                     get_engine_listener_list_mut().register_listener(event_handler);
                     // Register all the pools with dbus
                     for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-                        handle.register_pool(pool_uuid, pool)?;
+                        handle.register_pool(pool_uuid, pool)
                     }
                     self.handle = Some(handle);
                     connected = true;
                 }
             }
         }
-        Ok(connected)
+        connected
     }
 
     /// Handle any client dbus requests.
@@ -352,8 +349,8 @@ impl MaybeDbusSupport {
         engine: &Rc<RefCell<Engine>>,
         fds: &mut Vec<libc::pollfd>,
         dbus_client_index_start: usize,
-    ) -> StratisResult<()> {
-        if self.check_connect(engine)? {
+    ) {
+        if self.check_connect(engine) {
             let handle = &mut self
                 .handle
                 .as_mut()
@@ -373,14 +370,12 @@ impl MaybeDbusSupport {
                     .map(|w| w.to_pollfd()),
             );
         }
-        Ok(())
     }
 
-    fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) -> StratisResult<()> {
+    fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) {
         if let Some(h) = self.handle.as_mut() {
-            h.register_pool(pool_uuid, pool)?;
+            h.register_pool(pool_uuid, pool)
         }
-        Ok(())
     }
 
     fn poll_timeout(&self) -> i32 {
@@ -411,11 +406,7 @@ impl<'a> UdevMonitor<'a> {
 
     /// Given some udev events, see if any new pools are formed, and set up
     /// dbus if so.
-    fn handle_events(
-        &mut self,
-        engine: &Rc<RefCell<Engine>>,
-        dbus_support: &mut MaybeDbusSupport,
-    ) -> StratisResult<()> {
+    fn handle_events(&mut self, engine: &Rc<RefCell<Engine>>, dbus_support: &mut MaybeDbusSupport) {
         while let Some(event) = self.socket.receive_event() {
             if event.event_type() == libudev::EventType::Add
                 || event.event_type() == libudev::EventType::Change
@@ -434,11 +425,10 @@ impl<'a> UdevMonitor<'a> {
                     let (_, pool) = eng_ref
                         .get_mut_pool(pool_uuid)
                         .expect("block_evaluate() returned a pool UUID, pool must be available");
-                    dbus_support.register_pool(pool_uuid, pool)?;
+                    dbus_support.register_pool(pool_uuid, pool);
                 }
             }
         }
-        Ok(())
     }
 }
 
@@ -613,7 +603,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            udev_monitor.handle_events(&engine, &mut dbus_support)?;
+            udev_monitor.handle_events(&engine, &mut dbus_support)
         }
 
         // Process any signals off of signalfd
@@ -646,7 +636,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         // Iterate through D-Bus file descriptors (if enabled) and dbus is
         // actually available, otherwise attempt to bring up the dbus
         // interface.
-        dbus_support.process(&engine, &mut fds, dbus_client_index_start)?;
+        dbus_support.process(&engine, &mut fds, dbus_client_index_start);
 
         let poll_timeout = dbus_support.poll_timeout();
         // Block until we have something to handle

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -51,7 +51,7 @@ use libstratis::dbus_api::{consts, prop_changed_dispatch};
 use libstratis::engine::{
     get_engine_listener_list_mut, EngineEvent, EngineListener, MaybeDbusPath,
 };
-use libstratis::engine::{Engine, SimEngine, StratEngine};
+use libstratis::engine::{Engine, Pool, SimEngine, StratEngine};
 use libstratis::stratis::buff_log;
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
 
@@ -303,6 +303,113 @@ impl EngineListener for EventHandler {
     }
 }
 
+struct MaybeDbusSupport {
+    #[cfg(feature = "dbus_enabled")]
+    handle: Option<libstratis::dbus_api::DbusConnectionData>,
+}
+
+// If D-Bus compiled out, do very little.
+#[cfg(not(feature = "dbus_enabled"))]
+impl MaybeDbusSupport {
+    fn new() -> MaybeDbusSupport {
+        MaybeDbusSupport {}
+    }
+
+    fn process(
+        &mut self,
+        _engine: &Rc<RefCell<Engine>>,
+        _fds: &mut Vec<libc::pollfd>,
+        _dbus_client_index_start: usize,
+    ) -> StratisResult<()> {
+        Ok(())
+    }
+
+    fn register_pool(&mut self, _pool_uuid: Uuid, _pool: &mut Pool) -> StratisResult<()> {
+        Ok(())
+    }
+
+    fn poll_timeout(&self) -> i32 {
+        // Non-DBus timeout is infinite
+        -1
+    }
+}
+
+#[cfg(feature = "dbus_enabled")]
+impl MaybeDbusSupport {
+    fn new() -> MaybeDbusSupport {
+        MaybeDbusSupport { handle: None }
+    }
+
+    /// Connect to D-Bus and register pools, if not already connected.
+    fn check_connect(&mut self, engine: &Rc<RefCell<Engine>>) -> StratisResult<bool> {
+        let mut connected = self.handle.is_some();
+        if !connected {
+            match libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(&engine)) {
+                Err(_err) => {
+                    info!("D-Bus API is not available");
+                    connected = false;
+                }
+                Ok(mut handle) => {
+                    info!("D-Bus API is available");
+                    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
+                    get_engine_listener_list_mut().register_listener(event_handler);
+                    // Register all the pools with dbus
+                    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
+                        handle.register_pool(pool_uuid, pool)?;
+                    }
+                    self.handle = Some(handle);
+                    connected = true;
+                }
+            }
+        }
+        Ok(connected)
+    }
+
+    /// Handle any client dbus requests.
+    fn process(
+        &mut self,
+        engine: &Rc<RefCell<Engine>>,
+        fds: &mut Vec<libc::pollfd>,
+        dbus_client_index_start: usize,
+    ) -> StratisResult<()> {
+        if self.check_connect(engine)? {
+            let handle = &mut self
+                .handle
+                .as_mut()
+                .expect("Connected, so handle is present");
+
+            handle.handle(&fds[dbus_client_index_start..]);
+
+            // Refresh list of dbus fds to poll for. This can change as
+            // D-Bus clients come and go.
+            fds.truncate(dbus_client_index_start);
+            fds.extend(
+                handle
+                    .connection
+                    .borrow()
+                    .watch_fds()
+                    .iter()
+                    .map(|w| w.to_pollfd()),
+            );
+        }
+        Ok(())
+    }
+
+    fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) -> StratisResult<()> {
+        if let Some(h) = self.handle.as_mut() {
+            h.register_pool(pool_uuid, pool)?;
+        }
+        Ok(())
+    }
+
+    fn poll_timeout(&self) -> i32 {
+        // If dbus support is compiled in and dbus isn't available we will set
+        // timeout to 1 second so that we periodically check to see if we can
+        // bring it up.
+        self.handle.as_ref().map_or(1000, |_| -1)
+    }
+}
+
 struct UdevMonitor<'a> {
     socket: libudev::MonitorSocket<'a>,
 }
@@ -361,58 +468,6 @@ fn process_signal(
     }
 }
 
-/// Handle any client dbus requests.
-#[cfg(feature = "dbus_enabled")]
-fn process_dbus(
-    handle: &mut libstratis::dbus_api::DbusConnectionData,
-    fds: &mut Vec<libc::pollfd>,
-    dbus_client_index_start: usize,
-) -> StratisResult<()> {
-    handle.handle(&fds[dbus_client_index_start..]);
-
-    // Refresh list of dbus fds to poll for. This can change as
-    // D-Bus clients come and go.
-    fds.truncate(dbus_client_index_start);
-    fds.extend(
-        handle
-            .connection
-            .borrow()
-            .watch_fds()
-            .iter()
-            .map(|w| w.to_pollfd()),
-    );
-
-    Ok(())
-}
-
-/// Iterate through all the pools and register them with the dbus interface and update the vector
-/// of file poll file descriptors.
-#[cfg(feature = "dbus_enabled")]
-fn initialize_dbus(
-    handle: &mut libstratis::dbus_api::DbusConnectionData,
-    engine: &Rc<RefCell<Engine>>,
-    fds: &mut Vec<libc::pollfd>,
-) -> StratisResult<()> {
-    info!("DBUS API is now available");
-    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
-    get_engine_listener_list_mut().register_listener(event_handler);
-    // Register all the pools with dbus
-    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-        handle.register_pool(pool_uuid, pool)?;
-    }
-
-    // Add dbus FD to fds as dbus is now available.
-    fds.extend(
-        handle
-            .connection
-            .borrow()
-            .watch_fds()
-            .iter()
-            .map(|w| w.to_pollfd()),
-    );
-    Ok(())
-}
-
 /// Handle blocking the event loop
 fn process_poll(poll_timeout: i32, fds: &mut Vec<libc::pollfd>) -> StratisResult<()> {
     let r = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, poll_timeout) };
@@ -438,10 +493,9 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     // Ensure that the debug log is output when we leave this function.
     let _guard = buff_log.to_guard();
 
-    // Even if dbus is enabled at compile time, it may not be available at all times depending
-    // on the environment we are running in.
-    #[cfg(feature = "dbus_enabled")]
-    let mut dbus_handle: Option<libstratis::dbus_api::DbusConnectionData> = None;
+    // Even if dbus is enabled at compile time, it may not be available at all
+    // times depending on the environment we are running in.
+    let mut dbus_support = MaybeDbusSupport::new();
 
     // Setup a udev listener before initializing the engine. A device may
     // appear after the engine has processed the udev db, but before it has
@@ -539,7 +593,6 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         });
     };
 
-    #[cfg(feature = "dbus_enabled")]
     let dbus_client_index_start = if eventable.is_some() {
         FD_INDEX_ENGINE + 1
     } else {
@@ -552,21 +605,13 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
             while let Some(event) = udev_monitor.receive_event() {
-                if let Some(_pool_uuid) = handle_udev_event(&event, &engine) {
-                    #[cfg(feature = "dbus_enabled")]
-                    {
-                        let mut eng_ref = engine.borrow_mut();
-                        if let Some(ref mut handle) = dbus_handle {
-                            let pool = eng_ref
-                                .get_mut_pool(_pool_uuid)
-                                .expect(
-                                    "block_evaluate() returned a pool UUID, pool must be available",
-                                )
-                                .1;
+                if let Some(pool_uuid) = handle_udev_event(&event, &engine) {
+                    let mut eng_ref = engine.borrow_mut();
+                    let (_, pool) = eng_ref
+                        .get_mut_pool(pool_uuid)
+                        .expect("block_evaluate() returned a pool UUID, pool must be available");
 
-                            handle.register_pool(_pool_uuid, pool)?;
-                        }
-                    }
+                    dbus_support.register_pool(pool_uuid, pool)?;
                 }
             }
         }
@@ -598,27 +643,12 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
             }
         }
 
-        // Iterate through D-Bus file descriptors (if enabled) and dbus is actually available,
-        // otherwise attempt to bring up the dbus interface.
-        #[cfg(feature = "dbus_enabled")]
-        {
-            if let Some(ref mut handle) = dbus_handle {
-                process_dbus(handle, &mut fds, dbus_client_index_start)?;
-            } else if let Ok(mut handle) =
-                libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(&engine))
-            {
-                initialize_dbus(&mut handle, &engine, &mut fds)?;
-                dbus_handle = Some(handle);
-            }
-        }
+        // Iterate through D-Bus file descriptors (if enabled) and dbus is
+        // actually available, otherwise attempt to bring up the dbus
+        // interface.
+        dbus_support.process(&engine, &mut fds, dbus_client_index_start)?;
 
-        // If dbus support is compiled in and dbus isn't available we will set timeout to
-        // 1 second so that we periodically check to see if we can bring it up.
-        #[cfg(feature = "dbus_enabled")]
-        let poll_timeout = dbus_handle.as_ref().map_or(1000, |_| -1);
-        // Default timeout is infinite
-        #[cfg(not(feature = "dbus_enabled"))]
-        let poll_timeout = -1;
+        let poll_timeout = dbus_support.poll_timeout();
         // Block until we have something to handle
         process_poll(poll_timeout, &mut fds)?;
     }

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -313,6 +313,52 @@ impl<'a> UdevMonitor<'a> {
     }
 }
 
+/// Process the udev event by bringing up pools if possible and registering them with dbus api.
+fn process_udev_event(
+    udev_events: &mut UdevMonitor,
+    dbus_handle: &mut Option<libstratis::dbus_api::DbusConnectionData>,
+    engine: &Rc<RefCell<Engine>>,
+) -> StratisResult<()> {
+    while let Some(event) = udev_events.socket.receive_event() {
+        if let Some((device, devnode)) = handle_udev_event(&event) {
+            // If block evaluate returns an error we are going to ignore it as
+            // there is nothing we can do for a device we are getting errors with.
+            #[cfg(not(feature = "dbus_enabled"))]
+            let _ = engine.borrow_mut().block_evaluate(device, devnode);
+
+            #[cfg(feature = "dbus_enabled")]
+            {
+                let mut eng_ref = engine.borrow_mut();
+                let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
+
+                if let Some(ref mut handle) = dbus_handle {
+                    if let Some(pool_uuid) = pool_uuid {
+                        let pool = eng_ref
+                            .get_mut_pool(pool_uuid)
+                            .expect("block_evaluate() returned a pool UUID, pool must be available")
+                            .1;
+
+                        if let Err(e) = libstratis::dbus_api::register_pool(
+                            &handle.connection.borrow(),
+                            &handle.context,
+                            &mut handle.tree,
+                            pool_uuid,
+                            pool,
+                            &handle.path,
+                        ) {
+                            error!(
+                                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                                pool_uuid, pool, handle.path, e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -434,42 +480,8 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_events.socket.receive_event() {
-                if let Some((device, devnode)) = handle_udev_event(&event) {
-                    // If block evaluate returns an error we are going to ignore it as
-                    // there is nothing we can do for a device we are getting errors with.
-                    #[cfg(not(feature = "dbus_enabled"))]
-                    let _ = engine.borrow_mut().block_evaluate(device, devnode);
-
-                    #[cfg(feature = "dbus_enabled")]
-                    {
-                        let mut eng_ref = engine.borrow_mut();
-                        let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
-
-                        if let Some(ref mut handle) = dbus_handle {
-                            if let Some(pool_uuid) = pool_uuid {
-                                let pool = eng_ref
-                                        .get_mut_pool(pool_uuid)
-                                        .expect(
-                                            "block_evaluate() returned a pool UUID, pool must be available",
-                                        )
-                                        .1;
-
-                                if let Err(e) = libstratis::dbus_api::register_pool(
-                                    &handle.connection.borrow(),
-                                    &handle.context,
-                                    &mut handle.tree,
-                                    pool_uuid,
-                                    pool,
-                                    &handle.path,
-                                ) {
-                                    error!("libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                                            pool_uuid, pool, handle.path, e);
-                                }
-                            }
-                        }
-                    }
-                }
+            if let Err(e) = process_udev_event(&mut udev_events, &mut dbus_handle, &engine) {
+                error!("process_udev_event: {:?}", e);
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -110,25 +110,6 @@ fn initialize_log(debug: bool) -> buff_log::Handle<env_logger::Logger> {
     }
 }
 
-/// Given a udev event, if it's one of interest and the block device is a stratis device, return
-/// the pool UUID for it.
-fn handle_udev_event(event: &libudev::Event, engine: &Rc<RefCell<Engine>>) -> Option<Uuid> {
-    if event.event_type() == libudev::EventType::Add
-        || event.event_type() == libudev::EventType::Change
-    {
-        let device = event.device();
-        return device.devnode().and_then(|devnode| {
-            device.devnum().and_then(|devnum| {
-                engine
-                    .borrow_mut()
-                    .block_evaluate(Device::from(devnum), PathBuf::from(devnode))
-                    .unwrap_or(None)
-            })
-        });
-    }
-    None
-}
-
 /// To ensure only one instance of stratisd runs at a time, acquire an
 /// exclusive lock. Return an error if lock attempt fails.
 fn trylock_pid_file() -> StratisResult<File> {
@@ -428,8 +409,36 @@ impl<'a> UdevMonitor<'a> {
         self.socket.as_raw_fd()
     }
 
-    fn receive_event(&mut self) -> Option<libudev::Event> {
-        self.socket.receive_event()
+    /// Given some udev events, see if any new pools are formed, and set up
+    /// dbus if so.
+    fn handle_events(
+        &mut self,
+        engine: &Rc<RefCell<Engine>>,
+        dbus_support: &mut MaybeDbusSupport,
+    ) -> StratisResult<()> {
+        while let Some(event) = self.socket.receive_event() {
+            if event.event_type() == libudev::EventType::Add
+                || event.event_type() == libudev::EventType::Change
+            {
+                let device = event.device();
+                let new_pool_uuid = device.devnode().and_then(|devnode| {
+                    device.devnum().and_then(|devnum| {
+                        engine
+                            .borrow_mut()
+                            .block_evaluate(Device::from(devnum), PathBuf::from(devnode))
+                            .unwrap_or(None)
+                    })
+                });
+                if let Some(pool_uuid) = new_pool_uuid {
+                    let mut eng_ref = engine.borrow_mut();
+                    let (_, pool) = eng_ref
+                        .get_mut_pool(pool_uuid)
+                        .expect("block_evaluate() returned a pool UUID, pool must be available");
+                    dbus_support.register_pool(pool_uuid, pool)?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -604,16 +613,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_monitor.receive_event() {
-                if let Some(pool_uuid) = handle_udev_event(&event, &engine) {
-                    let mut eng_ref = engine.borrow_mut();
-                    let (_, pool) = eng_ref
-                        .get_mut_pool(pool_uuid)
-                        .expect("block_evaluate() returned a pool UUID, pool must be available");
-
-                    dbus_support.register_pool(pool_uuid, pool)?;
-                }
-            }
+            udev_monitor.handle_events(&engine, &mut dbus_support)?;
         }
 
         // Process any signals off of signalfd

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -208,15 +208,15 @@ fn register_pool_dbus(
 }
 
 /// Returned data from when you connect a stratis engine to dbus.
-pub struct DbusConnectionData<'a> {
+pub struct DbusConnectionData {
     pub connection: Rc<RefCell<Connection>>,
     pub tree: Tree<MTFn<TData>, TData>,
-    pub path: dbus::Path<'a>,
+    pub path: dbus::Path<'static>,
     pub context: DbusContext,
 }
 
 /// Connect a stratis engine to dbus.
-pub fn connect<'a>(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData<'a>, dbus::Error> {
+pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
     let c = Connection::get_private(BusType::System)?;
     let (tree, object_path) = get_base_tree(DbusContext::new(engine));
     let dbus_context = tree.get_data().clone();

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -236,21 +236,31 @@ impl DbusConnectionData {
     }
 
     /// Given the UUID of a pool, register all the pertinent information with dbus.
-    pub fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) -> Result<(), dbus::Error> {
+    pub fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) {
         register_pool_dbus(&self.context, pool_uuid, pool, &self.path);
         self.process_deferred_actions()
     }
 
     /// Update the dbus tree with deferred adds and removes.
-    fn process_deferred_actions(&mut self) -> Result<(), dbus::Error> {
+    fn process_deferred_actions(&mut self) {
         let mut actions = self.context.actions.borrow_mut();
         for action in actions.drain() {
             match action {
                 DeferredAction::Add(path) => {
-                    self.connection
+                    match self
+                        .connection
                         .borrow_mut()
-                        .register_object_path(path.get_name())?;
-                    self.tree.insert(path);
+                        .register_object_path(path.get_name())
+                    {
+                        Err(err) => error!(
+                            "Could not register object path {}, should never happen: {}",
+                            path.get_name(),
+                            err
+                        ),
+                        Ok(_) => {
+                            self.tree.insert(path);
+                        }
+                    }
                 }
                 DeferredAction::Remove(path) => {
                     self.connection.borrow_mut().unregister_object_path(&path);
@@ -258,7 +268,6 @@ impl DbusConnectionData {
                 }
             }
         }
-        Ok(())
     }
 
     /// Handle any client dbus requests
@@ -280,13 +289,7 @@ impl DbusConnectionData {
                         }
                     }
 
-                    if let Err(e) = self.process_deferred_actions() {
-                        // There are 2 functions to handle each of these lines in stratisd
-                        // (print_err, log_engine_state) we should relocate them to a library
-                        // if needed in both places
-                        debug!("Engine state: \n{:#?}", &*self.context.engine.borrow());
-                        error!("Client dbus handle: {}", e);
-                    }
+                    self.process_deferred_actions();
                 }
             }
         }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -22,7 +22,7 @@ use super::blockdev::create_dbus_blockdev;
 use super::consts;
 use super::filesystem::create_dbus_filesystem;
 use super::pool::create_dbus_pool;
-use super::types::{ActionQueue, DbusContext, DbusErrorEnum, DeferredAction, TData};
+use super::types::{DbusContext, DbusErrorEnum, DeferredAction, TData};
 use super::util::{
     engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
 };
@@ -215,75 +215,79 @@ pub struct DbusConnectionData {
     pub context: DbusContext,
 }
 
-/// Connect a stratis engine to dbus.
-pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
-    let c = Connection::get_private(BusType::System)?;
-    let (tree, object_path) = get_base_tree(DbusContext::new(engine));
-    let dbus_context = tree.get_data().clone();
-    tree.set_registered(&c, true)?;
-    c.register_name(
-        consts::STRATIS_BASE_SERVICE,
-        NameFlag::ReplaceExisting as u32,
-    )?;
-    Ok(DbusConnectionData {
-        connection: Rc::new(RefCell::new(c)),
-        tree,
-        path: object_path,
-        context: dbus_context,
-    })
-}
+impl DbusConnectionData {
+    /// Connect a stratis engine to dbus.
+    pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
+        let c = Connection::get_private(BusType::System)?;
+        let (tree, object_path) = get_base_tree(DbusContext::new(engine));
+        let dbus_context = tree.get_data().clone();
+        tree.set_registered(&c, true)?;
+        c.register_name(
+            consts::STRATIS_BASE_SERVICE,
+            NameFlag::ReplaceExisting as u32,
+        )?;
+        Ok(DbusConnectionData {
+            connection: Rc::new(RefCell::new(c)),
+            tree,
+            path: object_path,
+            context: dbus_context,
+        })
+    }
 
-/// Given the UUID of a pool, register all the pertinent information with dbus.
-pub fn register_pool(
-    c: &Connection,
-    dbus_context: &DbusContext,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    pool_uuid: Uuid,
-    pool: &mut Pool,
-    object_path: &dbus::Path<'static>,
-) -> Result<(), dbus::Error> {
-    register_pool_dbus(dbus_context, pool_uuid, pool, object_path);
-    process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut())
-}
+    /// Given the UUID of a pool, register all the pertinent information with dbus.
+    pub fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) -> Result<(), dbus::Error> {
+        register_pool_dbus(&self.context, pool_uuid, pool, &self.path);
+        self.process_deferred_actions()
+    }
 
-/// Update the dbus tree with deferred adds and removes.
-fn process_deferred_actions(
-    c: &Connection,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    actions: &mut ActionQueue,
-) -> Result<(), dbus::Error> {
-    for action in actions.drain() {
-        match action {
-            DeferredAction::Add(path) => {
-                c.register_object_path(path.get_name())?;
-                tree.insert(path);
+    /// Update the dbus tree with deferred adds and removes.
+    fn process_deferred_actions(&mut self) -> Result<(), dbus::Error> {
+        let mut actions = self.context.actions.borrow_mut();
+        for action in actions.drain() {
+            match action {
+                DeferredAction::Add(path) => {
+                    self.connection
+                        .borrow_mut()
+                        .register_object_path(path.get_name())?;
+                    self.tree.insert(path);
+                }
+                DeferredAction::Remove(path) => {
+                    self.connection.borrow_mut().unregister_object_path(&path);
+                    self.tree.remove(&path);
+                }
             }
-            DeferredAction::Remove(path) => {
-                c.unregister_object_path(&path);
-                tree.remove(&path);
+        }
+        Ok(())
+    }
+
+    /// Handle any client dbus requests
+    pub fn handle(&mut self, fds: &[libc::pollfd]) -> () {
+        for pfd in fds.iter().filter(|pfd| pfd.revents != 0) {
+            let items: Vec<ConnectionItem> = self
+                .connection
+                .borrow()
+                .watch_handle(pfd.fd, dbus::WatchEvent::from_revents(pfd.revents))
+                .collect();
+
+            for item in items {
+                if let ConnectionItem::MethodCall(ref msg) = item {
+                    if let Some(v) = self.tree.handle(msg) {
+                        // Probably the wisest is to ignore any send errors here -
+                        // maybe the remote has disconnected during our processing.
+                        for m in v {
+                            let _ = self.connection.borrow_mut().send(m);
+                        }
+                    }
+
+                    if let Err(e) = self.process_deferred_actions() {
+                        // There are 2 functions to handle each of these lines in stratisd
+                        // (print_err, log_engine_state) we should relocate them to a library
+                        // if needed in both places
+                        debug!("Engine state: \n{:#?}", &*self.context.engine.borrow());
+                        error!("Client dbus handle: {}", e);
+                    }
+                }
             }
         }
     }
-    Ok(())
-}
-
-pub fn handle(
-    c: &Connection,
-    item: &ConnectionItem,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    dbus_context: &DbusContext,
-) -> Result<(), dbus::Error> {
-    if let ConnectionItem::MethodCall(ref msg) = *item {
-        if let Some(v) = tree.handle(msg) {
-            // Probably the wisest is to ignore any send errors here -
-            // maybe the remote has disconnected during our processing.
-            for m in v {
-                let _ = c.send(m);
-            }
-        }
-
-        process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut())?;
-    }
-
-    Ok(())
 }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -13,6 +13,7 @@ use dbus::tree::{
     Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo, Tree,
 };
 use dbus::{BusType, Connection, ConnectionItem, Message, NameFlag};
+use libc;
 use uuid::Uuid;
 
 use super::super::engine::{Engine, Pool, PoolUuid};

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -247,20 +247,11 @@ impl DbusConnectionData {
         for action in actions.drain() {
             match action {
                 DeferredAction::Add(path) => {
-                    match self
-                        .connection
+                    self.connection
                         .borrow_mut()
                         .register_object_path(path.get_name())
-                    {
-                        Err(err) => error!(
-                            "Could not register object path {}, should never happen: {}",
-                            path.get_name(),
-                            err
-                        ),
-                        Ok(_) => {
-                            self.tree.insert(path);
-                        }
-                    }
+                        .expect("Must succeed since object paths are unique");
+                    self.tree.insert(path);
                 }
                 DeferredAction::Remove(path) => {
                     self.connection.borrow_mut().unregister_object_path(&path);

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -13,5 +13,5 @@ mod pool;
 mod types;
 mod util;
 
-pub use self::api::{connect, handle, register_pool, DbusConnectionData};
+pub use self::api::DbusConnectionData;
 pub use self::util::prop_changed_dispatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate uuid;
 #[cfg(feature = "dbus_enabled")]
 extern crate dbus;
 
+extern crate libc;
 extern crate libmount;
 extern crate rand;
 extern crate serde;


### PR DESCRIPTION
This turned out to be more involved than I had planned, especially with the need to build without dbus support.  This will need to be rebased and squashed, but I wanted to preserve the history of how I got to where it is.

This also fixes a clippy error for the complexity of `run`.