### PR TITLE
Revert "Revert "Temporarily allow a Travis failure""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ addons:
 language: rust
 
 matrix:
+    allow_failures:
+        # Temporarily allow failure until Travis bug is fixed.
+        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         # Verify formatting of Rust code
         - rust: stable


### PR DESCRIPTION
This reverts commit b13158f41a9491b1b53969ab909802f915a75606.

Because it is failing again.