### PR TITLE
Tasleson 1343

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -18,6 +18,7 @@ extern crate libc;
 extern crate libudev;
 extern crate nix;
 extern crate timerfd;
+extern crate uuid;
 
 use std::cell::RefCell;
 use std::env;
@@ -38,6 +39,7 @@ use nix::sys::signal::{self, SigSet};
 use nix::sys::signalfd::{SfdFlags, SignalFd};
 use nix::unistd::getpid;
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
+use uuid::Uuid;
 
 #[cfg(feature = "dbus_enabled")]
 use dbus::{Connection, WatchEvent};
@@ -52,6 +54,9 @@ use libstratis::engine::{
 use libstratis::engine::{Engine, SimEngine, StratEngine};
 use libstratis::stratis::buff_log;
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
+
+#[cfg(feature = "dbus_enabled")]
+use libstratis::engine::Pool;
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
 
@@ -108,17 +113,20 @@ fn initialize_log(debug: bool) -> buff_log::Handle<env_logger::Logger> {
     }
 }
 
-/// Given a udev event check to see if it's an add or change and if it is return the device node
-/// and devicemapper::Device.
-fn handle_udev_event(event: &libudev::Event) -> Option<(Device, PathBuf)> {
+/// Given a udev event, if it's one of interest and the block device is a stratis device, return
+/// the pool UUID for it.
+fn handle_udev_event(event: &libudev::Event, engine: &Rc<RefCell<Engine>>) -> Option<Uuid> {
     if event.event_type() == libudev::EventType::Add
         || event.event_type() == libudev::EventType::Change
     {
         let device = event.device();
         return device.devnode().and_then(|devnode| {
-            device
-                .devnum()
-                .and_then(|devnum| Some((Device::from(devnum), PathBuf::from(devnode))))
+            device.devnum().and_then(|devnum| {
+                engine
+                    .borrow_mut()
+                    .block_evaluate(Device::from(devnum), PathBuf::from(devnode))
+                    .unwrap_or(None)
+            })
         });
     }
     None
@@ -300,52 +308,6 @@ impl<'a> UdevMonitor<'a> {
     }
 }
 
-/// Process the udev event by bringing up pools if possible and registering them with dbus api.
-fn process_udev_event(
-    udev_events: &mut UdevMonitor,
-    dbus_handle: &mut Option<libstratis::dbus_api::DbusConnectionData>,
-    engine: &Rc<RefCell<Engine>>,
-) -> StratisResult<()> {
-    while let Some(event) = udev_events.socket.receive_event() {
-        if let Some((device, devnode)) = handle_udev_event(&event) {
-            // If block evaluate returns an error we are going to ignore it as
-            // there is nothing we can do for a device we are getting errors with.
-            #[cfg(not(feature = "dbus_enabled"))]
-            let _ = engine.borrow_mut().block_evaluate(device, devnode);
-
-            #[cfg(feature = "dbus_enabled")]
-            {
-                let mut eng_ref = engine.borrow_mut();
-                let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
-
-                if let Some(ref mut handle) = dbus_handle {
-                    if let Some(pool_uuid) = pool_uuid {
-                        let pool = eng_ref
-                            .get_mut_pool(pool_uuid)
-                            .expect("block_evaluate() returned a pool UUID, pool must be available")
-                            .1;
-
-                        if let Err(e) = libstratis::dbus_api::register_pool(
-                            &handle.connection.borrow(),
-                            &handle.context,
-                            &mut handle.tree,
-                            pool_uuid,
-                            pool,
-                            &handle.path,
-                        ) {
-                            error!(
-                                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                                pool_uuid, pool, handle.path, e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 // Process any pending signals, return true if we should exit.
 fn process_signal(
     sfd: &mut SignalFd,
@@ -363,11 +325,11 @@ fn process_signal(
                     buff_log.buffered_count()
                 );
                 buff_log.dump();
-                return Ok(false);
+                Ok(false)
             }
             nix::libc::SIGINT => {
                 info!("SIGINT received, exiting");
-                return Ok(true);
+                Ok(true)
             }
             signo => {
                 panic!("Caught an impossible signal {:?}", signo);
@@ -377,11 +339,12 @@ fn process_signal(
         Ok(None) => Ok(false),
 
         // Pessimistically exit on an error reading the signal.
-        Err(err) => return Err(err.into()),
+        Err(err) => Err(err.into()),
     }
 }
 
 /// Handle any client dbus requests.
+#[cfg(feature = "dbus_enabled")]
 fn process_dbus(
     handle: &mut libstratis::dbus_api::DbusConnectionData,
     engine: &Rc<RefCell<Engine>>,
@@ -424,8 +387,33 @@ fn process_dbus(
     Ok(())
 }
 
+/// Handle registering the pool with the dbus library.  Wondering why the actual register_pool
+/// isn't implements with methods on the DbusConnectionData structure???
+#[cfg(feature = "dbus_enabled")]
+fn dbus_register_pool(
+    handle: &mut libstratis::dbus_api::DbusConnectionData,
+    pool_uuid: Uuid,
+    pool: &mut Pool,
+) -> StratisResult<()> {
+    if let Err(e) = libstratis::dbus_api::register_pool(
+        &handle.connection.borrow(),
+        &handle.context,
+        &mut handle.tree,
+        pool_uuid,
+        pool,
+        &handle.path,
+    ) {
+        error!(
+            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+            pool_uuid, pool, handle.path, e
+        );
+    }
+    Ok(())
+}
+
 /// Iterate through all the pools and register them with the dbus interface and update the vector
 /// of file poll file descriptors.
+#[cfg(feature = "dbus_enabled")]
 fn initialize_dbus(
     handle: &mut libstratis::dbus_api::DbusConnectionData,
     engine: &Rc<RefCell<Engine>>,
@@ -436,19 +424,7 @@ fn initialize_dbus(
     get_engine_listener_list_mut().register_listener(event_handler);
     // Register all the pools with dbus
     for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-        if let Err(e) = libstratis::dbus_api::register_pool(
-            &handle.connection.borrow(),
-            &handle.context,
-            &mut handle.tree,
-            pool_uuid,
-            pool,
-            &handle.path,
-        ) {
-            error!(
-                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                pool_uuid, pool, handle.path, e
-            );
-        }
+        dbus_register_pool(handle, pool_uuid, pool)?;
     }
 
     // Add dbus FD to fds as dbus is now available.
@@ -601,8 +577,23 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            if let Err(e) = process_udev_event(&mut udev_events, &mut dbus_handle, &engine) {
-                error!("process_udev_event: {:?}", e);
+            while let Some(event) = udev_events.socket.receive_event() {
+                if let Some(_pool_uuid) = handle_udev_event(&event, &engine) {
+                    #[cfg(feature = "dbus_enabled")]
+                    {
+                        let mut eng_ref = engine.borrow_mut();
+                        if let Some(ref mut handle) = dbus_handle {
+                            let pool = eng_ref
+                                .get_mut_pool(_pool_uuid)
+                                .expect(
+                                    "block_evaluate() returned a pool UUID, pool must be available",
+                                )
+                                .1;
+
+                            dbus_register_pool(handle, _pool_uuid, pool)?;
+                        }
+                    }
+                }
             }
         }
 
@@ -639,12 +630,9 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         {
             if let Some(ref mut handle) = dbus_handle {
                 process_dbus(handle, &engine, &mut fds, dbus_client_index_start)?;
-            } else {
-                // Try to establish dbus
-                if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
-                    initialize_dbus(&mut handle, &engine, &mut fds)?;
-                    dbus_handle = Some(handle);
-                }
+            } else if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
+                initialize_dbus(&mut handle, &engine, &mut fds)?;
+                dbus_handle = Some(handle);
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::process::exit;
 use std::rc::Rc;
@@ -303,6 +303,14 @@ impl<'a> UdevMonitor<'a> {
             socket: monitor.listen()?,
         })
     }
+
+    fn as_raw_fd(&mut self) -> RawFd {
+        self.socket.as_raw_fd()
+    }
+
+    fn receive_event(&mut self) -> Option<libudev::Event> {
+        self.socket.receive_event()
+    }
 }
 
 // Process any pending signals, return true if we should exit.
@@ -428,7 +436,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.
     let context = libudev::Context::new()?;
-    let mut udev_events = UdevMonitor::create(&context)?;
+    let mut udev_monitor = UdevMonitor::create(&context)?;
 
     let engine: Rc<RefCell<Engine>> = {
         if matches.is_present("sim") {
@@ -470,7 +478,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut fds = Vec::new();
 
     fds.push(libc::pollfd {
-        fd: udev_events.socket.as_raw_fd(),
+        fd: udev_monitor.as_raw_fd(),
         revents: 0,
         events: libc::POLLIN,
     });
@@ -530,7 +538,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_events.socket.receive_event() {
+            while let Some(event) = udev_monitor.receive_event() {
                 if let Some(_pool_uuid) = handle_udev_event(&event, &engine) {
                     #[cfg(feature = "dbus_enabled")]
                     {

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -463,6 +463,23 @@ fn initialize_dbus(
     Ok(())
 }
 
+/// Handle blocking the event loop
+fn process_poll(poll_timeout: i32, fds: &mut Vec<libc::pollfd>) -> StratisResult<()> {
+    let r = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, poll_timeout) };
+
+    // TODO: refine this behavior.
+    // Different behaviors may be indicated, depending on the value of
+    // errno when return value is -1.
+    if r < 0 {
+        return Err(StratisError::Error(format!(
+            "poll command failed: number of fds: {}, timeout: {}",
+            fds.len(),
+            poll_timeout
+        )));
+    }
+    Ok(())
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -638,19 +655,8 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         // Default timeout is infinite
         #[cfg(not(feature = "dbus_enabled"))]
         let poll_timeout = -1;
-
-        let r = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, poll_timeout) };
-
-        // TODO: refine this behavior.
-        // Different behaviors may be indicated, depending on the value of
-        // errno when return value is -1.
-        if r < 0 {
-            return Err(StratisError::Error(format!(
-                "poll command failed: number of fds: {}, timeout: {}",
-                fds.len(),
-                poll_timeout
-            )));
-        }
+        // Block until we have something to handle
+        process_poll(poll_timeout, &mut fds)?;
     }
 }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -285,6 +285,21 @@ impl EngineListener for EventHandler {
     }
 }
 
+struct UdevMonitor<'a> {
+    socket: libudev::MonitorSocket<'a>,
+}
+
+impl<'a> UdevMonitor<'a> {
+    fn create(context: &'a libudev::Context) -> StratisResult<UdevMonitor<'a>> {
+        let mut monitor = libudev::Monitor::new(&context)?;
+        monitor.match_subsystem_devtype("block", "disk")?;
+
+        Ok(UdevMonitor {
+            socket: monitor.listen()?,
+        })
+    }
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -304,9 +319,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.
     let context = libudev::Context::new()?;
-    let mut monitor = libudev::Monitor::new(&context)?;
-    monitor.match_subsystem_devtype("block", "disk")?;
-    let mut udev = monitor.listen()?;
+    let mut udev_events = UdevMonitor::create(&context)?;
 
     let engine: Rc<RefCell<Engine>> = {
         if matches.is_present("sim") {
@@ -348,7 +361,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut fds = Vec::new();
 
     fds.push(libc::pollfd {
-        fd: udev.as_raw_fd(),
+        fd: udev_events.socket.as_raw_fd(),
         revents: 0,
         events: libc::POLLIN,
     });
@@ -408,7 +421,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev.receive_event() {
+            while let Some(event) = udev_events.socket.receive_event() {
                 if let Some((device, devnode)) = handle_udev_event(&event) {
                     // If block evaluate returns an error we are going to ignore it as
                     // there is nothing we can do for a device we are getting errors with.

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -381,6 +381,88 @@ fn process_signal(
     }
 }
 
+/// Handle any client dbus requests.
+fn process_dbus(
+    handle: &mut libstratis::dbus_api::DbusConnectionData,
+    engine: &Rc<RefCell<Engine>>,
+    fds: &mut Vec<libc::pollfd>,
+    dbus_client_index_start: usize,
+) -> StratisResult<()> {
+    for pfd in fds[dbus_client_index_start..]
+        .iter()
+        .filter(|pfd| pfd.revents != 0)
+    {
+        for item in handle
+            .connection
+            .borrow()
+            .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
+        {
+            if let Err(r) = libstratis::dbus_api::handle(
+                &handle.connection.borrow(),
+                &item,
+                &mut handle.tree,
+                &handle.context,
+            ) {
+                log_engine_state(&*engine.borrow());
+                print_err(&From::from(r));
+            }
+        }
+    }
+
+    // Refresh list of dbus fds to poll for. This can change as
+    // D-Bus clients come and go.
+    fds.truncate(dbus_client_index_start);
+    fds.extend(
+        handle
+            .connection
+            .borrow()
+            .watch_fds()
+            .iter()
+            .map(|w| w.to_pollfd()),
+    );
+
+    Ok(())
+}
+
+/// Iterate through all the pools and register them with the dbus interface and update the vector
+/// of file poll file descriptors.
+fn initialize_dbus(
+    handle: &mut libstratis::dbus_api::DbusConnectionData,
+    engine: &Rc<RefCell<Engine>>,
+    fds: &mut Vec<libc::pollfd>,
+) -> StratisResult<()> {
+    info!("DBUS API is now available");
+    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
+    get_engine_listener_list_mut().register_listener(event_handler);
+    // Register all the pools with dbus
+    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
+        if let Err(e) = libstratis::dbus_api::register_pool(
+            &handle.connection.borrow(),
+            &handle.context,
+            &mut handle.tree,
+            pool_uuid,
+            pool,
+            &handle.path,
+        ) {
+            error!(
+                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                pool_uuid, pool, handle.path, e
+            );
+        }
+    }
+
+    // Add dbus FD to fds as dbus is now available.
+    fds.extend(
+        handle
+            .connection
+            .borrow()
+            .watch_fds()
+            .iter()
+            .map(|w| w.to_pollfd()),
+    );
+    Ok(())
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -539,69 +621,13 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         #[cfg(feature = "dbus_enabled")]
         {
             if let Some(ref mut handle) = dbus_handle {
-                for pfd in fds[dbus_client_index_start..]
-                    .iter()
-                    .filter(|pfd| pfd.revents != 0)
-                {
-                    for item in handle
-                        .connection
-                        .borrow()
-                        .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
-                    {
-                        if let Err(r) = libstratis::dbus_api::handle(
-                            &handle.connection.borrow(),
-                            &item,
-                            &mut handle.tree,
-                            &handle.context,
-                        ) {
-                            log_engine_state(&*engine.borrow());
-                            print_err(&From::from(r));
-                        }
-                    }
+                process_dbus(handle, &engine, &mut fds, dbus_client_index_start)?;
+            } else {
+                // Try to establish dbus
+                if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
+                    initialize_dbus(&mut handle, &engine, &mut fds)?;
+                    dbus_handle = Some(handle);
                 }
-
-                // Refresh list of dbus fds to poll for. This can change as
-                // D-Bus clients come and go.
-                fds.truncate(dbus_client_index_start);
-                fds.extend(
-                    handle
-                        .connection
-                        .borrow()
-                        .watch_fds()
-                        .iter()
-                        .map(|w| w.to_pollfd()),
-                );
-            } else if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
-                info!("DBUS API is now available");
-                let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
-                get_engine_listener_list_mut().register_listener(event_handler);
-                // Register all the pools with dbus
-                for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-                    if let Err(e) = libstratis::dbus_api::register_pool(
-                        &handle.connection.borrow(),
-                        &handle.context,
-                        &mut handle.tree,
-                        pool_uuid,
-                        pool,
-                        &handle.path,
-                    ) {
-                        error!(
-                            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                            pool_uuid, pool, handle.path, e
-                        );
-                    }
-                }
-
-                // Add dbus FD to fds as dbus is now available.
-                fds.extend(
-                    handle
-                        .connection
-                        .borrow()
-                        .watch_fds()
-                        .iter()
-                        .map(|w| w.to_pollfd()),
-                );
-                dbus_handle = Some(handle);
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -299,7 +299,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut dbus_handle: Option<libstratis::dbus_api::DbusConnectionData> = None;
 
     // Setup a udev listener before initializing the engine. A device may
-    // appear after the engine has read the /dev directory but before it has
+    // appear after the engine has processed the udev db, but before it has
     // completed initialization. Unless the udev event has been recorded, the
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -300,6 +300,52 @@ impl<'a> UdevMonitor<'a> {
     }
 }
 
+/// Process the udev event by bringing up pools if possible and registering them with dbus api.
+fn process_udev_event(
+    udev_events: &mut UdevMonitor,
+    dbus_handle: &mut Option<libstratis::dbus_api::DbusConnectionData>,
+    engine: &Rc<RefCell<Engine>>,
+) -> StratisResult<()> {
+    while let Some(event) = udev_events.socket.receive_event() {
+        if let Some((device, devnode)) = handle_udev_event(&event) {
+            // If block evaluate returns an error we are going to ignore it as
+            // there is nothing we can do for a device we are getting errors with.
+            #[cfg(not(feature = "dbus_enabled"))]
+            let _ = engine.borrow_mut().block_evaluate(device, devnode);
+
+            #[cfg(feature = "dbus_enabled")]
+            {
+                let mut eng_ref = engine.borrow_mut();
+                let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
+
+                if let Some(ref mut handle) = dbus_handle {
+                    if let Some(pool_uuid) = pool_uuid {
+                        let pool = eng_ref
+                            .get_mut_pool(pool_uuid)
+                            .expect("block_evaluate() returned a pool UUID, pool must be available")
+                            .1;
+
+                        if let Err(e) = libstratis::dbus_api::register_pool(
+                            &handle.connection.borrow(),
+                            &handle.context,
+                            &mut handle.tree,
+                            pool_uuid,
+                            pool,
+                            &handle.path,
+                        ) {
+                            error!(
+                                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                                pool_uuid, pool, handle.path, e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -421,42 +467,8 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_events.socket.receive_event() {
-                if let Some((device, devnode)) = handle_udev_event(&event) {
-                    // If block evaluate returns an error we are going to ignore it as
-                    // there is nothing we can do for a device we are getting errors with.
-                    #[cfg(not(feature = "dbus_enabled"))]
-                    let _ = engine.borrow_mut().block_evaluate(device, devnode);
-
-                    #[cfg(feature = "dbus_enabled")]
-                    {
-                        let mut eng_ref = engine.borrow_mut();
-                        let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
-
-                        if let Some(ref mut handle) = dbus_handle {
-                            if let Some(pool_uuid) = pool_uuid {
-                                let pool = eng_ref
-                                        .get_mut_pool(pool_uuid)
-                                        .expect(
-                                            "block_evaluate() returned a pool UUID, pool must be available",
-                                        )
-                                        .1;
-
-                                if let Err(e) = libstratis::dbus_api::register_pool(
-                                    &handle.connection.borrow(),
-                                    &handle.context,
-                                    &mut handle.tree,
-                                    pool_uuid,
-                                    pool,
-                                    &handle.path,
-                                ) {
-                                    error!("libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                                            pool_uuid, pool, handle.path, e);
-                                }
-                            }
-                        }
-                    }
-                }
+            if let Err(e) = process_udev_event(&mut udev_events, &mut dbus_handle, &engine) {
+                error!("process_udev_event: {:?}", e);
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -417,27 +417,29 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
 
                     #[cfg(feature = "dbus_enabled")]
                     {
-                        let pool_uuid = engine
-                            .borrow_mut()
-                            .block_evaluate(device, devnode)
-                            .unwrap_or(None);
+                        let mut eng_ref = engine.borrow_mut();
+                        let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
 
                         if let Some(ref mut handle) = dbus_handle {
                             if let Some(pool_uuid) = pool_uuid {
-                                libstratis::dbus_api::register_pool(
-                                    &handle.connection.borrow(),
-                                    &handle.context,
-                                    &mut handle.tree,
-                                    pool_uuid,
-                                    engine
-                                        .borrow_mut()
+                                let pool = eng_ref
                                         .get_mut_pool(pool_uuid)
                                         .expect(
                                             "block_evaluate() returned a pool UUID, pool must be available",
                                         )
-                                        .1,
+                                        .1;
+
+                                if let Err(e) = libstratis::dbus_api::register_pool(
+                                    &handle.connection.borrow(),
+                                    &handle.context,
+                                    &mut handle.tree,
+                                    pool_uuid,
+                                    pool,
                                     &handle.path,
-                                )?;
+                                ) {
+                                    error!("libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                                            pool_uuid, pool, handle.path, e);
+                                }
                             }
                         }
                     }
@@ -534,14 +536,19 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                 get_engine_listener_list_mut().register_listener(event_handler);
                 // Register all the pools with dbus
                 for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-                    libstratis::dbus_api::register_pool(
+                    if let Err(e) = libstratis::dbus_api::register_pool(
                         &handle.connection.borrow(),
                         &handle.context,
                         &mut handle.tree,
                         pool_uuid,
                         pool,
                         &handle.path,
-                    )?;
+                    ) {
+                        error!(
+                            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                            pool_uuid, pool, handle.path, e
+                        );
+                    }
                 }
 
                 // Add dbus FD to fds as dbus is now available.

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -346,6 +346,41 @@ fn process_udev_event(
     Ok(())
 }
 
+// Process any pending signals, return true if we should exit.
+fn process_signal(
+    sfd: &mut SignalFd,
+    buff_log: &buff_log::Handle<env_logger::Logger>,
+) -> StratisResult<bool> {
+    match sfd.read_signal() {
+        // This is an unsafe conversion, but in this context that is
+        // mostly harmless. A negative converted value, which is
+        // virtually impossible, will not match any of the masked
+        // values, and stratisd will panic and exit.
+        Ok(Some(sig)) => match sig.ssi_signo as i32 {
+            nix::libc::SIGUSR1 => {
+                info!(
+                    "SIGUSR1 received, dumping {} buffered log entries",
+                    buff_log.buffered_count()
+                );
+                buff_log.dump();
+                return Ok(false);
+            }
+            nix::libc::SIGINT => {
+                info!("SIGINT received, exiting");
+                return Ok(true);
+            }
+            signo => {
+                panic!("Caught an impossible signal {:?}", signo);
+            }
+        },
+        // No signals waiting (SFD_NONBLOCK flag is set)
+        Ok(None) => Ok(false),
+
+        // Pessimistically exit on an error reading the signal.
+        Err(err) => return Err(err.into()),
+    }
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -472,34 +507,15 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
             }
         }
 
-        // Process any signals off signalfd
+        // Process any signals off of signalfd
         if fds[FD_INDEX_SIGNALFD].revents != 0 {
-            match sfd.read_signal() {
-                // This is an unsafe conversion, but in this context that is
-                // mostly harmless. A negative converted value, which is
-                // virtually impossible, will not match any of the masked
-                // values, and stratisd will panic and exit.
-                Ok(Some(sig)) => match sig.ssi_signo as i32 {
-                    nix::libc::SIGUSR1 => {
-                        info!(
-                            "SIGUSR1 received, dumping {} buffered log entries",
-                            buff_log.buffered_count()
-                        );
-                        buff_log.dump()
-                    }
-                    nix::libc::SIGINT => {
-                        info!("SIGINT received, exiting");
+            match process_signal(&mut sfd, &buff_log) {
+                Ok(should_exit) => {
+                    if should_exit {
                         return Ok(());
                     }
-                    signo => {
-                        panic!("Caught an impossible signal {:?}", signo);
-                    }
-                },
-                // No signals waiting (SFD_NONBLOCK flag is set)
-                Ok(None) => (),
-
-                // Pessimistically exit on an error reading the signal.
-                Err(err) => return Err(err.into()),
+                }
+                Err(e) => error!("process_signal: {:?}", e),
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -42,7 +42,7 @@ use timerfd::{SetTimeFlags, TimerFd, TimerState};
 use uuid::Uuid;
 
 #[cfg(feature = "dbus_enabled")]
-use dbus::{Connection, WatchEvent};
+use dbus::Connection;
 
 use devicemapper::Device;
 #[cfg(feature = "dbus_enabled")]
@@ -54,9 +54,6 @@ use libstratis::engine::{
 use libstratis::engine::{Engine, SimEngine, StratEngine};
 use libstratis::stratis::buff_log;
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
-
-#[cfg(feature = "dbus_enabled")]
-use libstratis::engine::Pool;
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
 
@@ -347,30 +344,10 @@ fn process_signal(
 #[cfg(feature = "dbus_enabled")]
 fn process_dbus(
     handle: &mut libstratis::dbus_api::DbusConnectionData,
-    engine: &Rc<RefCell<Engine>>,
     fds: &mut Vec<libc::pollfd>,
     dbus_client_index_start: usize,
 ) -> StratisResult<()> {
-    for pfd in fds[dbus_client_index_start..]
-        .iter()
-        .filter(|pfd| pfd.revents != 0)
-    {
-        for item in handle
-            .connection
-            .borrow()
-            .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
-        {
-            if let Err(r) = libstratis::dbus_api::handle(
-                &handle.connection.borrow(),
-                &item,
-                &mut handle.tree,
-                &handle.context,
-            ) {
-                log_engine_state(&*engine.borrow());
-                print_err(&From::from(r));
-            }
-        }
-    }
+    handle.handle(&fds[dbus_client_index_start..]);
 
     // Refresh list of dbus fds to poll for. This can change as
     // D-Bus clients come and go.
@@ -387,30 +364,6 @@ fn process_dbus(
     Ok(())
 }
 
-/// Handle registering the pool with the dbus library.  Wondering why the actual register_pool
-/// isn't implements with methods on the DbusConnectionData structure???
-#[cfg(feature = "dbus_enabled")]
-fn dbus_register_pool(
-    handle: &mut libstratis::dbus_api::DbusConnectionData,
-    pool_uuid: Uuid,
-    pool: &mut Pool,
-) -> StratisResult<()> {
-    if let Err(e) = libstratis::dbus_api::register_pool(
-        &handle.connection.borrow(),
-        &handle.context,
-        &mut handle.tree,
-        pool_uuid,
-        pool,
-        &handle.path,
-    ) {
-        error!(
-            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-            pool_uuid, pool, handle.path, e
-        );
-    }
-    Ok(())
-}
-
 /// Iterate through all the pools and register them with the dbus interface and update the vector
 /// of file poll file descriptors.
 #[cfg(feature = "dbus_enabled")]
@@ -424,7 +377,7 @@ fn initialize_dbus(
     get_engine_listener_list_mut().register_listener(event_handler);
     // Register all the pools with dbus
     for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-        dbus_register_pool(handle, pool_uuid, pool)?;
+        handle.register_pool(pool_uuid, pool)?;
     }
 
     // Add dbus FD to fds as dbus is now available.
@@ -590,7 +543,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                                 )
                                 .1;
 
-                            dbus_register_pool(handle, _pool_uuid, pool)?;
+                            handle.register_pool(_pool_uuid, pool)?;
                         }
                     }
                 }
@@ -629,8 +582,10 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         #[cfg(feature = "dbus_enabled")]
         {
             if let Some(ref mut handle) = dbus_handle {
-                process_dbus(handle, &engine, &mut fds, dbus_client_index_start)?;
-            } else if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
+                process_dbus(handle, &mut fds, dbus_client_index_start)?;
+            } else if let Ok(mut handle) =
+                libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(&engine))
+            {
                 initialize_dbus(&mut handle, &engine, &mut fds)?;
                 dbus_handle = Some(handle);
             }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -204,15 +204,15 @@ fn register_pool_dbus(
 }
 
 /// Returned data from when you connect a stratis engine to dbus.
-pub struct DbusConnectionData<'a> {
+pub struct DbusConnectionData {
     pub connection: Rc<RefCell<Connection>>,
     pub tree: Tree<MTFn<TData>, TData>,
-    pub path: dbus::Path<'a>,
+    pub path: dbus::Path<'static>,
     pub context: DbusContext,
 }
 
 /// Connect a stratis engine to dbus.
-pub fn connect<'a>(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData<'a>, dbus::Error> {
+pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
     let c = Connection::get_private(BusType::System)?;
     let (tree, object_path) = get_base_tree(DbusContext::new(engine));
     let dbus_context = tree.get_data().clone();

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -21,7 +21,7 @@ use super::super::stratis::VERSION;
 use super::blockdev::create_dbus_blockdev;
 use super::filesystem::create_dbus_filesystem;
 use super::pool::create_dbus_pool;
-use super::types::{ActionQueue, DbusContext, DbusErrorEnum, DeferredAction, TData};
+use super::types::{DbusContext, DbusErrorEnum, DeferredAction, TData};
 use super::util::{
     engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
     STRATIS_BASE_PATH, STRATIS_BASE_SERVICE,
@@ -211,72 +211,75 @@ pub struct DbusConnectionData {
     pub context: DbusContext,
 }
 
-/// Connect a stratis engine to dbus.
-pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
-    let c = Connection::get_private(BusType::System)?;
-    let (tree, object_path) = get_base_tree(DbusContext::new(engine));
-    let dbus_context = tree.get_data().clone();
-    tree.set_registered(&c, true)?;
-    c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32)?;
-    Ok(DbusConnectionData {
-        connection: Rc::new(RefCell::new(c)),
-        tree,
-        path: object_path,
-        context: dbus_context,
-    })
-}
+impl DbusConnectionData {
+    /// Connect a stratis engine to dbus.
+    pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
+        let c = Connection::get_private(BusType::System)?;
+        let (tree, object_path) = get_base_tree(DbusContext::new(engine));
+        let dbus_context = tree.get_data().clone();
+        tree.set_registered(&c, true)?;
+        c.register_name(STRATIS_BASE_SERVICE, NameFlag::ReplaceExisting as u32)?;
+        Ok(DbusConnectionData {
+            connection: Rc::new(RefCell::new(c)),
+            tree,
+            path: object_path,
+            context: dbus_context,
+        })
+    }
 
-/// Given the UUID of a pool, register all the pertinent information with dbus.
-pub fn register_pool(
-    c: &Connection,
-    dbus_context: &DbusContext,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    pool_uuid: Uuid,
-    pool: &mut Pool,
-    object_path: &dbus::Path<'static>,
-) -> Result<(), dbus::Error> {
-    register_pool_dbus(dbus_context, pool_uuid, pool, object_path);
-    process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut())
-}
+    /// Given the UUID of a pool, register all the pertinent information with dbus.
+    pub fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) -> Result<(), dbus::Error> {
+        register_pool_dbus(&self.context, pool_uuid, pool, &self.path);
+        self.process_deferred_actions()
+    }
 
-/// Update the dbus tree with deferred adds and removes.
-fn process_deferred_actions(
-    c: &Connection,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    actions: &mut ActionQueue,
-) -> Result<(), dbus::Error> {
-    for action in actions.drain() {
-        match action {
-            DeferredAction::Add(path) => {
-                c.register_object_path(path.get_name())?;
-                tree.insert(path);
+    /// Update the dbus tree with deferred adds and removes.
+    fn process_deferred_actions(&mut self) -> Result<(), dbus::Error> {
+        let mut actions = self.context.actions.borrow_mut();
+        for action in actions.drain() {
+            match action {
+                DeferredAction::Add(path) => {
+                    self.connection
+                        .borrow_mut()
+                        .register_object_path(path.get_name())?;
+                    self.tree.insert(path);
+                }
+                DeferredAction::Remove(path) => {
+                    self.connection.borrow_mut().unregister_object_path(&path);
+                    self.tree.remove(&path);
+                }
             }
-            DeferredAction::Remove(path) => {
-                c.unregister_object_path(&path);
-                tree.remove(&path);
+        }
+        Ok(())
+    }
+
+    /// Handle any client dbus requests
+    pub fn handle(&mut self, fds: &[libc::pollfd]) -> () {
+        for pfd in fds.iter().filter(|pfd| pfd.revents != 0) {
+            let items: Vec<ConnectionItem> = self.connection
+                .borrow()
+                .watch_handle(pfd.fd, dbus::WatchEvent::from_revents(pfd.revents))
+                .collect();
+
+            for item in items {
+                if let ConnectionItem::MethodCall(ref msg) = item {
+                    if let Some(v) = self.tree.handle(msg) {
+                        // Probably the wisest is to ignore any send errors here -
+                        // maybe the remote has disconnected during our processing.
+                        for m in v {
+                            let _ = self.connection.borrow_mut().send(m);
+                        }
+                    }
+
+                    if let Err(e) = self.process_deferred_actions() {
+                        // There are 2 functions to handle each of these lines in stratisd
+                        // (print_err, log_engine_state) we should relocate them to a library
+                        // if needed in both places
+                        debug!("Engine state: \n{:#?}", &*self.context.engine.borrow());
+                        error!("Client dbus handle: {}", e);
+                    }
+                }
             }
         }
     }
-    Ok(())
-}
-
-pub fn handle(
-    c: &Connection,
-    item: &ConnectionItem,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    dbus_context: &DbusContext,
-) -> Result<(), dbus::Error> {
-    if let ConnectionItem::MethodCall(ref msg) = *item {
-        if let Some(v) = tree.handle(msg) {
-            // Probably the wisest is to ignore any send errors here -
-            // maybe the remote has disconnected during our processing.
-            for m in v {
-                let _ = c.send(m);
-            }
-        }
-
-        process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut())?;
-    }
-
-    Ok(())
 }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -13,6 +13,7 @@ use dbus::tree::{
     Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo, Tree,
 };
 use dbus::{BusType, Connection, ConnectionItem, Message, NameFlag};
+use libc;
 use uuid::Uuid;
 
 use super::super::engine::{Engine, Pool, PoolUuid};

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -13,5 +13,5 @@ mod pool;
 mod types;
 mod util;
 
-pub use self::api::{connect, handle, register_pool, DbusConnectionData};
+pub use self::api::DbusConnectionData;
 pub use self::util::prop_changed_dispatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate uuid;
 #[cfg(feature = "dbus_enabled")]
 extern crate dbus;
 
+extern crate libc;
 extern crate libmount;
 extern crate rand;
 extern crate serde;


### PR DESCRIPTION
Two possible additions to #1343. 

1. 37fde30: just a little more complete encapsulation with UdevMonitor.
1. 0e586ca: Takes things one step further and puts all D-Bus stuff in one conditionally-compiled struct. What's nice about this is it gets `[cfg(feature = "dbus_enabled")]` completely out of event loop, but it is more lines of code. (IMO more lines is ok if the overall readability is improved, which I think it is)

There also may be further consolidation that could happen to merge MaybeDbusSupport with DbusConnectionData that *might* make sense, but have not tried.