### PR TITLE
Ensure that stratisd builds against 1.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - rust: stable
           env: TASK=build TARGET=x86_64-unknown-linux-gnu
           install:
-            - rustup default 1.25.0
+            - rustup default 1.24.1
         # Verify that source builds on a 32 bit system
         - rust: stable
           env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/


### PR DESCRIPTION
This is what is in Debian stable.

Signed-off-by: Andy Grover <agrover@redhat.com>