### PR TITLE
Mark clippy as allowed-failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
     allow_failures:
         # Temporarily allow failure until Travis bug is fixed.
         - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
+        # Temporarily allow failure until after next release.
+        - env: TASK=clippy TARGET=x86_64-unknown-linux-gnu
     include:
         # Verify formatting of Rust code
         - rust: stable


### PR DESCRIPTION
bad timing, and it's not totally clear how to fix issues and still
compile with older compiler versions.

Signed-off-by: Andy Grover <agrover@redhat.com>