### PR TITLE
Re-run thinpool::check() if it changed thinpool configuration (final)

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -497,6 +497,18 @@ impl ThinPool {
     /// Returns a bool communicating if a configuration change requiring a
     /// metadata save has been made.
     pub fn check(&mut self, pool_uuid: PoolUuid, backstore: &mut Backstore) -> StratisResult<bool> {
+        let mut should_save = false;
+
+        // Re-run to ensure pool status is updated if we made any changes
+        while self.do_check(pool_uuid, backstore)? {
+            should_save = true;
+        }
+
+        Ok(should_save)
+    }
+
+    /// Do the real work of check().
+    fn do_check(&mut self, pool_uuid: PoolUuid, backstore: &mut Backstore) -> StratisResult<bool> {
         // Calculate amount to request for data- or meta- device.
         // Return None if device does not need to be expanded.
         // Returned request, if it exists, is always INITIAL_META_SIZE


### PR DESCRIPTION
Make check() a private method and rename to do_check(). Make check()
a wrapper that re-runs do_check() until it returns false, to ensure
status values are up to date given thinpool changes.

Signed-off-by: Andy Grover <agrover@redhat.com>