### PR TITLE
Bug fix: Do not shadow meta_extend_failed with a let

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -579,7 +579,7 @@ impl ThinPool {
                     meta_lowater.sectors(),
                     false,
                 ) {
-                    let meta_extend_failed =
+                    meta_extend_failed =
                         match self.extend_thin_meta_device(pool_uuid, backstore, request) {
                             Ok(extend_size) => extend_size == Sectors(0),
                             Err(_) => true,


### PR DESCRIPTION
Because then the value is not assigned to the intended identifier.

Signed-off-by: mulhern <amulhern@redhat.com>