### PR TITLE
Make logs about extension less alarmist

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -834,6 +834,7 @@ impl ThinPool {
         existing_segs: &mut Vec<(Sectors, Sectors)>,
         data: bool,
     ) -> StratisResult<Sectors> {
+        assert!(modulus != Sectors(0));
         let sub_device_str = if data { "data" } else { "metadata" };
         let pool_uuid_str = pool_uuid.simple().to_string();
         info!(
@@ -862,7 +863,9 @@ impl ThinPool {
         };
         match result {
             Ok(actual_extend_size) => {
-                if actual_extend_size == extend_size {
+                // (extend_size / modulus) * modulus is the maximum size that
+                // Backstore::request() can return when operating correctly.
+                if (extend_size / modulus) * modulus == actual_extend_size {
                     info!(
                         "Extended thinpool {} sub-device belonging to pool with uuid {} by {}",
                         sub_device_str, pool_uuid_str, actual_extend_size


### PR DESCRIPTION
The amount by which the device is extended will always be less than
the amount requested unless the requested amount is a multiple of the
modulus. Don't warn in this case, only warn if it is less than the
maximum possible amount to satisfy the request.

Signed-off-by: mulhern <amulhern@redhat.com>