### PR TITLE
Tasleson pr 1343

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -305,7 +305,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut dbus_handle: Option<libstratis::dbus_api::DbusConnectionData> = None;
 
     // Setup a udev listener before initializing the engine. A device may
-    // appear after the engine has read the /dev directory but before it has
+    // appear after the engine has processed the udev db, but before it has
     // completed initialization. Unless the udev event has been recorded, the
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -291,6 +291,21 @@ impl EngineListener for EventHandler {
     }
 }
 
+struct UdevMonitor<'a> {
+    socket: libudev::MonitorSocket<'a>,
+}
+
+impl<'a> UdevMonitor<'a> {
+    fn create(context: &'a libudev::Context) -> StratisResult<UdevMonitor<'a>> {
+        let mut monitor = libudev::Monitor::new(&context)?;
+        monitor.match_subsystem_devtype("block", "disk")?;
+
+        Ok(UdevMonitor {
+            socket: monitor.listen()?,
+        })
+    }
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -310,9 +325,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.
     let context = libudev::Context::new()?;
-    let mut monitor = libudev::Monitor::new(&context)?;
-    monitor.match_subsystem_devtype("block", "disk")?;
-    let mut udev = monitor.listen()?;
+    let mut udev_events = UdevMonitor::create(&context)?;
 
     let engine: Rc<RefCell<Engine>> = {
         if matches.is_present("sim") {
@@ -354,7 +367,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut fds = Vec::new();
 
     fds.push(libc::pollfd {
-        fd: udev.as_raw_fd(),
+        fd: udev_events.socket.as_raw_fd(),
         revents: 0,
         events: libc::POLLIN,
     });
@@ -414,7 +427,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev.receive_event() {
+            while let Some(event) = udev_events.socket.receive_event() {
                 if let Some((device, devnode)) = handle_udev_event(&event) {
                     // If block evaluate returns an error we are going to ignore it as
                     // there is nothing we can do for a device we are getting errors with.

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -423,27 +423,29 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
 
                     #[cfg(feature = "dbus_enabled")]
                     {
-                        let pool_uuid = engine
-                            .borrow_mut()
-                            .block_evaluate(device, devnode)
-                            .unwrap_or(None);
+                        let mut eng_ref = engine.borrow_mut();
+                        let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
 
                         if let Some(ref mut handle) = dbus_handle {
                             if let Some(pool_uuid) = pool_uuid {
-                                libstratis::dbus_api::register_pool(
-                                    &handle.connection.borrow(),
-                                    &handle.context,
-                                    &mut handle.tree,
-                                    pool_uuid,
-                                    engine
-                                        .borrow_mut()
+                                let pool = eng_ref
                                         .get_mut_pool(pool_uuid)
                                         .expect(
                                             "block_evaluate() returned a pool UUID, pool must be available",
                                         )
-                                        .1,
+                                        .1;
+
+                                if let Err(e) = libstratis::dbus_api::register_pool(
+                                    &handle.connection.borrow(),
+                                    &handle.context,
+                                    &mut handle.tree,
+                                    pool_uuid,
+                                    pool,
                                     &handle.path,
-                                )?;
+                                ) {
+                                    error!("libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                                            pool_uuid, pool, handle.path, e);
+                                }
                             }
                         }
                     }
@@ -540,14 +542,19 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                 get_engine_listener_list_mut().register_listener(event_handler);
                 // Register all the pools with dbus
                 for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-                    libstratis::dbus_api::register_pool(
+                    if let Err(e) = libstratis::dbus_api::register_pool(
                         &handle.connection.borrow(),
                         &handle.context,
                         &mut handle.tree,
                         pool_uuid,
                         pool,
                         &handle.path,
-                    )?;
+                    ) {
+                        error!(
+                            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                            pool_uuid, pool, handle.path, e
+                        );
+                    }
                 }
 
                 // Add dbus FD to fds as dbus is now available.

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -387,6 +387,88 @@ fn process_signal(
     }
 }
 
+/// Handle any client dbus requests.
+fn process_dbus(
+    handle: &mut libstratis::dbus_api::DbusConnectionData,
+    engine: &Rc<RefCell<Engine>>,
+    fds: &mut Vec<libc::pollfd>,
+    dbus_client_index_start: usize,
+) -> StratisResult<()> {
+    for pfd in fds[dbus_client_index_start..]
+        .iter()
+        .filter(|pfd| pfd.revents != 0)
+    {
+        for item in handle
+            .connection
+            .borrow()
+            .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
+        {
+            if let Err(r) = libstratis::dbus_api::handle(
+                &handle.connection.borrow(),
+                &item,
+                &mut handle.tree,
+                &handle.context,
+            ) {
+                log_engine_state(&*engine.borrow());
+                print_err(&From::from(r));
+            }
+        }
+    }
+
+    // Refresh list of dbus fds to poll for. This can change as
+    // D-Bus clients come and go.
+    fds.truncate(dbus_client_index_start);
+    fds.extend(
+        handle
+            .connection
+            .borrow()
+            .watch_fds()
+            .iter()
+            .map(|w| w.to_pollfd()),
+    );
+
+    Ok(())
+}
+
+/// Iterate through all the pools and register them with the dbus interface and update the vector
+/// of file poll file descriptors.
+fn initialize_dbus(
+    handle: &mut libstratis::dbus_api::DbusConnectionData,
+    engine: &Rc<RefCell<Engine>>,
+    fds: &mut Vec<libc::pollfd>,
+) -> StratisResult<()> {
+    info!("DBUS API is now available");
+    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
+    get_engine_listener_list_mut().register_listener(event_handler);
+    // Register all the pools with dbus
+    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
+        if let Err(e) = libstratis::dbus_api::register_pool(
+            &handle.connection.borrow(),
+            &handle.context,
+            &mut handle.tree,
+            pool_uuid,
+            pool,
+            &handle.path,
+        ) {
+            error!(
+                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                pool_uuid, pool, handle.path, e
+            );
+        }
+    }
+
+    // Add dbus FD to fds as dbus is now available.
+    fds.extend(
+        handle
+            .connection
+            .borrow()
+            .watch_fds()
+            .iter()
+            .map(|w| w.to_pollfd()),
+    );
+    Ok(())
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -545,69 +627,13 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         #[cfg(feature = "dbus_enabled")]
         {
             if let Some(ref mut handle) = dbus_handle {
-                for pfd in fds[dbus_client_index_start..]
-                    .iter()
-                    .filter(|pfd| pfd.revents != 0)
-                {
-                    for item in handle
-                        .connection
-                        .borrow()
-                        .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
-                    {
-                        if let Err(r) = libstratis::dbus_api::handle(
-                            &handle.connection.borrow(),
-                            &item,
-                            &mut handle.tree,
-                            &handle.context,
-                        ) {
-                            log_engine_state(&*engine.borrow());
-                            print_err(&From::from(r));
-                        }
-                    }
+                process_dbus(handle, &engine, &mut fds, dbus_client_index_start)?;
+            } else {
+                // Try to establish dbus
+                if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
+                    initialize_dbus(&mut handle, &engine, &mut fds)?;
+                    dbus_handle = Some(handle);
                 }
-
-                // Refresh list of dbus fds to poll for. This can change as
-                // D-Bus clients come and go.
-                fds.truncate(dbus_client_index_start);
-                fds.extend(
-                    handle
-                        .connection
-                        .borrow()
-                        .watch_fds()
-                        .iter()
-                        .map(|w| w.to_pollfd()),
-                );
-            } else if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
-                info!("DBUS API is now available");
-                let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
-                get_engine_listener_list_mut().register_listener(event_handler);
-                // Register all the pools with dbus
-                for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-                    if let Err(e) = libstratis::dbus_api::register_pool(
-                        &handle.connection.borrow(),
-                        &handle.context,
-                        &mut handle.tree,
-                        pool_uuid,
-                        pool,
-                        &handle.path,
-                    ) {
-                        error!(
-                            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                            pool_uuid, pool, handle.path, e
-                        );
-                    }
-                }
-
-                // Add dbus FD to fds as dbus is now available.
-                fds.extend(
-                    handle
-                        .connection
-                        .borrow()
-                        .watch_fds()
-                        .iter()
-                        .map(|w| w.to_pollfd()),
-                );
-                dbus_handle = Some(handle);
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -352,6 +352,41 @@ fn process_udev_event(
     Ok(())
 }
 
+// Process any pending signals, return true if we should exit.
+fn process_signal(
+    sfd: &mut SignalFd,
+    buff_log: &buff_log::Handle<env_logger::Logger>,
+) -> StratisResult<bool> {
+    match sfd.read_signal() {
+        // This is an unsafe conversion, but in this context that is
+        // mostly harmless. A negative converted value, which is
+        // virtually impossible, will not match any of the masked
+        // values, and stratisd will panic and exit.
+        Ok(Some(sig)) => match sig.ssi_signo as i32 {
+            nix::libc::SIGUSR1 => {
+                info!(
+                    "SIGUSR1 received, dumping {} buffered log entries",
+                    buff_log.buffered_count()
+                );
+                buff_log.dump();
+                return Ok(false);
+            }
+            nix::libc::SIGINT => {
+                info!("SIGINT received, exiting");
+                return Ok(true);
+            }
+            signo => {
+                panic!("Caught an impossible signal {:?}", signo);
+            }
+        },
+        // No signals waiting (SFD_NONBLOCK flag is set)
+        Ok(None) => Ok(false),
+
+        // Pessimistically exit on an error reading the signal.
+        Err(err) => return Err(err.into()),
+    }
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -478,34 +513,15 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
             }
         }
 
-        // Process any signals off signalfd
+        // Process any signals off of signalfd
         if fds[FD_INDEX_SIGNALFD].revents != 0 {
-            match sfd.read_signal() {
-                // This is an unsafe conversion, but in this context that is
-                // mostly harmless. A negative converted value, which is
-                // virtually impossible, will not match any of the masked
-                // values, and stratisd will panic and exit.
-                Ok(Some(sig)) => match sig.ssi_signo as i32 {
-                    nix::libc::SIGUSR1 => {
-                        info!(
-                            "SIGUSR1 received, dumping {} buffered log entries",
-                            buff_log.buffered_count()
-                        );
-                        buff_log.dump()
-                    }
-                    nix::libc::SIGINT => {
-                        info!("SIGINT received, exiting");
+            match process_signal(&mut sfd, &buff_log) {
+                Ok(should_exit) => {
+                    if should_exit {
                         return Ok(());
                     }
-                    signo => {
-                        panic!("Caught an impossible signal {:?}", signo);
-                    }
-                },
-                // No signals waiting (SFD_NONBLOCK flag is set)
-                Ok(None) => (),
-
-                // Pessimistically exit on an error reading the signal.
-                Err(err) => return Err(err.into()),
+                }
+                Err(e) => error!("process_signal: {:?}", e),
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::process::exit;
 use std::rc::Rc;
@@ -309,6 +309,14 @@ impl<'a> UdevMonitor<'a> {
             socket: monitor.listen()?,
         })
     }
+
+    fn as_raw_fd(&mut self) -> RawFd {
+        self.socket.as_raw_fd()
+    }
+
+    fn receive_event(&mut self) -> Option<libudev::Event> {
+        self.socket.receive_event()
+    }
 }
 
 // Process any pending signals, return true if we should exit.
@@ -434,7 +442,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     // engine will miss the device.
     // This is especially important since stratisd must run during early boot.
     let context = libudev::Context::new()?;
-    let mut udev_events = UdevMonitor::create(&context)?;
+    let mut udev_monitor = UdevMonitor::create(&context)?;
 
     let engine: Rc<RefCell<Engine>> = {
         if matches.is_present("sim") {
@@ -476,7 +484,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     let mut fds = Vec::new();
 
     fds.push(libc::pollfd {
-        fd: udev_events.socket.as_raw_fd(),
+        fd: udev_monitor.as_raw_fd(),
         revents: 0,
         events: libc::POLLIN,
     });
@@ -536,7 +544,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_events.socket.receive_event() {
+            while let Some(event) = udev_monitor.receive_event() {
                 if let Some(_pool_uuid) = handle_udev_event(&event, &engine) {
                     #[cfg(feature = "dbus_enabled")]
                     {

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -51,7 +51,7 @@ use libstratis::dbus_api::{consts, prop_changed_dispatch};
 use libstratis::engine::{
     get_engine_listener_list_mut, EngineEvent, EngineListener, MaybeDbusPath,
 };
-use libstratis::engine::{Engine, SimEngine, StratEngine};
+use libstratis::engine::{Engine, Pool, SimEngine, StratEngine};
 use libstratis::stratis::buff_log;
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
 
@@ -296,6 +296,112 @@ impl EngineListener for EventHandler {
     }
 }
 
+struct MaybeDbusSupport {
+    #[cfg(feature = "dbus_enabled")]
+    handle: Option<libstratis::dbus_api::DbusConnectionData>,
+}
+
+// If D-Bus compiled out, do very little.
+#[cfg(not(feature = "dbus_enabled"))]
+impl MaybeDbusSupport {
+    fn new() -> MaybeDbusSupport {
+        MaybeDbusSupport {}
+    }
+
+    fn process(
+        &mut self,
+        _engine: &Rc<RefCell<Engine>>,
+        _fds: &mut Vec<libc::pollfd>,
+        _dbus_client_index_start: usize,
+    ) -> StratisResult<()> {
+        Ok(())
+    }
+
+    fn register_pool(&mut self, _pool_uuid: Uuid, _pool: &mut Pool) -> StratisResult<()> {
+        Ok(())
+    }
+
+    fn poll_timeout(&self) -> i32 {
+        // Non-DBus timeout is infinite
+        -1
+    }
+}
+
+#[cfg(feature = "dbus_enabled")]
+impl MaybeDbusSupport {
+    fn new() -> MaybeDbusSupport {
+        MaybeDbusSupport { handle: None }
+    }
+
+    /// Connect to D-Bus and register pools, if not already connected.
+    fn check_connect(&mut self, engine: &Rc<RefCell<Engine>>) -> StratisResult<bool> {
+        let mut connected = self.handle.is_some();
+        if !connected {
+            match libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(&engine)) {
+                Err(_err) => {
+                    info!("D-Bus API is not available");
+                    connected = false;
+                }
+                Ok(mut handle) => {
+                    info!("D-Bus API is available");
+                    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
+                    get_engine_listener_list_mut().register_listener(event_handler);
+                    // Register all the pools with dbus
+                    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
+                        handle.register_pool(pool_uuid, pool)?;
+                    }
+                    self.handle = Some(handle);
+                    connected = true;
+                }
+            }
+        }
+        Ok(connected)
+    }
+
+    /// Handle any client dbus requests.
+    fn process(
+        &mut self,
+        engine: &Rc<RefCell<Engine>>,
+        fds: &mut Vec<libc::pollfd>,
+        dbus_client_index_start: usize,
+    ) -> StratisResult<()> {
+        if self.check_connect(engine)? {
+            let handle = &mut self.handle
+                .as_mut()
+                .expect("Connected, so handle is present");
+
+            handle.handle(&fds[dbus_client_index_start..]);
+
+            // Refresh list of dbus fds to poll for. This can change as
+            // D-Bus clients come and go.
+            fds.truncate(dbus_client_index_start);
+            fds.extend(
+                handle
+                    .connection
+                    .borrow()
+                    .watch_fds()
+                    .iter()
+                    .map(|w| w.to_pollfd()),
+            );
+        }
+        Ok(())
+    }
+
+    fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) -> StratisResult<()> {
+        if let Some(h) = self.handle.as_mut() {
+            h.register_pool(pool_uuid, pool)?;
+        }
+        Ok(())
+    }
+
+    fn poll_timeout(&self) -> i32 {
+        // If dbus support is compiled in and dbus isn't available we will set
+        // timeout to 1 second so that we periodically check to see if we can
+        // bring it up.
+        self.handle.as_ref().map_or(1000, |_| -1)
+    }
+}
+
 struct UdevMonitor<'a> {
     socket: libudev::MonitorSocket<'a>,
 }
@@ -354,58 +460,6 @@ fn process_signal(
     }
 }
 
-/// Handle any client dbus requests.
-#[cfg(feature = "dbus_enabled")]
-fn process_dbus(
-    handle: &mut libstratis::dbus_api::DbusConnectionData,
-    fds: &mut Vec<libc::pollfd>,
-    dbus_client_index_start: usize,
-) -> StratisResult<()> {
-    handle.handle(&fds[dbus_client_index_start..]);
-
-    // Refresh list of dbus fds to poll for. This can change as
-    // D-Bus clients come and go.
-    fds.truncate(dbus_client_index_start);
-    fds.extend(
-        handle
-            .connection
-            .borrow()
-            .watch_fds()
-            .iter()
-            .map(|w| w.to_pollfd()),
-    );
-
-    Ok(())
-}
-
-/// Iterate through all the pools and register them with the dbus interface and update the vector
-/// of file poll file descriptors.
-#[cfg(feature = "dbus_enabled")]
-fn initialize_dbus(
-    handle: &mut libstratis::dbus_api::DbusConnectionData,
-    engine: &Rc<RefCell<Engine>>,
-    fds: &mut Vec<libc::pollfd>,
-) -> StratisResult<()> {
-    info!("DBUS API is now available");
-    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
-    get_engine_listener_list_mut().register_listener(event_handler);
-    // Register all the pools with dbus
-    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-        handle.register_pool(pool_uuid, pool)?;
-    }
-
-    // Add dbus FD to fds as dbus is now available.
-    fds.extend(
-        handle
-            .connection
-            .borrow()
-            .watch_fds()
-            .iter()
-            .map(|w| w.to_pollfd()),
-    );
-    Ok(())
-}
-
 /// Handle blocking the event loop
 fn process_poll(poll_timeout: i32, fds: &mut Vec<libc::pollfd>) -> StratisResult<()> {
     let r = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::c_ulong, poll_timeout) };
@@ -431,10 +485,9 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     // Ensure that the debug log is output when we leave this function.
     let _guard = buff_log.to_guard();
 
-    // Even if dbus is enabled at compile time, it may not be available at all times depending
-    // on the environment we are running in.
-    #[cfg(feature = "dbus_enabled")]
-    let mut dbus_handle: Option<libstratis::dbus_api::DbusConnectionData> = None;
+    // Even if dbus is enabled at compile time, it may not be available at all
+    // times depending on the environment we are running in.
+    let mut dbus_support = MaybeDbusSupport::new();
 
     // Setup a udev listener before initializing the engine. A device may
     // appear after the engine has processed the udev db, but before it has
@@ -532,7 +585,6 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         });
     };
 
-    #[cfg(feature = "dbus_enabled")]
     let dbus_client_index_start = if eventable.is_some() {
         FD_INDEX_ENGINE + 1
     } else {
@@ -545,21 +597,13 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
             while let Some(event) = udev_monitor.receive_event() {
-                if let Some(_pool_uuid) = handle_udev_event(&event, &engine) {
-                    #[cfg(feature = "dbus_enabled")]
-                    {
-                        let mut eng_ref = engine.borrow_mut();
-                        if let Some(ref mut handle) = dbus_handle {
-                            let pool = eng_ref
-                                .get_mut_pool(_pool_uuid)
-                                .expect(
-                                    "block_evaluate() returned a pool UUID, pool must be available",
-                                )
-                                .1;
+                if let Some(pool_uuid) = handle_udev_event(&event, &engine) {
+                    let mut eng_ref = engine.borrow_mut();
+                    let (_, pool) = eng_ref
+                        .get_mut_pool(pool_uuid)
+                        .expect("block_evaluate() returned a pool UUID, pool must be available");
 
-                            handle.register_pool(_pool_uuid, pool)?;
-                        }
-                    }
+                    dbus_support.register_pool(pool_uuid, pool)?;
                 }
             }
         }
@@ -591,27 +635,12 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
             }
         }
 
-        // Iterate through D-Bus file descriptors (if enabled) and dbus is actually available,
-        // otherwise attempt to bring up the dbus interface.
-        #[cfg(feature = "dbus_enabled")]
-        {
-            if let Some(ref mut handle) = dbus_handle {
-                process_dbus(handle, &mut fds, dbus_client_index_start)?;
-            } else if let Ok(mut handle) =
-                libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(&engine))
-            {
-                initialize_dbus(&mut handle, &engine, &mut fds)?;
-                dbus_handle = Some(handle);
-            }
-        }
+        // Iterate through D-Bus file descriptors (if enabled) and dbus is
+        // actually available, otherwise attempt to bring up the dbus
+        // interface.
+        dbus_support.process(&engine, &mut fds, dbus_client_index_start)?;
 
-        // If dbus support is compiled in and dbus isn't available we will set timeout to
-        // 1 second so that we periodically check to see if we can bring it up.
-        #[cfg(feature = "dbus_enabled")]
-        let poll_timeout = dbus_handle.as_ref().map_or(1000, |_| -1);
-        // Default timeout is infinite
-        #[cfg(not(feature = "dbus_enabled"))]
-        let poll_timeout = -1;
+        let poll_timeout = dbus_support.poll_timeout();
         // Block until we have something to handle
         process_poll(poll_timeout, &mut fds)?;
     }

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -306,6 +306,52 @@ impl<'a> UdevMonitor<'a> {
     }
 }
 
+/// Process the udev event by bringing up pools if possible and registering them with dbus api.
+fn process_udev_event(
+    udev_events: &mut UdevMonitor,
+    dbus_handle: &mut Option<libstratis::dbus_api::DbusConnectionData>,
+    engine: &Rc<RefCell<Engine>>,
+) -> StratisResult<()> {
+    while let Some(event) = udev_events.socket.receive_event() {
+        if let Some((device, devnode)) = handle_udev_event(&event) {
+            // If block evaluate returns an error we are going to ignore it as
+            // there is nothing we can do for a device we are getting errors with.
+            #[cfg(not(feature = "dbus_enabled"))]
+            let _ = engine.borrow_mut().block_evaluate(device, devnode);
+
+            #[cfg(feature = "dbus_enabled")]
+            {
+                let mut eng_ref = engine.borrow_mut();
+                let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
+
+                if let Some(ref mut handle) = dbus_handle {
+                    if let Some(pool_uuid) = pool_uuid {
+                        let pool = eng_ref
+                            .get_mut_pool(pool_uuid)
+                            .expect("block_evaluate() returned a pool UUID, pool must be available")
+                            .1;
+
+                        if let Err(e) = libstratis::dbus_api::register_pool(
+                            &handle.connection.borrow(),
+                            &handle.context,
+                            &mut handle.tree,
+                            pool_uuid,
+                            pool,
+                            &handle.path,
+                        ) {
+                            error!(
+                                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+                                pool_uuid, pool, handle.path, e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Set up all sorts of signal and event handling mechanisms.
 /// Initialize the engine and keep it running until a signal is received
 /// or a fatal error is encountered. Dump log entries on specified signal
@@ -427,42 +473,8 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_events.socket.receive_event() {
-                if let Some((device, devnode)) = handle_udev_event(&event) {
-                    // If block evaluate returns an error we are going to ignore it as
-                    // there is nothing we can do for a device we are getting errors with.
-                    #[cfg(not(feature = "dbus_enabled"))]
-                    let _ = engine.borrow_mut().block_evaluate(device, devnode);
-
-                    #[cfg(feature = "dbus_enabled")]
-                    {
-                        let mut eng_ref = engine.borrow_mut();
-                        let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
-
-                        if let Some(ref mut handle) = dbus_handle {
-                            if let Some(pool_uuid) = pool_uuid {
-                                let pool = eng_ref
-                                        .get_mut_pool(pool_uuid)
-                                        .expect(
-                                            "block_evaluate() returned a pool UUID, pool must be available",
-                                        )
-                                        .1;
-
-                                if let Err(e) = libstratis::dbus_api::register_pool(
-                                    &handle.connection.borrow(),
-                                    &handle.context,
-                                    &mut handle.tree,
-                                    pool_uuid,
-                                    pool,
-                                    &handle.path,
-                                ) {
-                                    error!("libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                                            pool_uuid, pool, handle.path, e);
-                                }
-                            }
-                        }
-                    }
-                }
+            if let Err(e) = process_udev_event(&mut udev_events, &mut dbus_handle, &engine) {
+                error!("process_udev_event: {:?}", e);
             }
         }
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -110,25 +110,6 @@ fn initialize_log(debug: bool) -> buff_log::Handle<env_logger::Logger> {
     }
 }
 
-/// Given a udev event, if it's one of interest and the block device is a stratis device, return
-/// the pool UUID for it.
-fn handle_udev_event(event: &libudev::Event, engine: &Rc<RefCell<Engine>>) -> Option<Uuid> {
-    if event.event_type() == libudev::EventType::Add
-        || event.event_type() == libudev::EventType::Change
-    {
-        let device = event.device();
-        return device.devnode().and_then(|devnode| {
-            device.devnum().and_then(|devnum| {
-                engine
-                    .borrow_mut()
-                    .block_evaluate(Device::from(devnum), PathBuf::from(devnode))
-                    .unwrap_or(None)
-            })
-        });
-    }
-    None
-}
-
 /// To ensure only one instance of stratisd runs at a time, acquire an
 /// exclusive lock. Return an error if lock attempt fails.
 fn trylock_pid_file() -> StratisResult<File> {
@@ -420,8 +401,36 @@ impl<'a> UdevMonitor<'a> {
         self.socket.as_raw_fd()
     }
 
-    fn receive_event(&mut self) -> Option<libudev::Event> {
-        self.socket.receive_event()
+    /// Given some udev events, see if any new pools are formed, and set up
+    /// dbus if so.
+    fn handle_events(
+        &mut self,
+        engine: &Rc<RefCell<Engine>>,
+        dbus_support: &mut MaybeDbusSupport,
+    ) -> StratisResult<()> {
+        while let Some(event) = self.socket.receive_event() {
+            if event.event_type() == libudev::EventType::Add
+                || event.event_type() == libudev::EventType::Change
+            {
+                let device = event.device();
+                let new_pool_uuid = device.devnode().and_then(|devnode| {
+                    device.devnum().and_then(|devnum| {
+                        engine
+                            .borrow_mut()
+                            .block_evaluate(Device::from(devnum), PathBuf::from(devnode))
+                            .unwrap_or(None)
+                    })
+                });
+                if let Some(pool_uuid) = new_pool_uuid {
+                    let mut eng_ref = engine.borrow_mut();
+                    let (_, pool) = eng_ref
+                        .get_mut_pool(pool_uuid)
+                        .expect("block_evaluate() returned a pool UUID, pool must be available");
+                    dbus_support.register_pool(pool_uuid, pool)?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -596,16 +605,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            while let Some(event) = udev_monitor.receive_event() {
-                if let Some(pool_uuid) = handle_udev_event(&event, &engine) {
-                    let mut eng_ref = engine.borrow_mut();
-                    let (_, pool) = eng_ref
-                        .get_mut_pool(pool_uuid)
-                        .expect("block_evaluate() returned a pool UUID, pool must be available");
-
-                    dbus_support.register_pool(pool_uuid, pool)?;
-                }
-            }
+            udev_monitor.handle_events(&engine, &mut dbus_support)?;
         }
 
         // Process any signals off of signalfd

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -18,6 +18,7 @@ extern crate libc;
 extern crate libudev;
 extern crate nix;
 extern crate timerfd;
+extern crate uuid;
 
 use std::cell::RefCell;
 use std::env;
@@ -38,6 +39,7 @@ use nix::sys::signal::{self, SigSet};
 use nix::sys::signalfd::{SfdFlags, SignalFd};
 use nix::unistd::getpid;
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
+use uuid::Uuid;
 
 #[cfg(feature = "dbus_enabled")]
 use dbus::{Connection, WatchEvent};
@@ -52,6 +54,9 @@ use libstratis::engine::{
 use libstratis::engine::{Engine, SimEngine, StratEngine};
 use libstratis::stratis::buff_log;
 use libstratis::stratis::{StratisError, StratisResult, VERSION};
+
+#[cfg(feature = "dbus_enabled")]
+use libstratis::engine::Pool;
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
 
@@ -108,17 +113,20 @@ fn initialize_log(debug: bool) -> buff_log::Handle<env_logger::Logger> {
     }
 }
 
-/// Given a udev event check to see if it's an add or change and if it is return the device node
-/// and devicemapper::Device.
-fn handle_udev_event(event: &libudev::Event) -> Option<(Device, PathBuf)> {
+/// Given a udev event, if it's one of interest and the block device is a stratis device, return
+/// the pool UUID for it.
+fn handle_udev_event(event: &libudev::Event, engine: &Rc<RefCell<Engine>>) -> Option<Uuid> {
     if event.event_type() == libudev::EventType::Add
         || event.event_type() == libudev::EventType::Change
     {
         let device = event.device();
         return device.devnode().and_then(|devnode| {
-            device
-                .devnum()
-                .and_then(|devnum| Some((Device::from(devnum), PathBuf::from(devnode))))
+            device.devnum().and_then(|devnum| {
+                engine
+                    .borrow_mut()
+                    .block_evaluate(Device::from(devnum), PathBuf::from(devnode))
+                    .unwrap_or(None)
+            })
         });
     }
     None
@@ -306,52 +314,6 @@ impl<'a> UdevMonitor<'a> {
     }
 }
 
-/// Process the udev event by bringing up pools if possible and registering them with dbus api.
-fn process_udev_event(
-    udev_events: &mut UdevMonitor,
-    dbus_handle: &mut Option<libstratis::dbus_api::DbusConnectionData>,
-    engine: &Rc<RefCell<Engine>>,
-) -> StratisResult<()> {
-    while let Some(event) = udev_events.socket.receive_event() {
-        if let Some((device, devnode)) = handle_udev_event(&event) {
-            // If block evaluate returns an error we are going to ignore it as
-            // there is nothing we can do for a device we are getting errors with.
-            #[cfg(not(feature = "dbus_enabled"))]
-            let _ = engine.borrow_mut().block_evaluate(device, devnode);
-
-            #[cfg(feature = "dbus_enabled")]
-            {
-                let mut eng_ref = engine.borrow_mut();
-                let pool_uuid = eng_ref.block_evaluate(device, devnode).unwrap_or(None);
-
-                if let Some(ref mut handle) = dbus_handle {
-                    if let Some(pool_uuid) = pool_uuid {
-                        let pool = eng_ref
-                            .get_mut_pool(pool_uuid)
-                            .expect("block_evaluate() returned a pool UUID, pool must be available")
-                            .1;
-
-                        if let Err(e) = libstratis::dbus_api::register_pool(
-                            &handle.connection.borrow(),
-                            &handle.context,
-                            &mut handle.tree,
-                            pool_uuid,
-                            pool,
-                            &handle.path,
-                        ) {
-                            error!(
-                                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                                pool_uuid, pool, handle.path, e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 // Process any pending signals, return true if we should exit.
 fn process_signal(
     sfd: &mut SignalFd,
@@ -369,11 +331,11 @@ fn process_signal(
                     buff_log.buffered_count()
                 );
                 buff_log.dump();
-                return Ok(false);
+                Ok(false)
             }
             nix::libc::SIGINT => {
                 info!("SIGINT received, exiting");
-                return Ok(true);
+                Ok(true)
             }
             signo => {
                 panic!("Caught an impossible signal {:?}", signo);
@@ -383,11 +345,12 @@ fn process_signal(
         Ok(None) => Ok(false),
 
         // Pessimistically exit on an error reading the signal.
-        Err(err) => return Err(err.into()),
+        Err(err) => Err(err.into()),
     }
 }
 
 /// Handle any client dbus requests.
+#[cfg(feature = "dbus_enabled")]
 fn process_dbus(
     handle: &mut libstratis::dbus_api::DbusConnectionData,
     engine: &Rc<RefCell<Engine>>,
@@ -430,8 +393,33 @@ fn process_dbus(
     Ok(())
 }
 
+/// Handle registering the pool with the dbus library.  Wondering why the actual register_pool
+/// isn't implements with methods on the DbusConnectionData structure???
+#[cfg(feature = "dbus_enabled")]
+fn dbus_register_pool(
+    handle: &mut libstratis::dbus_api::DbusConnectionData,
+    pool_uuid: Uuid,
+    pool: &mut Pool,
+) -> StratisResult<()> {
+    if let Err(e) = libstratis::dbus_api::register_pool(
+        &handle.connection.borrow(),
+        &handle.context,
+        &mut handle.tree,
+        pool_uuid,
+        pool,
+        &handle.path,
+    ) {
+        error!(
+            "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
+            pool_uuid, pool, handle.path, e
+        );
+    }
+    Ok(())
+}
+
 /// Iterate through all the pools and register them with the dbus interface and update the vector
 /// of file poll file descriptors.
+#[cfg(feature = "dbus_enabled")]
 fn initialize_dbus(
     handle: &mut libstratis::dbus_api::DbusConnectionData,
     engine: &Rc<RefCell<Engine>>,
@@ -442,19 +430,7 @@ fn initialize_dbus(
     get_engine_listener_list_mut().register_listener(event_handler);
     // Register all the pools with dbus
     for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
-        if let Err(e) = libstratis::dbus_api::register_pool(
-            &handle.connection.borrow(),
-            &handle.context,
-            &mut handle.tree,
-            pool_uuid,
-            pool,
-            &handle.path,
-        ) {
-            error!(
-                "libstratis::dbus_api::register_pool {}, {:?}, Path {}, error: {}",
-                pool_uuid, pool, handle.path, e
-            );
-        }
+        dbus_register_pool(handle, pool_uuid, pool)?;
     }
 
     // Add dbus FD to fds as dbus is now available.
@@ -607,8 +583,23 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
     loop {
         // Process any udev block events
         if fds[FD_INDEX_UDEV].revents != 0 {
-            if let Err(e) = process_udev_event(&mut udev_events, &mut dbus_handle, &engine) {
-                error!("process_udev_event: {:?}", e);
+            while let Some(event) = udev_events.socket.receive_event() {
+                if let Some(_pool_uuid) = handle_udev_event(&event, &engine) {
+                    #[cfg(feature = "dbus_enabled")]
+                    {
+                        let mut eng_ref = engine.borrow_mut();
+                        if let Some(ref mut handle) = dbus_handle {
+                            let pool = eng_ref
+                                .get_mut_pool(_pool_uuid)
+                                .expect(
+                                    "block_evaluate() returned a pool UUID, pool must be available",
+                                )
+                                .1;
+
+                            dbus_register_pool(handle, _pool_uuid, pool)?;
+                        }
+                    }
+                }
             }
         }
 
@@ -645,12 +636,9 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
         {
             if let Some(ref mut handle) = dbus_handle {
                 process_dbus(handle, &engine, &mut fds, dbus_client_index_start)?;
-            } else {
-                // Try to establish dbus
-                if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
-                    initialize_dbus(&mut handle, &engine, &mut fds)?;
-                    dbus_handle = Some(handle);
-                }
+            } else if let Ok(mut handle) = libstratis::dbus_api::connect(Rc::clone(&engine)) {
+                initialize_dbus(&mut handle, &engine, &mut fds)?;
+                dbus_handle = Some(handle);
             }
         }
 

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -202,15 +202,15 @@ fn register_pool_dbus(
 }
 
 /// Returned data from when you connect a stratis engine to dbus.
-pub struct DbusConnectionData<'a> {
+pub struct DbusConnectionData {
     pub connection: Rc<RefCell<Connection>>,
     pub tree: Tree<MTFn<TData>, TData>,
-    pub path: dbus::Path<'a>,
+    pub path: dbus::Path<'static>,
     pub context: DbusContext,
 }
 
 /// Connect a stratis engine to dbus.
-pub fn connect<'a>(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData<'a>, dbus::Error> {
+pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
     let c = Connection::get_private(BusType::System)?;
     let (tree, object_path) = get_base_tree(DbusContext::new(engine));
     let dbus_context = tree.get_data().clone();

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -22,7 +22,7 @@ use super::blockdev::create_dbus_blockdev;
 use super::consts;
 use super::filesystem::create_dbus_filesystem;
 use super::pool::create_dbus_pool;
-use super::types::{ActionQueue, DbusContext, DbusErrorEnum, DeferredAction, TData};
+use super::types::{DbusContext, DbusErrorEnum, DeferredAction, TData};
 use super::util::{
     engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
 };
@@ -209,75 +209,78 @@ pub struct DbusConnectionData {
     pub context: DbusContext,
 }
 
-/// Connect a stratis engine to dbus.
-pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
-    let c = Connection::get_private(BusType::System)?;
-    let (tree, object_path) = get_base_tree(DbusContext::new(engine));
-    let dbus_context = tree.get_data().clone();
-    tree.set_registered(&c, true)?;
-    c.register_name(
-        consts::STRATIS_BASE_SERVICE,
-        NameFlag::ReplaceExisting as u32,
-    )?;
-    Ok(DbusConnectionData {
-        connection: Rc::new(RefCell::new(c)),
-        tree,
-        path: object_path,
-        context: dbus_context,
-    })
-}
+impl DbusConnectionData {
+    /// Connect a stratis engine to dbus.
+    pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
+        let c = Connection::get_private(BusType::System)?;
+        let (tree, object_path) = get_base_tree(DbusContext::new(engine));
+        let dbus_context = tree.get_data().clone();
+        tree.set_registered(&c, true)?;
+        c.register_name(
+            consts::STRATIS_BASE_SERVICE,
+            NameFlag::ReplaceExisting as u32,
+        )?;
+        Ok(DbusConnectionData {
+            connection: Rc::new(RefCell::new(c)),
+            tree,
+            path: object_path,
+            context: dbus_context,
+        })
+    }
 
-/// Given the UUID of a pool, register all the pertinent information with dbus.
-pub fn register_pool(
-    c: &Connection,
-    dbus_context: &DbusContext,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    pool_uuid: Uuid,
-    pool: &mut Pool,
-    object_path: &dbus::Path<'static>,
-) -> Result<(), dbus::Error> {
-    register_pool_dbus(dbus_context, pool_uuid, pool, object_path);
-    process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut())
-}
+    /// Given the UUID of a pool, register all the pertinent information with dbus.
+    pub fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut Pool) -> Result<(), dbus::Error> {
+        register_pool_dbus(&self.context, pool_uuid, pool, &self.path);
+        self.process_deferred_actions()
+    }
 
-/// Update the dbus tree with deferred adds and removes.
-fn process_deferred_actions(
-    c: &Connection,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    actions: &mut ActionQueue,
-) -> Result<(), dbus::Error> {
-    for action in actions.drain() {
-        match action {
-            DeferredAction::Add(path) => {
-                c.register_object_path(path.get_name())?;
-                tree.insert(path);
+    /// Update the dbus tree with deferred adds and removes.
+    fn process_deferred_actions(&mut self) -> Result<(), dbus::Error> {
+        let mut actions = self.context.actions.borrow_mut();
+        for action in actions.drain() {
+            match action {
+                DeferredAction::Add(path) => {
+                    self.connection
+                        .borrow_mut()
+                        .register_object_path(path.get_name())?;
+                    self.tree.insert(path);
+                }
+                DeferredAction::Remove(path) => {
+                    self.connection.borrow_mut().unregister_object_path(&path);
+                    self.tree.remove(&path);
+                }
             }
-            DeferredAction::Remove(path) => {
-                c.unregister_object_path(&path);
-                tree.remove(&path);
+        }
+        Ok(())
+    }
+
+    /// Handle any client dbus requests
+    pub fn handle(&mut self, fds: &[libc::pollfd]) -> () {
+        for pfd in fds.iter().filter(|pfd| pfd.revents != 0) {
+            let items: Vec<ConnectionItem> = self.connection
+                .borrow()
+                .watch_handle(pfd.fd, dbus::WatchEvent::from_revents(pfd.revents))
+                .collect();
+
+            for item in items {
+                if let ConnectionItem::MethodCall(ref msg) = item {
+                    if let Some(v) = self.tree.handle(msg) {
+                        // Probably the wisest is to ignore any send errors here -
+                        // maybe the remote has disconnected during our processing.
+                        for m in v {
+                            let _ = self.connection.borrow_mut().send(m);
+                        }
+                    }
+
+                    if let Err(e) = self.process_deferred_actions() {
+                        // There are 2 functions to handle each of these lines in stratisd
+                        // (print_err, log_engine_state) we should relocate them to a library
+                        // if needed in both places
+                        debug!("Engine state: \n{:#?}", &*self.context.engine.borrow());
+                        error!("Client dbus handle: {}", e);
+                    }
+                }
             }
         }
     }
-    Ok(())
-}
-
-pub fn handle(
-    c: &Connection,
-    item: &ConnectionItem,
-    tree: &mut Tree<MTFn<TData>, TData>,
-    dbus_context: &DbusContext,
-) -> Result<(), dbus::Error> {
-    if let ConnectionItem::MethodCall(ref msg) = *item {
-        if let Some(v) = tree.handle(msg) {
-            // Probably the wisest is to ignore any send errors here -
-            // maybe the remote has disconnected during our processing.
-            for m in v {
-                let _ = c.send(m);
-            }
-        }
-
-        process_deferred_actions(c, tree, &mut dbus_context.actions.borrow_mut())?;
-    }
-
-    Ok(())
 }

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -13,6 +13,7 @@ use dbus::tree::{
     Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo, Tree,
 };
 use dbus::{BusType, Connection, ConnectionItem, Message, NameFlag};
+use libc;
 use uuid::Uuid;
 
 use super::super::engine::{Engine, Pool, PoolUuid};

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -13,5 +13,5 @@ mod pool;
 mod types;
 mod util;
 
-pub use self::api::{connect, handle, register_pool, DbusConnectionData};
+pub use self::api::DbusConnectionData;
 pub use self::util::prop_changed_dispatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate uuid;
 #[cfg(feature = "dbus_enabled")]
 extern crate dbus;
 
+extern crate libc;
 extern crate libmount;
 extern crate rand;
 extern crate serde;


### PR DESCRIPTION
This PR adds a commit to #1343, for your consideration. Commit message:

Do not return an error if register_object_path fails

It should never fail -- the only time it should fail is if we attempt to
register a duplicate object path, which should never happen because
object paths include a serial id.

Catching that possibility with a log message (hey, you never know)
results in a series of functions then not needing to return Result,
all the way up to the main event loop, where we can see that handling
dbus events now cannot fail. Cool.
