### PR TITLE
Revert "Revert "Revert "Temporarily allow a Travis failure"""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ language: rust
 
 matrix:
     allow_failures:
-        # Temporarily allow failure until Travis bug is fixed.
-        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
         # Temporarily allow failure until after next release.
         - env: TASK=clippy TARGET=x86_64-unknown-linux-gnu
     include:


### PR DESCRIPTION
This reverts commit 1d61f9a90d18ba5c54cad447abd398f2d3d9c100.

Travis bug is fixed again.