### PR TITLE
Omit some unnecessary dead code annotations

### DIFF
--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -58,8 +58,6 @@ impl EngineListenerList {
     }
 
     /// Add a listener.
-    // This code is marked dead because it is called only by bin/stratisd.rs
-    #[allow(dead_code)]
     pub fn register_listener(&mut self, listener: Box<EngineListener>) {
         self.listeners.push(listener);
     }

--- a/src/engine/strat_engine/names.rs
+++ b/src/engine/strat_engine/names.rs
@@ -65,13 +65,10 @@ impl Display for ThinPoolRole {
 #[derive(Clone, Copy)]
 pub enum CacheRole {
     /// The DM cache device, contains the other three devices.
-    #[allow(dead_code)]
     Cache,
     /// The cache sub-device of the DM cache device.
-    #[allow(dead_code)]
     CacheSub,
     /// The meta sub-device of the DM cache device.
-    #[allow(dead_code)]
     MetaSub,
     /// The origin sub-device of the DM cache device, holds the actual data.
     OriginSub,

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -254,13 +254,11 @@ impl StratFilesystem {
         }
     }
 
-    #[allow(dead_code)]
     pub fn suspend(&mut self, flush: bool) -> StratisResult<()> {
         self.thin_dev.suspend(get_dm(), flush)?;
         Ok(())
     }
 
-    #[allow(dead_code)]
     pub fn resume(&mut self) -> StratisResult<()> {
         self.thin_dev.resume(get_dm())?;
         Ok(())


### PR DESCRIPTION
The code is not actually dead _and_ the compiler can tell this.

Signed-off-by: mulhern <amulhern@redhat.com>