### PR TITLE
Break out thinpool extension policy from extension calculations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ matches = "0.1.8"
 [features]
 default = ["dbus_enabled"]
 dbus_enabled = ["dbus"]
+incremental_policy = []

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -416,6 +416,7 @@ impl Backstore {
     }
 
     /// The current usable size of all the blockdevs in the data tier.
+    #[allow(dead_code)]
     pub fn datatier_usable_size(&self) -> Sectors {
         self.data_tier.usable_size()
     }


### PR DESCRIPTION
Create an ExtensionPolicy trait, to obtain values that may differ between different extension policies (example policies include Greedy (what we have now) vs Incremental (what we had previously.)

The intent is to 1) separate extension policy-specific from general implementation code (e.g. lowater calc math) for clarity and 2) to make it easier for developers to experiment with new policies in a clean way.

This PR right now makes policy choosable at compile-time: default is Greedy, but incremental can be used by compiling with `cargo build --features incremental_policy`. But, the code uses a trait object, as a nod towards being choosable at runtime. @trgill you're the person most likely to work on extension policy, any thoughts on compile vs runtime policy selection being preferable?