### PR TITLE
Expect dbus method register_object_path to always succeed

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -450,7 +450,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                                         )
                                         .1,
                                     &handle.path,
-                                )?;
+                                );
                             }
                         }
                     }
@@ -518,15 +518,12 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                         .borrow()
                         .watch_handle(pfd.fd, WatchEvent::from_revents(pfd.revents))
                     {
-                        if let Err(r) = libstratis::dbus_api::handle(
+                        libstratis::dbus_api::handle(
                             &handle.connection.borrow(),
                             &item,
                             &mut handle.tree,
                             &handle.context,
-                        ) {
-                            log_engine_state(&*engine.borrow());
-                            print_err(&From::from(r));
-                        }
+                        );
                     }
                 }
 
@@ -554,7 +551,7 @@ fn run(matches: &ArgMatches, buff_log: &buff_log::Handle<env_logger::Logger>) ->
                         pool_uuid,
                         pool,
                         &handle.path,
-                    )?;
+                    );
                 }
 
                 // Add dbus FD to fds as dbus is now available.

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -17,7 +17,8 @@ use super::consts;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::{
-    engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, msg_code_ok, msg_string_ok,
+    engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
+    msg_string_ok,
 };
 
 pub fn create_dbus_blockdev<'a>(
@@ -89,11 +90,7 @@ pub fn create_dbus_blockdev<'a>(
         .emits_changed(EmitsChangedSignal::False)
         .on_get(get_blockdev_tier);
 
-    let object_name = format!(
-        "{}/{}",
-        consts::STRATIS_BASE_PATH,
-        dbus_context.get_next_id().to_string()
-    );
+    let object_name = make_object_path(dbus_context);
 
     let object_path = f
         .object_path(object_name, Some(OPContext::new(parent, uuid)))

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -18,7 +18,8 @@ use super::consts;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
 use super::util::{
-    engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, msg_code_ok, msg_string_ok,
+    engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
+    msg_string_ok,
 };
 
 pub fn create_dbus_filesystem<'a>(
@@ -72,11 +73,7 @@ pub fn create_dbus_filesystem<'a>(
         .emits_changed(EmitsChangedSignal::False)
         .on_get(get_filesystem_used);
 
-    let object_name = format!(
-        "{}/{}",
-        consts::STRATIS_BASE_PATH,
-        dbus_context.get_next_id().to_string()
-    );
+    let object_name = make_object_path(dbus_context);
 
     let object_path = f
         .object_path(object_name, Some(OPContext::new(parent, uuid)))

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -24,7 +24,9 @@ use super::consts;
 use super::filesystem::create_dbus_filesystem;
 use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 
-use super::util::{engine_to_dbus_err_tuple, get_next_arg, get_uuid, msg_code_ok, msg_string_ok};
+use super::util::{
+    engine_to_dbus_err_tuple, get_next_arg, get_uuid, make_object_path, msg_code_ok, msg_string_ok,
+};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
@@ -465,11 +467,7 @@ pub fn create_dbus_pool<'a>(
         .emits_changed(EmitsChangedSignal::True)
         .on_get(get_space_state);
 
-    let object_name = format!(
-        "{}/{}",
-        consts::STRATIS_BASE_PATH,
-        dbus_context.get_next_id().to_string()
-    );
+    let object_name = make_object_path(dbus_context);
 
     let object_path = f
         .object_path(object_name, Some(OPContext::new(parent, uuid)))

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -38,6 +38,16 @@ where
     Ok(value)
 }
 
+/// Generate a new object path which is guaranteed unique wrt. all previously
+/// generated object paths.
+pub fn make_object_path(context: &DbusContext) -> String {
+    format!(
+        "{}/{}",
+        consts::STRATIS_BASE_PATH,
+        context.get_next_id().to_string()
+    )
+}
+
 /// Translates an engine error to the (errorcode, string) tuple that Stratis
 /// D-Bus methods return.
 pub fn engine_to_dbus_err_tuple(err: &StratisError) -> (u16, String) {

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -15,7 +15,8 @@ use devicemapper::DmError;
 
 use super::super::stratis::{ErrorEnum, StratisError};
 
-use super::types::{DbusErrorEnum, TData};
+use super::consts;
+use super::types::{DbusContext, DbusErrorEnum, TData};
 
 /// Convert a tuple as option to an Option type
 pub fn tuple_to_option<T>(value: (bool, T)) -> Option<T> {


### PR DESCRIPTION
It must succeed because each new object path generated is guaranteed unique. Abstract object path generation into a separate method, in order to make it more likely that the uniqueness property will continue to hold as the code is maintained.