### PR TITLE
Tighten up computations connected w/ FreeSpaceState

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -635,6 +635,10 @@ impl ThinPool {
 
         self.set_free_space_state(new_state);
 
+        // FreeSpaceState::Warn is never used.
+        assert_ne!(self.free_space_state, FreeSpaceState::Warn);
+        assert_ne!(new_state, FreeSpaceState::Warn);
+
         match (self.free_space_state, new_state) {
             (FreeSpaceState::Good, FreeSpaceState::Crit) => {
                 for (_, _, fs) in &mut self.filesystems {

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -52,7 +52,8 @@ pub enum PoolExtendState {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FreeSpaceState {
     Good = 1,
-    Crit = 2,
+    Warn = 2,
+    Crit = 3,
 }
 
 /// See Design Doc section 10.2.1 for more details.

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -52,8 +52,7 @@ pub enum PoolExtendState {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FreeSpaceState {
     Good = 1,
-    Warn = 2,
-    Crit = 3,
+    Crit = 2,
 }
 
 /// See Design Doc section 10.2.1 for more details.


### PR DESCRIPTION
Tidies up ```free_space_check``` and eliminates a now redundant state from ```FreeSpaceState``` enum.