### PR TITLE
Allow i686 build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ addons:
 language: rust
 
 matrix:
+    allow_failures:
+        # Temporarily allow failure until Travis bug is fixed.
+        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         # Verify formatting of Rust code
         - rust: stable


### PR DESCRIPTION
Another upstream issue.

Signed-off-by: Andy Grover <agrover@redhat.com>