### PR TITLE
Deny all future-incompatible and unused lints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DENY = "-D warnings -D future-incompatible"
+
 TARGET ?= "x86_64-unknown-linux-gnu"
 
 ${HOME}/.cargo/bin/cargo-tree:
@@ -25,25 +27,25 @@ fmt-travis:
 
 build:
 	PKG_CONFIG_ALLOW_CROSS=1 \
-	RUSTFLAGS='-D warnings' \
+	RUSTFLAGS=${DENY} \
 	cargo build --target $(TARGET)
 
 build-no-default:
 	PKG_CONFIG_ALLOW_CROSS=1 \
-	RUSTFLAGS='-D warnings' \
+	RUSTFLAGS=${DENY} \
 	cargo build --no-default-features --target $(TARGET)
 
 test-loop:
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_
+	sudo env "PATH=${PATH}" RUSTFLAGS=${DENY} RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_
 
 test-real:
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test real_
+	sudo env "PATH=${PATH}" RUSTFLAGS=${DENY} RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test real_
 
 test-travis:
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test travis_
+	sudo env "PATH=${PATH}" RUSTFLAGS=${DENY} RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test travis_
 
 test:
-	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_ --skip travis_
+	RUSTFLAGS=${DENY} RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_ --skip travis_
 
 docs: stratisd.8 docs-rust
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible"
+DENY = "-D warnings -D future-incompatible -D unused"
 
 TARGET ?= "x86_64-unknown-linux-gnu"
 

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -15,15 +15,15 @@ use dbus::tree::{
 use dbus::{BusType, Connection, ConnectionItem, Message, NameFlag};
 use libc;
 
-use super::super::engine::{Engine, Pool, PoolUuid};
-use super::super::stratis::VERSION;
+use crate::dbus_api::consts;
+use crate::engine::{Engine, Pool, PoolUuid};
+use crate::stratis::VERSION;
 
-use super::blockdev::create_dbus_blockdev;
-use super::consts;
-use super::filesystem::create_dbus_filesystem;
-use super::pool::create_dbus_pool;
-use super::types::{DbusContext, DbusErrorEnum, DeferredAction, TData};
-use super::util::{
+use crate::dbus_api::blockdev::create_dbus_blockdev;
+use crate::dbus_api::filesystem::create_dbus_filesystem;
+use crate::dbus_api::pool::create_dbus_pool;
+use crate::dbus_api::types::{DbusContext, DbusErrorEnum, DeferredAction, TData};
+use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
 };
 

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -11,12 +11,11 @@ use dbus::Message;
 
 use uuid::Uuid;
 
-use super::super::engine::{BlockDev, BlockDevTier, MaybeDbusPath};
+use crate::dbus_api::consts;
+use crate::engine::{BlockDev, BlockDevTier, MaybeDbusPath};
 
-use super::consts;
-use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
-
-use super::util::{
+use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
+use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
     msg_string_ok,
 };

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -12,12 +12,11 @@ use dbus::Message;
 
 use uuid::Uuid;
 
-use super::super::engine::{filesystem_mount_path, Filesystem, MaybeDbusPath, Name, RenameAction};
+use crate::dbus_api::consts;
+use crate::engine::{filesystem_mount_path, Filesystem, MaybeDbusPath, Name, RenameAction};
 
-use super::consts;
-use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
-
-use super::util::{
+use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
+use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
     msg_string_ok,
 };

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -17,14 +17,13 @@ use uuid::Uuid;
 
 use devicemapper::Sectors;
 
-use super::super::engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction};
+use crate::dbus_api::consts;
+use crate::engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction};
 
-use super::blockdev::create_dbus_blockdev;
-use super::consts;
-use super::filesystem::create_dbus_filesystem;
-use super::types::{DbusContext, DbusErrorEnum, OPContext, TData};
-
-use super::util::{
+use crate::dbus_api::blockdev::create_dbus_blockdev;
+use crate::dbus_api::filesystem::create_dbus_filesystem;
+use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
+use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_uuid, make_object_path, msg_code_ok, msg_string_ok,
 };
 

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -11,7 +11,7 @@ use dbus::Path;
 
 use uuid::Uuid;
 
-use super::super::engine::Engine;
+use crate::engine::Engine;
 
 #[derive(Clone, Copy, Debug)]
 #[allow(non_camel_case_types)]

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -13,10 +13,10 @@ use dbus::SignalArgs;
 
 use devicemapper::DmError;
 
-use super::super::stratis::{ErrorEnum, StratisError};
+use crate::stratis::{ErrorEnum, StratisError};
 
-use super::consts;
-use super::types::{DbusContext, DbusErrorEnum, TData};
+use crate::dbus_api::consts;
+use crate::dbus_api::types::{DbusContext, DbusErrorEnum, TData};
 
 /// Convert a tuple as option to an Option type
 pub fn tuple_to_option<T>(value: (bool, T)) -> Option<T> {

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -8,12 +8,11 @@ use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::{fs, str};
 
-use stratis::StratisResult;
+use crate::engine::Pool;
+use crate::stratis::StratisResult;
 
-use super::super::engine::Pool;
-use super::types::{Name, PoolUuid};
-
-use super::engine::DEV_PATH;
+use crate::engine::engine::DEV_PATH;
+use crate::engine::types::{Name, PoolUuid};
 
 /// Set up the root Stratis directory, where dev links as well as temporary
 /// MDV mounts will be created. This must occur before any pools are setup.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -11,11 +11,13 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Device, Sectors};
 
-use super::types::{
-    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
-    PoolExtendState, PoolState, PoolUuid, RenameAction,
+use crate::engine::{
+    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+    RenameAction,
 };
-use stratis::StratisResult;
+use crate::stratis::StratisResult;
+
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
 
 pub const DEV_PATH: &str = "/stratis";
 

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -5,7 +5,9 @@
 use std::fmt::Debug;
 use std::sync::{Once, ONCE_INIT};
 
-use super::types::{BlockDevState, FreeSpaceState, MaybeDbusPath, PoolExtendState, PoolState};
+use crate::engine::MaybeDbusPath;
+
+use crate::engine::types::{BlockDevState, FreeSpaceState, PoolExtendState, PoolState};
 
 static INIT: Once = ONCE_INIT;
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub use devicemapper::{IEC, SECTOR_SIZE};
-
 pub use self::devlinks::filesystem_mount_path;
 
 pub use self::engine::BlockDev;

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -11,10 +11,9 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC};
 
-use super::super::engine::BlockDev;
-use super::super::types::{BlockDevState, MaybeDbusPath};
+use crate::engine::{BlockDev, BlockDevState, MaybeDbusPath};
 
-use super::randomization::Randomizer;
+use crate::engine::sim_engine::randomization::Randomizer;
 
 #[derive(Debug)]
 /// A simulated device.

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -13,14 +13,14 @@ use std::rc::Rc;
 
 use devicemapper::Device;
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{Engine, Name, Pool, PoolUuid, Redundancy, RenameAction};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::engine::{Engine, Eventable, Pool};
-use super::super::structures::Table;
-use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
+use crate::engine::engine::Eventable;
+use crate::engine::structures::Table;
 
-use super::pool::SimPool;
-use super::randomization::Randomizer;
+use crate::engine::sim_engine::pool::SimPool;
+use crate::engine::sim_engine::randomization::Randomizer;
 
 #[derive(Debug, Default)]
 pub struct SimEngine {
@@ -146,12 +146,10 @@ mod tests {
     use proptest::prelude::any;
     use uuid::Uuid;
 
-    use stratis::{ErrorEnum, StratisError};
+    use crate::engine::{Engine, RenameAction};
+    use crate::stratis::{ErrorEnum, StratisError};
 
-    use super::SimEngine;
-
-    use engine::Engine;
-    use engine::RenameAction;
+    use super::*;
 
     proptest! {
         #[test]

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -10,10 +10,8 @@ use std::path::PathBuf;
 
 use devicemapper::Bytes;
 
-use super::super::engine::Filesystem;
-use super::super::types::MaybeDbusPath;
-
-use stratis::StratisResult;
+use crate::engine::{Filesystem, MaybeDbusPath};
+use crate::stratis::StratisResult;
 
 #[derive(Debug)]
 pub struct SimFilesystem {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -14,18 +14,18 @@ use uuid::Uuid;
 
 use devicemapper::{Sectors, IEC};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
-
-use super::super::engine::{BlockDev, Filesystem, Pool};
-use super::super::structures::Table;
-use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState,
-    PoolState, PoolUuid, Redundancy, RenameAction,
+use crate::engine::{
+    BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
+    PoolUuid, Redundancy, RenameAction,
 };
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::blockdev::SimDev;
-use super::filesystem::SimFilesystem;
-use super::randomization::Randomizer;
+use crate::engine::structures::Table;
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
+
+use crate::engine::sim_engine::blockdev::SimDev;
+use crate::engine::sim_engine::filesystem::SimFilesystem;
+use crate::engine::sim_engine::randomization::Randomizer;
 
 #[derive(Debug)]
 pub struct SimPool {
@@ -320,9 +320,9 @@ mod tests {
 
     use uuid::Uuid;
 
-    use engine::Engine;
+    use crate::engine::Engine;
 
-    use super::super::SimEngine;
+    use crate::engine::sim_engine::SimEngine;
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -12,21 +12,19 @@ use chrono::{DateTime, Utc};
 
 use devicemapper::{CacheDev, Device, DmDevice, LinearDev, Sectors};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
+use crate::engine::strat_engine::backstore::{StratBlockDev, MIN_MDA_SECTORS};
+use crate::engine::strat_engine::device::wipe_sectors;
+use crate::engine::strat_engine::dm::get_dm;
+use crate::engine::strat_engine::names::{format_backstore_ids, CacheRole};
+use crate::engine::strat_engine::serde_structs::{BackstoreSave, CapSave, Recordable};
 
-use super::super::device::wipe_sectors;
-use super::super::dm::get_dm;
-use super::super::names::{format_backstore_ids, CacheRole};
-use super::super::serde_structs::{BackstoreSave, CapSave, Recordable};
-
-use super::blockdev::StratBlockDev;
-use super::blockdevmgr::{map_to_dm, BlockDevMgr};
-use super::cache_tier::CacheTier;
-use super::data_tier::DataTier;
-use super::metadata::MIN_MDA_SECTORS;
-use super::setup::get_blockdevs;
+use crate::engine::strat_engine::backstore::blockdevmgr::{map_to_dm, BlockDevMgr};
+use crate::engine::strat_engine::backstore::cache_tier::CacheTier;
+use crate::engine::strat_engine::backstore::data_tier::DataTier;
+use crate::engine::strat_engine::backstore::setup::get_blockdevs;
 
 /// Use a cache block size that the kernel docs indicate is the largest
 /// typical size.
@@ -575,10 +573,9 @@ mod tests {
 
     use devicemapper::{CacheDevStatus, DataBlocks, IEC};
 
-    use super::super::super::cmd;
-    use super::super::super::tests::{loopbacked, real};
-
-    use super::super::setup::find_all;
+    use crate::engine::strat_engine::backstore::find_all;
+    use crate::engine::strat_engine::cmd;
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -11,16 +11,15 @@ use chrono::{DateTime, TimeZone, Utc};
 
 use devicemapper::{Device, Sectors};
 
-use stratis::StratisResult;
+use crate::engine::{BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath, PoolUuid};
+use crate::stratis::StratisResult;
 
-use super::super::super::engine::BlockDev;
-use super::super::super::event::{get_engine_listener_list, EngineEvent};
-use super::super::super::types::{BlockDevState, DevUuid, MaybeDbusPath, PoolUuid};
+use crate::engine::event::get_engine_listener_list;
 
-use super::super::serde_structs::{BaseBlockDevSave, Recordable};
+use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, Recordable};
 
-use super::metadata::BDA;
-use super::range_alloc::RangeAllocator;
+use crate::engine::strat_engine::backstore::metadata::BDA;
+use crate::engine::strat_engine::backstore::range_alloc::RangeAllocator;
 
 #[derive(Debug)]
 pub struct StratBlockDev {

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -17,18 +17,16 @@ use devicemapper::{
     Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine, IEC,
 };
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{BlockDev, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::engine::BlockDev;
-use super::super::super::types::{DevUuid, PoolUuid};
+use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev, MIN_MDA_SECTORS};
+use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable};
 
-use super::super::serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable};
-
-use super::blockdev::StratBlockDev;
-use super::cleanup::wipe_blockdevs;
-use super::device::{blkdev_size, identify, resolve_devices, DevOwnership};
-use super::metadata::{validate_mda_size, BDA, MIN_MDA_SECTORS};
-use super::util::hw_lookup;
+use crate::engine::strat_engine::backstore::cleanup::wipe_blockdevs;
+use crate::engine::strat_engine::backstore::device::{identify, resolve_devices, DevOwnership};
+use crate::engine::strat_engine::backstore::metadata::{validate_mda_size, BDA};
+use crate::engine::strat_engine::backstore::util::hw_lookup;
 
 const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
 const MAX_NUM_TO_WRITE: usize = 10;
@@ -510,13 +508,12 @@ mod tests {
     use rand;
     use uuid::Uuid;
 
-    use super::super::super::tests::{loopbacked, real};
+    use crate::engine::strat_engine::backstore::{find_all, get_metadata, MIN_MDA_SECTORS};
+    use crate::engine::strat_engine::cmd;
+    use crate::engine::strat_engine::device::wipe_sectors;
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
-    use super::super::metadata::{StaticHeader, MIN_MDA_SECTORS};
-    use super::super::setup::{find_all, get_metadata};
-
-    use super::super::super::cmd;
-    use super::super::super::device::wipe_sectors;
+    use crate::engine::strat_engine::backstore::metadata::StaticHeader;
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -8,14 +8,17 @@ use std::path::Path;
 
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
+use crate::engine::strat_engine::backstore::StratBlockDev;
+use crate::engine::strat_engine::serde_structs::{
+    BaseDevSave, BlockDevSave, CacheTierSave, Recordable,
+};
 
-use super::super::serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable};
-
-use super::blockdev::StratBlockDev;
-use super::blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment};
+use crate::engine::strat_engine::backstore::blockdevmgr::{
+    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
+};
 
 /// This is a temporary maximum cache size. In the future it will be possible
 /// to dynamically increase the cache size beyond this limit. When this is
@@ -234,9 +237,8 @@ mod tests {
 
     use uuid::Uuid;
 
-    use super::super::super::tests::{loopbacked, real};
-
-    use super::super::metadata::MIN_MDA_SECTORS;
+    use crate::engine::strat_engine::backstore::MIN_MDA_SECTORS;
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/cleanup.rs
+++ b/src/engine/strat_engine/backstore/cleanup.rs
@@ -4,9 +4,9 @@
 
 // Code to handle cleanup after a failed operation.
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::blockdev::StratBlockDev;
+use crate::engine::strat_engine::backstore::StratBlockDev;
 
 /// Wipe some blockdevs of their identifying headers.
 /// Return an error if any of the blockdevs could not be wiped.

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -8,14 +8,17 @@ use std::path::Path;
 
 use devicemapper::Sectors;
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
+use crate::engine::strat_engine::backstore::StratBlockDev;
+use crate::engine::strat_engine::serde_structs::{
+    BaseDevSave, BlockDevSave, DataTierSave, Recordable,
+};
 
-use super::super::serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable};
-
-use super::blockdev::StratBlockDev;
-use super::blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment};
+use crate::engine::strat_engine::backstore::blockdevmgr::{
+    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
+};
 
 /// Handles the lowest level, base layer of this tier.
 #[derive(Debug)]
@@ -173,9 +176,8 @@ mod tests {
 
     use uuid::Uuid;
 
-    use super::super::super::tests::{loopbacked, real};
-
-    use super::super::metadata::MIN_MDA_SECTORS;
+    use crate::engine::strat_engine::backstore::MIN_MDA_SECTORS;
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -10,11 +10,12 @@ use std::os::unix::prelude::AsRawFd;
 use std::path::Path;
 
 use devicemapper::{devnode_to_devno, Bytes, Device};
-use stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::types::{DevUuid, PoolUuid};
-use super::metadata::StaticHeader;
-use super::util::get_udev_block_device;
+use crate::engine::{DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+
+use crate::engine::strat_engine::backstore::metadata::StaticHeader;
+use crate::engine::strat_engine::backstore::util::get_udev_block_device;
 
 ioctl_read!(blkgetsize64, 0x12, 114, u64);
 
@@ -139,10 +140,10 @@ pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<(PoolUuid, DevU
 mod test {
     use std::path::Path;
 
-    use super::super::super::cmd;
-    use super::super::super::tests::{loopbacked, real};
+    use crate::engine::strat_engine::cmd;
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
-    use super::super::device;
+    use super::*;
 
     /// Verify that the device is not stratis by creating a device with XFS fs.
     fn test_other_ownership(paths: &[&Path]) {
@@ -150,10 +151,10 @@ mod test {
 
         cmd::udev_settle().unwrap();
 
-        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+        assert_eq!(is_stratis_device(paths[0]).unwrap(), None);
 
-        assert!(match device::identify(paths[0]).unwrap() {
-            device::DevOwnership::Theirs(identity) => {
+        assert!(match identify(paths[0]).unwrap() {
+            DevOwnership::Theirs(identity) => {
                 assert!(identity.contains("ID_FS_USAGE=filesystem"));
                 assert!(identity.contains("ID_FS_TYPE=ext3"));
                 assert!(identity.contains("ID_FS_UUID"));
@@ -167,14 +168,11 @@ mod test {
     fn test_empty(paths: &[&Path]) {
         cmd::udev_settle().unwrap();
 
-        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+        assert_eq!(is_stratis_device(paths[0]).unwrap(), None);
 
-        assert_matches!(
-            device::identify(paths[0]).unwrap(),
-            device::DevOwnership::Unowned
-        );
+        assert_matches!(identify(paths[0]).unwrap(), DevOwnership::Unowned);
 
-        assert_eq!(device::is_stratis_device(paths[0]).unwrap(), None);
+        assert_eq!(is_stratis_device(paths[0]).unwrap(), None);
     }
 
     #[test]

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -13,11 +13,10 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC, SECTOR_SIZE};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::types::{DevUuid, PoolUuid};
-
-use super::super::device::SyncAll;
+use crate::engine::strat_engine::device::SyncAll;
 
 pub use self::mda::{validate_mda_size, MIN_MDA_SECTORS};
 
@@ -440,9 +439,9 @@ mod mda {
 
     use devicemapper::{Bytes, Sectors};
 
-    use stratis::{ErrorEnum, StratisError, StratisResult};
+    use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-    use super::SyncAll;
+    use crate::engine::strat_engine::device::SyncAll;
 
     const _MDA_REGION_HDR_SIZE: usize = 32;
     const MDA_REGION_HDR_SIZE: Bytes = Bytes(_MDA_REGION_HDR_SIZE as u64);

--- a/src/engine/strat_engine/backstore/range_alloc.rs
+++ b/src/engine/strat_engine/backstore/range_alloc.rs
@@ -8,7 +8,7 @@ use std::collections::Bound::{Included, Unbounded};
 
 use devicemapper::Sectors;
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 #[derive(Debug)]
 pub struct RangeAllocator {

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -13,16 +13,14 @@ use serde_json;
 
 use devicemapper::{devnode_to_devno, Device, Sectors};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::types::{BlockDevTier, DevUuid, PoolUuid};
+use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev};
+use crate::engine::strat_engine::serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave};
 
-use super::super::serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave};
-
-use super::blockdev::StratBlockDev;
-use super::device::blkdev_size;
-use super::metadata::{StaticHeader, BDA};
-use super::util::get_stratis_block_devices;
+use crate::engine::strat_engine::backstore::metadata::{StaticHeader, BDA};
+use crate::engine::strat_engine::backstore::util::get_stratis_block_devices;
 
 /// Find all Stratis devices.
 ///

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -9,8 +9,9 @@ use std::path::{Path, PathBuf};
 
 use libudev;
 
-use super::device::is_stratis_device;
-use stratis::StratisResult;
+use crate::stratis::StratisResult;
+
+use crate::engine::strat_engine::backstore::is_stratis_device;
 
 /// Takes a libudev device entry and returns the properties as a HashMap.
 fn device_as_map(device: &libudev::Device) -> HashMap<String, String> {

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -4,11 +4,11 @@
 
 // Code to handle cleanup after a failed operation.
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::structures::Table;
+use crate::engine::structures::Table;
 
-use super::pool::StratPool;
+use crate::engine::strat_engine::pool::StratPool;
 
 /// Teardown pools.
 pub fn teardown_pools(pools: Table<StratPool>) -> StratisResult<()> {

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -20,7 +20,7 @@ use std::process::Command;
 
 use uuid::Uuid;
 
-use stratis::{StratisError, StratisResult};
+use crate::stratis::{StratisError, StratisResult};
 
 /// Find the binary with the given name by looking in likely locations.
 /// Return None if no binary was found.

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
-use stratis::StratisResult;
+use crate::stratis::StratisResult;
 
 /// The SyncAll trait unifies the File type with other types that do
 /// not implement sync_all(). The purpose is to allow testing of methods

--- a/src/engine/strat_engine/dm.rs
+++ b/src/engine/strat_engine/dm.rs
@@ -9,9 +9,9 @@ use std::sync::{Once, ONCE_INIT};
 
 use devicemapper::{DmResult, DM};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::engine::Eventable;
+use crate::engine::engine::Eventable;
 
 static INIT: Once = ONCE_INIT;
 static mut DM_CONTEXT: Option<DmResult<DM>> = None;

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -8,22 +8,22 @@ use std::path::{Path, PathBuf};
 
 use devicemapper::{Device, DmNameBuf};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{
+    devlinks, Engine, EngineEvent, Name, Pool, PoolUuid, Redundancy, RenameAction,
+};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::devlinks;
-use super::super::engine::{Engine, Eventable, Pool};
-use super::super::event::{get_engine_listener_list, EngineEvent};
-use super::super::structures::Table;
-use super::super::types::{Name, PoolUuid, Redundancy, RenameAction};
+use crate::engine::engine::Eventable;
+use crate::engine::event::get_engine_listener_list;
+use crate::engine::structures::Table;
 
-use super::backstore::device::is_stratis_device;
-use super::backstore::{find_all, get_metadata};
+use crate::engine::strat_engine::backstore::{find_all, get_metadata, is_stratis_device};
 #[cfg(test)]
-use super::cleanup::teardown_pools;
-use super::cmd::verify_binaries;
-use super::dm::{get_dm, get_dm_init};
-use super::names::validate_name;
-use super::pool::{check_metadata, StratPool};
+use crate::engine::strat_engine::cleanup::teardown_pools;
+use crate::engine::strat_engine::cmd::verify_binaries;
+use crate::engine::strat_engine::dm::{get_dm, get_dm_init};
+use crate::engine::strat_engine::names::validate_name;
+use crate::engine::strat_engine::pool::{check_metadata, StratPool};
 
 const REQUIRED_DM_MINOR_VERSION: u32 = 37;
 
@@ -372,9 +372,9 @@ impl Engine for StratEngine {
 mod test {
     use std::fs::remove_dir_all;
 
-    use engine::engine::DEV_PATH;
+    use crate::engine::engine::DEV_PATH;
 
-    use super::super::tests::{loopbacked, real};
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
     use super::*;
 

--- a/src/engine/strat_engine/names.rs
+++ b/src/engine/strat_engine/names.rs
@@ -10,9 +10,8 @@ use std::path::Path;
 
 use devicemapper::{DmNameBuf, DmUuidBuf};
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
-
-use super::super::super::engine::{FilesystemUuid, PoolUuid};
+use crate::engine::{FilesystemUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 const FORMAT_VERSION: u16 = 1;
 
@@ -237,7 +236,7 @@ pub fn validate_name(name: &str) -> StratisResult<()> {
 #[cfg(test)]
 mod tests {
 
-    use engine::strat_engine::names::validate_name;
+    use super::*;
 
     #[test]
     #[allow(clippy::cyclomatic_complexity)]

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -12,17 +12,18 @@ use uuid::Uuid;
 
 use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
-use super::super::engine::{BlockDev, Filesystem, Pool};
-use super::super::types::{
-    BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState,
-    PoolState, PoolUuid, Redundancy, RenameAction,
+use crate::engine::{
+    BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
+    PoolUuid, Redundancy, RenameAction,
 };
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS};
-use super::names::validate_name;
-use super::serde_structs::{FlexDevsSave, PoolSave, Recordable};
-use super::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
+
+use crate::engine::strat_engine::backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS};
+use crate::engine::strat_engine::names::validate_name;
+use crate::engine::strat_engine::serde_structs::{FlexDevsSave, PoolSave, Recordable};
+use crate::engine::strat_engine::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
 
 /// Get the index which indicates the start of unallocated space in the cap
 /// device.
@@ -485,12 +486,12 @@ mod tests {
 
     use devicemapper::{Bytes, IEC, SECTOR_SIZE};
 
-    use super::super::super::devlinks;
-    use super::super::super::types::Redundancy;
+    use crate::engine::devlinks;
+    use crate::engine::types::Redundancy;
 
-    use super::super::backstore::{find_all, get_metadata};
-    use super::super::cmd;
-    use super::super::tests::{loopbacked, real};
+    use crate::engine::strat_engine::backstore::{find_all, get_metadata};
+    use crate::engine::strat_engine::cmd;
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
     use super::*;
 

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 use devicemapper::{Sectors, ThinDevId};
 
-use super::super::types::{DevUuid, FilesystemUuid};
+use crate::engine::{DevUuid, FilesystemUuid};
 
 /// Implements saving struct data to a serializable form. The form should be
 /// sufficient, in conjunction with the environment, to reconstruct the

--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -16,8 +16,8 @@ use devicemapper::{Bytes, Sectors, IEC};
 
 use self::loopdev::{LoopControl, LoopDevice};
 
-use super::logger::init_logger;
-use super::util::clean_up;
+use crate::engine::strat_engine::tests::logger::init_logger;
+use crate::engine::strat_engine::tests::util::clean_up;
 
 /// Ways of specifying range of numbers of devices to use for tests.
 /// Unlike real tests, there is no AtLeast constructor, as, at least in theory

--- a/src/engine/strat_engine/tests/mod.rs
+++ b/src/engine/strat_engine/tests/mod.rs
@@ -2,9 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate env_logger;
-extern crate log;
-
 mod logger;
 pub mod loopbacked;
 pub mod real;

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -17,12 +17,12 @@ use devicemapper::{
     LinearTargetParams, Sectors, TargetLine, IEC,
 };
 
-use super::super::backstore::blkdev_size;
-use super::super::device::wipe_sectors;
-use super::super::dm::get_dm;
+use crate::engine::strat_engine::backstore::blkdev_size;
+use crate::engine::strat_engine::device::wipe_sectors;
+use crate::engine::strat_engine::dm::get_dm;
 
-use super::logger::init_logger;
-use super::util::clean_up;
+use crate::engine::strat_engine::tests::logger::init_logger;
+use crate::engine::strat_engine::tests::util::clean_up;
 
 pub struct RealTestDev {
     dev: Either<PathBuf, LinearDev>,

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -11,8 +11,8 @@ use nix::mount::{umount2, MntFlags};
 
 use devicemapper::{DevId, DmOptions};
 
-use super::super::cmd;
-use super::super::dm::{get_dm, get_dm_init};
+use crate::engine::strat_engine::cmd;
+use crate::engine::strat_engine::dm::{get_dm, get_dm_init};
 
 mod cleanup_errors {
     use libmount;

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -20,16 +20,16 @@ use nix::mount::{mount, umount, MsFlags};
 use nix::sys::statvfs::statvfs;
 use tempfile;
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::engine::{Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::super::engine::Filesystem;
-use super::super::super::types::{FilesystemUuid, MaybeDbusPath, Name, PoolUuid};
+use crate::engine::strat_engine::cmd::{create_fs, set_uuid, udev_settle, xfs_growfs};
+use crate::engine::strat_engine::dm::get_dm;
+use crate::engine::strat_engine::names::{format_thin_ids, ThinRole};
+use crate::engine::strat_engine::serde_structs::FilesystemSave;
+use crate::engine::strat_engine::thinpool::DATA_BLOCK_SIZE;
 
-use super::super::cmd::{create_fs, set_uuid, udev_settle, xfs_growfs};
-use super::super::dm::get_dm;
-use super::super::names::{format_thin_ids, ThinRole};
-use super::super::serde_structs::FilesystemSave;
-use super::thinpool::{DATA_BLOCK_SIZE, DATA_LOWATER};
+use crate::engine::strat_engine::thinpool::thinpool::DATA_LOWATER;
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -16,16 +16,15 @@ use serde_json;
 
 use devicemapper::{DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
 
-use stratis::StratisResult;
+use crate::engine::{FilesystemUuid, Name, PoolUuid};
+use crate::stratis::StratisResult;
 
-use super::super::super::engine::DEV_PATH;
-use super::super::super::types::{FilesystemUuid, Name, PoolUuid};
+use crate::engine::engine::DEV_PATH;
+use crate::engine::strat_engine::cmd::create_fs;
+use crate::engine::strat_engine::dm::get_dm;
+use crate::engine::strat_engine::serde_structs::FilesystemSave;
 
-use super::super::cmd::create_fs;
-use super::super::dm::get_dm;
-use super::super::serde_structs::FilesystemSave;
-
-use super::filesystem::StratFilesystem;
+use crate::engine::strat_engine::thinpool::filesystem::StratFilesystem;
 
 // TODO: Monitor fs size and extend linear and fs if needed
 // TODO: Document format of stuff on MDV in SWDD (currently ad-hoc)

--- a/src/engine/strat_engine/thinpool/thinids.rs
+++ b/src/engine/strat_engine/thinpool/thinids.rs
@@ -6,7 +6,7 @@
 
 use devicemapper::ThinDevId;
 
-use stratis::StratisResult;
+use crate::stratis::StratisResult;
 
 #[derive(Debug)]
 /// A pool of thindev ids, all unique.

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -15,29 +15,29 @@ use devicemapper::{
     ThinPoolDev, ThinPoolStatus, ThinPoolStatusSummary, IEC,
 };
 
-use stratis::{ErrorEnum, StratisError, StratisResult};
-
-use super::super::super::devlinks;
-use super::super::super::engine::Filesystem;
-use super::super::super::event::{get_engine_listener_list, EngineEvent};
-use super::super::super::structures::Table;
-use super::super::super::types::{
-    FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState, PoolUuid,
-    RenameAction,
+use crate::engine::{
+    devlinks, EngineEvent, Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, RenameAction,
 };
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
-use super::super::backstore::Backstore;
-use super::super::cmd::{thin_check, thin_repair};
-use super::super::device::wipe_sectors;
-use super::super::dm::get_dm;
-use super::super::names::{
+use crate::engine::event::get_engine_listener_list;
+use crate::engine::structures::Table;
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
+
+use crate::engine::strat_engine::backstore::Backstore;
+use crate::engine::strat_engine::cmd::{thin_check, thin_repair};
+use crate::engine::strat_engine::device::wipe_sectors;
+use crate::engine::strat_engine::dm::get_dm;
+use crate::engine::strat_engine::names::{
     format_flex_ids, format_thin_ids, format_thinpool_ids, FlexRole, ThinPoolRole, ThinRole,
 };
-use super::super::serde_structs::{FlexDevsSave, Recordable, ThinPoolDevSave};
+use crate::engine::strat_engine::serde_structs::{FlexDevsSave, Recordable, ThinPoolDevSave};
 
-use super::filesystem::{fs_settle, FilesystemStatus, StratFilesystem};
-use super::mdv::MetadataVol;
-use super::thinids::ThinDevIdPool;
+use crate::engine::strat_engine::thinpool::filesystem::{
+    fs_settle, FilesystemStatus, StratFilesystem,
+};
+use crate::engine::strat_engine::thinpool::mdv::MetadataVol;
+use crate::engine::strat_engine::thinpool::thinids::ThinDevIdPool;
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
 pub const DATA_LOWATER: DataBlocks = DataBlocks(2048); // 2 GiB
@@ -1204,12 +1204,12 @@ mod tests {
 
     use devicemapper::{Bytes, SECTOR_SIZE};
 
-    use super::super::super::backstore::MIN_MDA_SECTORS;
-    use super::super::super::cmd;
-    use super::super::super::device::SyncAll;
-    use super::super::super::tests::{loopbacked, real};
+    use crate::engine::strat_engine::backstore::MIN_MDA_SECTORS;
+    use crate::engine::strat_engine::cmd;
+    use crate::engine::strat_engine::device::SyncAll;
+    use crate::engine::strat_engine::tests::{loopbacked, real};
 
-    use super::super::filesystem::{fs_usage, FILESYSTEM_LOWATER};
+    use crate::engine::strat_engine::thinpool::filesystem::{fs_usage, FILESYSTEM_LOWATER};
 
     use super::*;
 

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -8,7 +8,7 @@ use std::iter::IntoIterator;
 
 use uuid::Uuid;
 
-use engine::Name;
+use crate::engine::types::Name;
 
 /// Map UUID and name to T items.
 pub struct Table<T> {
@@ -268,9 +268,9 @@ mod tests {
     use rand;
     use uuid::Uuid;
 
-    use engine::Name;
+    use crate::engine::Name;
 
-    use super::Table;
+    use super::*;
 
     #[derive(Debug)]
     struct TestThing {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate uuid;
 #[cfg(feature = "dbus_enabled")]
 extern crate dbus;
 
+#[cfg(feature = "dbus_enabled")]
 extern crate libc;
 extern crate libmount;
 extern crate rand;


### PR DESCRIPTION
The basic motivation is to ensure future compatibility.
The only interesting lint is the one that forbids floating imports.
This PR changes the imports so that absolute imports are used everywhere, except when importing the names in a module being tested from a test module.

Nested imports were considered but rejected at least for now. In themselves, they look like a very desirable change; they seem a good deal clearer than line-by-line imports. However, there needs to be considered the cost of making the change and also rustfmt's handling of nested imports. rustfmt can convert to nested imports but at this time only on nightly. Currently, the conversion mechanism is under discussion and may change. There is no external auto-conversion mechanism that I can find. Doing the conversion by hand would be so time-consuming as to be practically morally wrong. Writing one's own converter would take time, and rustfmt's would eventually supercede it anyway. The option of using nightly version of rustfmt to do the conversion and then using stable version of rustfmt to format the already converted code seems a bit risky, due to the instability of the conversion in rustfmt. It may look better as the conversion stabilizes.

Supercedes #1400.

