### PR TITLE
Rework Backstore::request()

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -414,20 +414,21 @@ impl Backstore {
             return Ok(None);
         }
 
-        let available_in_cap = self.available_in_cap();
-        if available_in_cap >= internal_request {
+        if self.available_in_cap() >= internal_request {
             self.next += internal_request;
             Ok(Some((self.next - internal_request, internal_request)))
         } else {
             let available_in_data_tier = self.data_tier.usable_size() - self.data_tier.allocated();
-            let datatier_request =
-                cmp::min(internal_request - available_in_cap, available_in_data_tier);
+            let datatier_request = cmp::min(
+                internal_request - self.available_in_cap(),
+                available_in_data_tier,
+            );
             if datatier_request == Sectors(0) {
                 // Sorry, datatier is full. Partial return solely from cap?
-                if available_in_cap < modulus {
+                if self.available_in_cap() < modulus {
                     Ok(None)
                 } else {
-                    let return_amt = align_down(available_in_cap, modulus);
+                    let return_amt = align_down(self.available_in_cap(), modulus);
                     self.next += return_amt;
                     Ok(Some((self.next - return_amt, return_amt)))
                 }

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -419,7 +419,7 @@ impl Backstore {
             self.next += internal_request;
             Ok(Some((self.next - internal_request, internal_request)))
         } else {
-            let available_in_data_tier = self.available_in_backstore() - available_in_cap;
+            let available_in_data_tier = self.data_tier.usable_size() - self.data_tier.allocated();
             let datatier_request =
                 cmp::min(internal_request - available_in_cap, available_in_data_tier);
             if datatier_request == Sectors(0) {

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -96,7 +96,6 @@ impl DataTier {
 
     /// The sum of the lengths of all the sectors that have been mapped to an
     /// upper device.
-    #[cfg(test)]
     pub fn allocated(&self) -> Sectors {
         self.segments
             .iter()


### PR DESCRIPTION
Do a few things:

Replace an algorithm that loops to discover how much of the data tier
that can be allocated with one that just asks how much space is available
and then modifies the single param to alloc() based on what's available.

Align the request UP to a multiple of the modulus instead of down. This
avoids issues where percentage-based requests fall short by some small
number of sectors and then try in vain repeatedly to get the difference
but keep failing.

Align the sectors allocated DOWN to a multiple of the modulus. This is
needed because cap extensions are *not* necessarily aligned to the
modulus, such as when there are a small number of unused sectors in the
cap already, or if remaining free sectors in data_tier is small.

Implement align_up() and align_down() as helper functions, with tests,
since this stuff is a little tricky, and maybe we will find other spots
in the future that need aligning.

Signed-off-by: Andy Grover <agrover@redhat.com>