### PR TITLE
Set fast-finish to true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
 language: rust
 
 matrix:
+    fast-finish: true
     allow_failures:
         # Temporarily allow failure until Travis bug is fixed.
         - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/


### PR DESCRIPTION
Build is marked as finished as soon as all required tasks complete, i.e.,
the allowed failures are not waited for.

Signed-off-by: mulhern <amulhern@redhat.com>