### PR TITLE
Use merged imports

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -7,24 +7,30 @@
 #[macro_use]
 extern crate log;
 
-use std::cell::RefCell;
-use std::env;
-use std::fs::{File, OpenOptions};
-use std::io::{ErrorKind, Read, Write};
-use std::os::unix::io::{AsRawFd, RawFd};
-use std::path::PathBuf;
-use std::process::exit;
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    env,
+    fs::{File, OpenOptions},
+    io::{ErrorKind, Read, Write},
+    os::unix::io::{AsRawFd, RawFd},
+    path::PathBuf,
+    process::exit,
+    rc::Rc,
+};
 
 use chrono::Duration;
 use clap::{App, Arg, ArgMatches};
 use env_logger::Builder;
 use libc::pid_t;
 use log::LevelFilter;
-use nix::fcntl::{flock, FlockArg};
-use nix::sys::signal::{self, SigSet};
-use nix::sys::signalfd::{SfdFlags, SignalFd};
-use nix::unistd::getpid;
+use nix::{
+    fcntl::{flock, FlockArg},
+    sys::{
+        signal::{self, SigSet},
+        signalfd::{SfdFlags, SignalFd},
+    },
+    unistd::getpid,
+};
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
 use uuid::Uuid;
 
@@ -38,9 +44,10 @@ use libstratis::dbus_api::{consts, prop_changed_dispatch, DbusConnectionData};
 use libstratis::engine::{
     get_engine_listener_list_mut, EngineEvent, EngineListener, MaybeDbusPath,
 };
-use libstratis::engine::{Engine, Pool, SimEngine, StratEngine};
-use libstratis::stratis::buff_log;
-use libstratis::stratis::{StratisError, StratisResult, VERSION};
+use libstratis::{
+    engine::{Engine, Pool, SimEngine, StratEngine},
+    stratis::{buff_log, StratisError, StratisResult, VERSION},
+};
 
 const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -38,12 +38,13 @@ use uuid::Uuid;
 use dbus::Connection;
 
 use devicemapper::Device;
+
 #[cfg(feature = "dbus_enabled")]
-use libstratis::dbus_api::{consts, prop_changed_dispatch, DbusConnectionData};
-#[cfg(feature = "dbus_enabled")]
-use libstratis::engine::{
-    get_engine_listener_list_mut, EngineEvent, EngineListener, MaybeDbusPath,
+use libstratis::{
+    dbus_api::{consts, prop_changed_dispatch, DbusConnectionData},
+    engine::{get_engine_listener_list_mut, EngineEvent, EngineListener, MaybeDbusPath},
 };
+
 use libstratis::{
     engine::{Engine, Pool, SimEngine, StratEngine},
     stratis::{buff_log, StratisError, StratisResult, VERSION},

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -15,17 +15,16 @@ use dbus::tree::{
 use dbus::{BusType, Connection, ConnectionItem, Message, NameFlag};
 use libc;
 
-use crate::dbus_api::consts;
-use crate::engine::{Engine, Pool, PoolUuid};
-use crate::stratis::VERSION;
-
 use crate::dbus_api::blockdev::create_dbus_blockdev;
+use crate::dbus_api::consts;
 use crate::dbus_api::filesystem::create_dbus_filesystem;
 use crate::dbus_api::pool::create_dbus_pool;
 use crate::dbus_api::types::{DbusContext, DbusErrorEnum, DeferredAction, TData};
 use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
 };
+use crate::engine::{Engine, Pool, PoolUuid};
+use crate::stratis::VERSION;
 
 fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -2,29 +2,33 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cell::RefCell;
-use std::path::Path;
-use std::rc::Rc;
-use std::vec::Vec;
+use std::{cell::RefCell, path::Path, rc::Rc, vec::Vec};
 
-use dbus;
-use dbus::arg::{Array, IterAppend};
-use dbus::tree::{
-    Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo, Tree,
+use dbus::{
+    self,
+    arg::{Array, IterAppend},
+    tree::{
+        Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+        Tree,
+    },
+    BusType, Connection, ConnectionItem, Message, NameFlag,
 };
-use dbus::{BusType, Connection, ConnectionItem, Message, NameFlag};
 use libc;
 
-use crate::dbus_api::blockdev::create_dbus_blockdev;
-use crate::dbus_api::consts;
-use crate::dbus_api::filesystem::create_dbus_filesystem;
-use crate::dbus_api::pool::create_dbus_pool;
-use crate::dbus_api::types::{DbusContext, DbusErrorEnum, DeferredAction, TData};
-use crate::dbus_api::util::{
-    engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
+use crate::{
+    dbus_api::{
+        blockdev::create_dbus_blockdev,
+        consts,
+        filesystem::create_dbus_filesystem,
+        pool::create_dbus_pool,
+        types::{DbusContext, DbusErrorEnum, DeferredAction, TData},
+        util::{
+            engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
+        },
+    },
+    engine::{Engine, Pool, PoolUuid},
+    stratis::VERSION,
 };
-use crate::engine::{Engine, Pool, PoolUuid};
-use crate::stratis::VERSION;
 
 fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -2,22 +2,28 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use dbus;
-use dbus::arg::IterAppend;
-use dbus::tree::{
-    Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+use dbus::{
+    self,
+    arg::IterAppend,
+    tree::{
+        Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+    },
+    Message,
 };
-use dbus::Message;
 
 use uuid::Uuid;
 
-use crate::dbus_api::consts;
-use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
-use crate::dbus_api::util::{
-    engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
-    msg_string_ok,
+use crate::{
+    dbus_api::{
+        consts,
+        types::{DbusContext, DbusErrorEnum, OPContext, TData},
+        util::{
+            engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path,
+            msg_code_ok, msg_string_ok,
+        },
+    },
+    engine::{BlockDev, BlockDevTier, MaybeDbusPath},
 };
-use crate::engine::{BlockDev, BlockDevTier, MaybeDbusPath};
 
 pub fn create_dbus_blockdev<'a>(
     dbus_context: &DbusContext,

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -12,13 +12,12 @@ use dbus::Message;
 use uuid::Uuid;
 
 use crate::dbus_api::consts;
-use crate::engine::{BlockDev, BlockDevTier, MaybeDbusPath};
-
 use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
     msg_string_ok,
 };
+use crate::engine::{BlockDev, BlockDevTier, MaybeDbusPath};
 
 pub fn create_dbus_blockdev<'a>(
     dbus_context: &DbusContext,

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -13,13 +13,12 @@ use dbus::Message;
 use uuid::Uuid;
 
 use crate::dbus_api::consts;
-use crate::engine::{filesystem_mount_path, Filesystem, MaybeDbusPath, Name, RenameAction};
-
 use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
     msg_string_ok,
 };
+use crate::engine::{filesystem_mount_path, Filesystem, MaybeDbusPath, Name, RenameAction};
 
 pub fn create_dbus_filesystem<'a>(
     dbus_context: &DbusContext,

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -3,22 +3,28 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use chrono::SecondsFormat;
-use dbus;
-use dbus::arg::IterAppend;
-use dbus::tree::{
-    Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+use dbus::{
+    self,
+    arg::IterAppend,
+    tree::{
+        Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+    },
+    Message,
 };
-use dbus::Message;
 
 use uuid::Uuid;
 
-use crate::dbus_api::consts;
-use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
-use crate::dbus_api::util::{
-    engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path, msg_code_ok,
-    msg_string_ok,
+use crate::{
+    dbus_api::{
+        consts,
+        types::{DbusContext, DbusErrorEnum, OPContext, TData},
+        util::{
+            engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path,
+            msg_code_ok, msg_string_ok,
+        },
+    },
+    engine::{filesystem_mount_path, Filesystem, MaybeDbusPath, Name, RenameAction},
 };
-use crate::engine::{filesystem_mount_path, Filesystem, MaybeDbusPath, Name, RenameAction};
 
 pub fn create_dbus_filesystem<'a>(
     dbus_context: &DbusContext,

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -13,5 +13,4 @@ mod pool;
 mod types;
 mod util;
 
-pub use self::api::DbusConnectionData;
-pub use self::util::prop_changed_dispatch;
+pub use self::{api::DbusConnectionData, util::prop_changed_dispatch};

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -17,15 +17,14 @@ use uuid::Uuid;
 
 use devicemapper::Sectors;
 
-use crate::dbus_api::consts;
-use crate::engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction};
-
 use crate::dbus_api::blockdev::create_dbus_blockdev;
+use crate::dbus_api::consts;
 use crate::dbus_api::filesystem::create_dbus_filesystem;
 use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
 use crate::dbus_api::util::{
     engine_to_dbus_err_tuple, get_next_arg, get_uuid, make_object_path, msg_code_ok, msg_string_ok,
 };
+use crate::engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -2,29 +2,34 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::collections::HashMap;
-use std::path::Path;
-use std::vec::Vec;
+use std::{collections::HashMap, path::Path, vec::Vec};
 
-use dbus;
-use dbus::arg::{Array, IterAppend};
-use dbus::tree::{
-    Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+use dbus::{
+    self,
+    arg::{Array, IterAppend},
+    tree::{
+        Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+    },
+    Message,
 };
-use dbus::Message;
 
 use uuid::Uuid;
 
 use devicemapper::Sectors;
 
-use crate::dbus_api::blockdev::create_dbus_blockdev;
-use crate::dbus_api::consts;
-use crate::dbus_api::filesystem::create_dbus_filesystem;
-use crate::dbus_api::types::{DbusContext, DbusErrorEnum, OPContext, TData};
-use crate::dbus_api::util::{
-    engine_to_dbus_err_tuple, get_next_arg, get_uuid, make_object_path, msg_code_ok, msg_string_ok,
+use crate::{
+    dbus_api::{
+        blockdev::create_dbus_blockdev,
+        consts,
+        filesystem::create_dbus_filesystem,
+        types::{DbusContext, DbusErrorEnum, OPContext, TData},
+        util::{
+            engine_to_dbus_err_tuple, get_next_arg, get_uuid, make_object_path, msg_code_ok,
+            msg_string_ok,
+        },
+    },
+    engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction},
 };
-use crate::engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction};
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -2,12 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cell::{Cell, RefCell};
-use std::collections::vec_deque::{Drain, VecDeque};
-use std::rc::Rc;
+use std::{
+    cell::{Cell, RefCell},
+    collections::vec_deque::{Drain, VecDeque},
+    rc::Rc,
+};
 
-use dbus::tree::{DataType, MTFn, ObjectPath, Tree};
-use dbus::Path;
+use dbus::{
+    tree::{DataType, MTFn, ObjectPath, Tree},
+    Path,
+};
 
 use uuid::Uuid;
 

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -13,10 +13,9 @@ use dbus::SignalArgs;
 
 use devicemapper::DmError;
 
-use crate::stratis::{ErrorEnum, StratisError};
-
 use crate::dbus_api::consts;
 use crate::dbus_api::types::{DbusContext, DbusErrorEnum, TData};
+use crate::stratis::{ErrorEnum, StratisError};
 
 /// Convert a tuple as option to an Option type
 pub fn tuple_to_option<T>(value: (bool, T)) -> Option<T> {

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -4,18 +4,23 @@
 
 use std::error::Error;
 
-use dbus;
-use dbus::arg::{ArgType, Iter, IterAppend, RefArg, Variant};
-use dbus::stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged;
-use dbus::tree::{MTFn, MethodErr, PropInfo};
-use dbus::Connection;
-use dbus::SignalArgs;
+use dbus::{
+    self,
+    arg::{ArgType, Iter, IterAppend, RefArg, Variant},
+    stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged,
+    tree::{MTFn, MethodErr, PropInfo},
+    Connection, SignalArgs,
+};
 
 use devicemapper::DmError;
 
-use crate::dbus_api::consts;
-use crate::dbus_api::types::{DbusContext, DbusErrorEnum, TData};
-use crate::stratis::{ErrorEnum, StratisError};
+use crate::{
+    dbus_api::{
+        consts,
+        types::{DbusContext, DbusErrorEnum, TData},
+    },
+    stratis::{ErrorEnum, StratisError},
+};
 
 /// Convert a tuple as option to an Option type
 pub fn tuple_to_option<T>(value: (bool, T)) -> Option<T> {

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -2,16 +2,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::collections::HashSet;
-use std::io::ErrorKind;
-use std::os::unix::fs::symlink;
-use std::path::{Path, PathBuf};
-use std::{fs, str};
+use std::{
+    collections::HashSet,
+    fs,
+    io::ErrorKind,
+    os::unix::fs::symlink,
+    path::{Path, PathBuf},
+    str,
+};
 
-use crate::engine::engine::DEV_PATH;
-use crate::engine::types::{Name, PoolUuid};
-use crate::engine::Pool;
-use crate::stratis::StratisResult;
+use crate::{
+    engine::{
+        engine::DEV_PATH,
+        types::{Name, PoolUuid},
+        Pool,
+    },
+    stratis::StratisResult,
+};
 
 /// Set up the root Stratis directory, where dev links as well as temporary
 /// MDV mounts will be created. This must occur before any pools are setup.

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -8,11 +8,10 @@ use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::{fs, str};
 
-use crate::engine::Pool;
-use crate::stratis::StratisResult;
-
 use crate::engine::engine::DEV_PATH;
 use crate::engine::types::{Name, PoolUuid};
+use crate::engine::Pool;
+use crate::stratis::StratisResult;
 
 /// Set up the root Stratis directory, where dev links as well as temporary
 /// MDV mounts will be created. This must occur before any pools are setup.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -11,13 +11,12 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Device, Sectors};
 
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
 use crate::engine::{
     BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
     RenameAction,
 };
 use crate::stratis::StratisResult;
-
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
 
 pub const DEV_PATH: &str = "/stratis";
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -2,21 +2,25 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fmt::Debug;
-use std::os::unix::io::RawFd;
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Debug,
+    os::unix::io::RawFd,
+    path::{Path, PathBuf},
+};
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use devicemapper::{Bytes, Device, Sectors};
 
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
-use crate::engine::{
-    BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
-    RenameAction,
+use crate::{
+    engine::{
+        types::{FreeSpaceState, PoolExtendState, PoolState},
+        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+        RenameAction,
+    },
+    stratis::StratisResult,
 };
-use crate::stratis::StratisResult;
 
 pub const DEV_PATH: &str = "/stratis";
 

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -2,11 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fmt::Debug;
-use std::sync::{Once, ONCE_INIT};
+use std::{
+    fmt::Debug,
+    sync::{Once, ONCE_INIT},
+};
 
-use crate::engine::types::{BlockDevState, FreeSpaceState, PoolExtendState, PoolState};
-use crate::engine::MaybeDbusPath;
+use crate::engine::{
+    types::{BlockDevState, FreeSpaceState, PoolExtendState, PoolState},
+    MaybeDbusPath,
+};
 
 static INIT: Once = ONCE_INIT;
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -5,9 +5,8 @@
 use std::fmt::Debug;
 use std::sync::{Once, ONCE_INIT};
 
-use crate::engine::MaybeDbusPath;
-
 use crate::engine::types::{BlockDevState, FreeSpaceState, PoolExtendState, PoolState};
+use crate::engine::MaybeDbusPath;
 
 static INIT: Once = ONCE_INIT;
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2,23 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub use self::devlinks::filesystem_mount_path;
-pub use self::engine::BlockDev;
-pub use self::engine::Engine;
-pub use self::engine::Filesystem;
-pub use self::engine::Pool;
-pub use self::event::{get_engine_listener_list_mut, EngineEvent, EngineListener};
-pub use self::sim_engine::SimEngine;
-pub use self::strat_engine::StratEngine;
-pub use self::types::BlockDevState;
-pub use self::types::BlockDevTier;
-pub use self::types::DevUuid;
-pub use self::types::FilesystemUuid;
-pub use self::types::MaybeDbusPath;
-pub use self::types::Name;
-pub use self::types::PoolUuid;
-pub use self::types::Redundancy;
-pub use self::types::RenameAction;
+pub use self::{
+    devlinks::filesystem_mount_path,
+    engine::{BlockDev, Engine, Filesystem, Pool},
+    event::{get_engine_listener_list_mut, EngineEvent, EngineListener},
+    sim_engine::SimEngine,
+    strat_engine::StratEngine,
+    types::{
+        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+        Redundancy, RenameAction,
+    },
+};
 
 #[macro_use]
 mod macros;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,17 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub use self::devlinks::filesystem_mount_path;
-
 pub use self::engine::BlockDev;
 pub use self::engine::Engine;
 pub use self::engine::Filesystem;
 pub use self::engine::Pool;
-
 pub use self::event::{get_engine_listener_list_mut, EngineEvent, EngineListener};
-
 pub use self::sim_engine::SimEngine;
 pub use self::strat_engine::StratEngine;
-
 pub use self::types::BlockDevState;
 pub use self::types::BlockDevTier;
 pub use self::types::DevUuid;

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -2,17 +2,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cell::RefCell;
-use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 use chrono::{DateTime, TimeZone, Utc};
 use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC};
 
-use crate::engine::sim_engine::randomization::Randomizer;
-use crate::engine::{BlockDev, BlockDevState, MaybeDbusPath};
+use crate::engine::{
+    sim_engine::randomization::Randomizer, BlockDev, BlockDevState, MaybeDbusPath,
+};
 
 #[derive(Debug)]
 /// A simulated device.

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -11,9 +11,8 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC};
 
-use crate::engine::{BlockDev, BlockDevState, MaybeDbusPath};
-
 use crate::engine::sim_engine::randomization::Randomizer;
+use crate::engine::{BlockDev, BlockDevState, MaybeDbusPath};
 
 #[derive(Debug)]
 /// A simulated device.

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -11,14 +11,12 @@ use std::rc::Rc;
 
 use devicemapper::Device;
 
-use crate::engine::{Engine, Name, Pool, PoolUuid, Redundancy, RenameAction};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
 use crate::engine::engine::Eventable;
-use crate::engine::structures::Table;
-
 use crate::engine::sim_engine::pool::SimPool;
 use crate::engine::sim_engine::randomization::Randomizer;
+use crate::engine::structures::Table;
+use crate::engine::{Engine, Name, Pool, PoolUuid, Redundancy, RenameAction};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 #[derive(Debug, Default)]
 pub struct SimEngine {

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -2,21 +2,25 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cell::RefCell;
-use std::collections::hash_map::RandomState;
-use std::collections::HashSet;
-use std::iter::FromIterator;
-use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::{hash_map::RandomState, HashSet},
+    iter::FromIterator,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 use devicemapper::Device;
 
-use crate::engine::engine::Eventable;
-use crate::engine::sim_engine::pool::SimPool;
-use crate::engine::sim_engine::randomization::Randomizer;
-use crate::engine::structures::Table;
-use crate::engine::{Engine, Name, Pool, PoolUuid, Redundancy, RenameAction};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{
+        engine::Eventable,
+        sim_engine::{pool::SimPool, randomization::Randomizer},
+        structures::Table,
+        Engine, Name, Pool, PoolUuid, Redundancy, RenameAction,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 #[derive(Debug, Default)]
 pub struct SimEngine {
@@ -136,14 +140,15 @@ impl Engine for SimEngine {
 #[cfg(test)]
 mod tests {
 
-    use std;
-    use std::path::Path;
+    use std::{self, path::Path};
 
     use proptest::prelude::any;
     use uuid::Uuid;
 
-    use crate::engine::{Engine, RenameAction};
-    use crate::stratis::{ErrorEnum, StratisError};
+    use crate::{
+        engine::{Engine, RenameAction},
+        stratis::{ErrorEnum, StratisError},
+    };
 
     use super::*;
 

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -10,8 +10,10 @@ use std::path::PathBuf;
 
 use devicemapper::Bytes;
 
-use crate::engine::{Filesystem, MaybeDbusPath};
-use crate::stratis::StratisResult;
+use crate::{
+    engine::{Filesystem, MaybeDbusPath},
+    stratis::StratisResult,
+};
 
 #[derive(Debug)]
 pub struct SimFilesystem {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -14,18 +14,16 @@ use uuid::Uuid;
 
 use devicemapper::{Sectors, IEC};
 
+use crate::engine::sim_engine::blockdev::SimDev;
+use crate::engine::sim_engine::filesystem::SimFilesystem;
+use crate::engine::sim_engine::randomization::Randomizer;
+use crate::engine::structures::Table;
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
 use crate::engine::{
     BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
     PoolUuid, Redundancy, RenameAction,
 };
 use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
-use crate::engine::structures::Table;
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
-
-use crate::engine::sim_engine::blockdev::SimDev;
-use crate::engine::sim_engine::filesystem::SimFilesystem;
-use crate::engine::sim_engine::randomization::Randomizer;
 
 #[derive(Debug)]
 pub struct SimPool {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -2,28 +2,29 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cell::RefCell;
-use std::collections::hash_map::RandomState;
-use std::collections::{HashMap, HashSet};
-use std::iter::FromIterator;
-use std::path::Path;
-use std::rc::Rc;
-use std::vec::Vec;
+use std::{
+    cell::RefCell,
+    collections::{hash_map::RandomState, HashMap, HashSet},
+    iter::FromIterator,
+    path::Path,
+    rc::Rc,
+    vec::Vec,
+};
 
 use uuid::Uuid;
 
 use devicemapper::{Sectors, IEC};
 
-use crate::engine::sim_engine::blockdev::SimDev;
-use crate::engine::sim_engine::filesystem::SimFilesystem;
-use crate::engine::sim_engine::randomization::Randomizer;
-use crate::engine::structures::Table;
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
-use crate::engine::{
-    BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
-    PoolUuid, Redundancy, RenameAction,
+use crate::{
+    engine::{
+        sim_engine::{blockdev::SimDev, filesystem::SimFilesystem, randomization::Randomizer},
+        structures::Table,
+        types::{FreeSpaceState, PoolExtendState, PoolState},
+        BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
+        PoolUuid, Redundancy, RenameAction,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
 };
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 #[derive(Debug)]
 pub struct SimPool {

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -4,25 +4,35 @@
 
 // Code to handle the backing store of a pool.
 
-use std::cmp;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::{
+    cmp,
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use chrono::{DateTime, Utc};
 
 use devicemapper::{CacheDev, Device, DmDevice, LinearDev, Sectors};
 
-use crate::engine::strat_engine::backstore::blockdevmgr::{map_to_dm, BlockDevMgr};
-use crate::engine::strat_engine::backstore::cache_tier::CacheTier;
-use crate::engine::strat_engine::backstore::data_tier::DataTier;
-use crate::engine::strat_engine::backstore::setup::get_blockdevs;
-use crate::engine::strat_engine::backstore::{StratBlockDev, MIN_MDA_SECTORS};
-use crate::engine::strat_engine::device::wipe_sectors;
-use crate::engine::strat_engine::dm::get_dm;
-use crate::engine::strat_engine::names::{format_backstore_ids, CacheRole};
-use crate::engine::strat_engine::serde_structs::{BackstoreSave, CapSave, Recordable};
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{
+        strat_engine::{
+            backstore::{
+                blockdevmgr::{map_to_dm, BlockDevMgr},
+                cache_tier::CacheTier,
+                data_tier::DataTier,
+                setup::get_blockdevs,
+                StratBlockDev, MIN_MDA_SECTORS,
+            },
+            device::wipe_sectors,
+            dm::get_dm,
+            names::{format_backstore_ids, CacheRole},
+            serde_structs::{BackstoreSave, CapSave, Recordable},
+        },
+        BlockDevTier, DevUuid, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 /// Use a cache block size that the kernel docs indicate is the largest
 /// typical size.
@@ -571,9 +581,11 @@ mod tests {
 
     use devicemapper::{CacheDevStatus, DataBlocks, IEC};
 
-    use crate::engine::strat_engine::backstore::find_all;
-    use crate::engine::strat_engine::cmd;
-    use crate::engine::strat_engine::tests::{loopbacked, real};
+    use crate::engine::strat_engine::{
+        backstore::find_all,
+        cmd,
+        tests::{loopbacked, real},
+    };
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -12,19 +12,17 @@ use chrono::{DateTime, Utc};
 
 use devicemapper::{CacheDev, Device, DmDevice, LinearDev, Sectors};
 
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
+use crate::engine::strat_engine::backstore::blockdevmgr::{map_to_dm, BlockDevMgr};
+use crate::engine::strat_engine::backstore::cache_tier::CacheTier;
+use crate::engine::strat_engine::backstore::data_tier::DataTier;
+use crate::engine::strat_engine::backstore::setup::get_blockdevs;
 use crate::engine::strat_engine::backstore::{StratBlockDev, MIN_MDA_SECTORS};
 use crate::engine::strat_engine::device::wipe_sectors;
 use crate::engine::strat_engine::dm::get_dm;
 use crate::engine::strat_engine::names::{format_backstore_ids, CacheRole};
 use crate::engine::strat_engine::serde_structs::{BackstoreSave, CapSave, Recordable};
-
-use crate::engine::strat_engine::backstore::blockdevmgr::{map_to_dm, BlockDevMgr};
-use crate::engine::strat_engine::backstore::cache_tier::CacheTier;
-use crate::engine::strat_engine::backstore::data_tier::DataTier;
-use crate::engine::strat_engine::backstore::setup::get_blockdevs;
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// Use a cache block size that the kernel docs indicate is the largest
 /// typical size.

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -11,15 +11,12 @@ use chrono::{DateTime, TimeZone, Utc};
 
 use devicemapper::{Device, Sectors};
 
-use crate::engine::{BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath, PoolUuid};
-use crate::stratis::StratisResult;
-
 use crate::engine::event::get_engine_listener_list;
-
-use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, Recordable};
-
 use crate::engine::strat_engine::backstore::metadata::BDA;
 use crate::engine::strat_engine::backstore::range_alloc::RangeAllocator;
+use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, Recordable};
+use crate::engine::{BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath, PoolUuid};
+use crate::stratis::StratisResult;
 
 #[derive(Debug)]
 pub struct StratBlockDev {

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -4,19 +4,23 @@
 
 // Code to handle a single block device.
 
-use std::fs::OpenOptions;
-use std::path::PathBuf;
+use std::{fs::OpenOptions, path::PathBuf};
 
 use chrono::{DateTime, TimeZone, Utc};
 
 use devicemapper::{Device, Sectors};
 
-use crate::engine::event::get_engine_listener_list;
-use crate::engine::strat_engine::backstore::metadata::BDA;
-use crate::engine::strat_engine::backstore::range_alloc::RangeAllocator;
-use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, Recordable};
-use crate::engine::{BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath, PoolUuid};
-use crate::stratis::StratisResult;
+use crate::{
+    engine::{
+        event::get_engine_listener_list,
+        strat_engine::{
+            backstore::{metadata::BDA, range_alloc::RangeAllocator},
+            serde_structs::{BaseBlockDevSave, Recordable},
+        },
+        BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath, PoolUuid,
+    },
+    stratis::StratisResult,
+};
 
 #[derive(Debug)]
 pub struct StratBlockDev {

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -4,10 +4,12 @@
 
 // Code to handle a collection of block devices.
 
-use std::collections::{HashMap, HashSet};
-use std::fmt;
-use std::fs::{File, OpenOptions};
-use std::path::Path;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    fs::{File, OpenOptions},
+    path::Path,
+};
 
 use chrono::{DateTime, Duration, Utc};
 use rand::{seq, thread_rng};
@@ -17,14 +19,23 @@ use devicemapper::{
     Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine, IEC,
 };
 
-use crate::engine::strat_engine::backstore::cleanup::wipe_blockdevs;
-use crate::engine::strat_engine::backstore::device::{identify, resolve_devices, DevOwnership};
-use crate::engine::strat_engine::backstore::metadata::{validate_mda_size, BDA};
-use crate::engine::strat_engine::backstore::util::hw_lookup;
-use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev, MIN_MDA_SECTORS};
-use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable};
-use crate::engine::{BlockDev, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{
+        strat_engine::{
+            backstore::{
+                blkdev_size,
+                cleanup::wipe_blockdevs,
+                device::{identify, resolve_devices, DevOwnership},
+                metadata::{validate_mda_size, BDA},
+                util::hw_lookup,
+                StratBlockDev, MIN_MDA_SECTORS,
+            },
+            serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable},
+        },
+        BlockDev, DevUuid, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
 const MAX_NUM_TO_WRITE: usize = 10;
@@ -503,10 +514,12 @@ mod tests {
     use rand;
     use uuid::Uuid;
 
-    use crate::engine::strat_engine::backstore::{find_all, get_metadata, MIN_MDA_SECTORS};
-    use crate::engine::strat_engine::cmd;
-    use crate::engine::strat_engine::device::wipe_sectors;
-    use crate::engine::strat_engine::tests::{loopbacked, real};
+    use crate::engine::strat_engine::{
+        backstore::{find_all, get_metadata, MIN_MDA_SECTORS},
+        cmd,
+        device::wipe_sectors,
+        tests::{loopbacked, real},
+    };
 
     use crate::engine::strat_engine::backstore::metadata::StaticHeader;
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -17,16 +17,14 @@ use devicemapper::{
     Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine, IEC,
 };
 
-use crate::engine::{BlockDev, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
-use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev, MIN_MDA_SECTORS};
-use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable};
-
 use crate::engine::strat_engine::backstore::cleanup::wipe_blockdevs;
 use crate::engine::strat_engine::backstore::device::{identify, resolve_devices, DevOwnership};
 use crate::engine::strat_engine::backstore::metadata::{validate_mda_size, BDA};
 use crate::engine::strat_engine::backstore::util::hw_lookup;
+use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev, MIN_MDA_SECTORS};
+use crate::engine::strat_engine::serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable};
+use crate::engine::{BlockDev, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
 const MAX_NUM_TO_WRITE: usize = 10;

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -8,17 +8,15 @@ use std::path::Path;
 
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
+use crate::engine::strat_engine::backstore::blockdevmgr::{
+    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
+};
 use crate::engine::strat_engine::backstore::StratBlockDev;
 use crate::engine::strat_engine::serde_structs::{
     BaseDevSave, BlockDevSave, CacheTierSave, Recordable,
 };
-
-use crate::engine::strat_engine::backstore::blockdevmgr::{
-    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
-};
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// This is a temporary maximum cache size. In the future it will be possible
 /// to dynamically increase the cache size beyond this limit. When this is

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -8,15 +8,19 @@ use std::path::Path;
 
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
-use crate::engine::strat_engine::backstore::blockdevmgr::{
-    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
+use crate::{
+    engine::{
+        strat_engine::{
+            backstore::{
+                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment},
+                StratBlockDev,
+            },
+            serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
+        },
+        BlockDevTier, DevUuid, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
 };
-use crate::engine::strat_engine::backstore::StratBlockDev;
-use crate::engine::strat_engine::serde_structs::{
-    BaseDevSave, BlockDevSave, CacheTierSave, Recordable,
-};
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// This is a temporary maximum cache size. In the future it will be possible
 /// to dynamically increase the cache size beyond this limit. When this is
@@ -235,8 +239,10 @@ mod tests {
 
     use uuid::Uuid;
 
-    use crate::engine::strat_engine::backstore::MIN_MDA_SECTORS;
-    use crate::engine::strat_engine::tests::{loopbacked, real};
+    use crate::engine::strat_engine::{
+        backstore::MIN_MDA_SECTORS,
+        tests::{loopbacked, real},
+    };
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/cleanup.rs
+++ b/src/engine/strat_engine/backstore/cleanup.rs
@@ -4,9 +4,8 @@
 
 // Code to handle cleanup after a failed operation.
 
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
 use crate::engine::strat_engine::backstore::StratBlockDev;
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// Wipe some blockdevs of their identifying headers.
 /// Return an error if any of the blockdevs could not be wiped.

--- a/src/engine/strat_engine/backstore/cleanup.rs
+++ b/src/engine/strat_engine/backstore/cleanup.rs
@@ -4,8 +4,10 @@
 
 // Code to handle cleanup after a failed operation.
 
-use crate::engine::strat_engine::backstore::StratBlockDev;
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::strat_engine::backstore::StratBlockDev,
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 /// Wipe some blockdevs of their identifying headers.
 /// Return an error if any of the blockdevs could not be wiped.

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -8,17 +8,15 @@ use std::path::Path;
 
 use devicemapper::Sectors;
 
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
+use crate::engine::strat_engine::backstore::blockdevmgr::{
+    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
+};
 use crate::engine::strat_engine::backstore::StratBlockDev;
 use crate::engine::strat_engine::serde_structs::{
     BaseDevSave, BlockDevSave, DataTierSave, Recordable,
 };
-
-use crate::engine::strat_engine::backstore::blockdevmgr::{
-    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
-};
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// Handles the lowest level, base layer of this tier.
 #[derive(Debug)]

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -8,15 +8,19 @@ use std::path::Path;
 
 use devicemapper::Sectors;
 
-use crate::engine::strat_engine::backstore::blockdevmgr::{
-    coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment,
+use crate::{
+    engine::{
+        strat_engine::{
+            backstore::{
+                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment},
+                StratBlockDev,
+            },
+            serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},
+        },
+        BlockDevTier, DevUuid, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
 };
-use crate::engine::strat_engine::backstore::StratBlockDev;
-use crate::engine::strat_engine::serde_structs::{
-    BaseDevSave, BlockDevSave, DataTierSave, Recordable,
-};
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// Handles the lowest level, base layer of this tier.
 #[derive(Debug)]
@@ -174,8 +178,10 @@ mod tests {
 
     use uuid::Uuid;
 
-    use crate::engine::strat_engine::backstore::MIN_MDA_SECTORS;
-    use crate::engine::strat_engine::tests::{loopbacked, real};
+    use crate::engine::strat_engine::{
+        backstore::MIN_MDA_SECTORS,
+        tests::{loopbacked, real},
+    };
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -11,11 +11,10 @@ use std::path::Path;
 
 use devicemapper::{devnode_to_devno, Bytes, Device};
 
-use crate::engine::{DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
 use crate::engine::strat_engine::backstore::metadata::StaticHeader;
 use crate::engine::strat_engine::backstore::util::get_udev_block_device;
+use crate::engine::{DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 ioctl_read!(blkgetsize64, 0x12, 114, u64);
 

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -4,17 +4,22 @@
 
 // Functions for dealing with devices.
 
-use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
-use std::os::unix::prelude::AsRawFd;
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    fs::{File, OpenOptions},
+    os::unix::prelude::AsRawFd,
+    path::Path,
+};
 
 use devicemapper::{devnode_to_devno, Bytes, Device};
 
-use crate::engine::strat_engine::backstore::metadata::StaticHeader;
-use crate::engine::strat_engine::backstore::util::get_udev_block_device;
-use crate::engine::{DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{
+        strat_engine::backstore::{metadata::StaticHeader, util::get_udev_block_device},
+        DevUuid, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 ioctl_read!(blkgetsize64, 0x12, 114, u64);
 
@@ -139,8 +144,10 @@ pub fn is_stratis_device(devnode: &Path) -> StratisResult<Option<(PoolUuid, DevU
 mod test {
     use std::path::Path;
 
-    use crate::engine::strat_engine::cmd;
-    use crate::engine::strat_engine::tests::{loopbacked, real};
+    use crate::engine::strat_engine::{
+        cmd,
+        tests::{loopbacked, real},
+    };
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fmt;
-use std::io::{self, Read, Seek, SeekFrom};
-use std::str::from_utf8;
+use std::{
+    fmt,
+    io::{self, Read, Seek, SeekFrom},
+    str::from_utf8,
+};
 
 use byteorder::{ByteOrder, LittleEndian};
 use chrono::{DateTime, Utc};
@@ -13,9 +15,10 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC, SECTOR_SIZE};
 
-use crate::engine::strat_engine::device::SyncAll;
-use crate::engine::{DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{strat_engine::device::SyncAll, DevUuid, PoolUuid},
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 pub use self::mda::{validate_mda_size, MIN_MDA_SECTORS};
 
@@ -482,9 +485,11 @@ impl fmt::Debug for StaticHeader {
 }
 
 mod mda {
-    use std;
-    use std::cmp::Ordering;
-    use std::io::{Read, Seek, SeekFrom};
+    use std::{
+        self,
+        cmp::Ordering,
+        io::{Read, Seek, SeekFrom},
+    };
 
     use byteorder::{ByteOrder, LittleEndian};
     use chrono::{DateTime, TimeZone, Utc};
@@ -492,9 +497,10 @@ mod mda {
 
     use devicemapper::{Bytes, Sectors};
 
-    use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
-    use crate::engine::strat_engine::device::SyncAll;
+    use crate::{
+        engine::strat_engine::device::SyncAll,
+        stratis::{ErrorEnum, StratisError, StratisResult},
+    };
 
     const _MDA_REGION_HDR_SIZE: usize = 32;
     const MDA_REGION_HDR_SIZE: Bytes = Bytes(_MDA_REGION_HDR_SIZE as u64);
@@ -884,8 +890,7 @@ mod mda {
             num,
         };
 
-        use super::super::*;
-        use super::*;
+        use super::{super::*, *};
 
         // 82102984128000 in decimal, approx 17 million years
         const UTC_TIMESTAMP_SECS_BOUND: i64 = 0x777_9beb_9f00;
@@ -966,7 +971,6 @@ mod mda {
 mod tests {
     use std::io::{Cursor, Write};
 
-    use devicemapper::{Bytes, Sectors, IEC};
     use proptest::{
         collection::{vec, SizeRange},
         num, option,
@@ -974,6 +978,8 @@ mod tests {
         strategy::Strategy,
     };
     use uuid::Uuid;
+
+    use devicemapper::{Bytes, Sectors, IEC};
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -13,10 +13,9 @@ use uuid::Uuid;
 
 use devicemapper::{Bytes, Sectors, IEC, SECTOR_SIZE};
 
+use crate::engine::strat_engine::device::SyncAll;
 use crate::engine::{DevUuid, PoolUuid};
 use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
-use crate::engine::strat_engine::device::SyncAll;
 
 pub use self::mda::{validate_mda_size, MIN_MDA_SECTORS};
 

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -15,9 +15,10 @@ mod range_alloc;
 mod setup;
 mod util;
 
-pub use self::backstore::Backstore;
-pub use self::blockdev::StratBlockDev;
-pub use self::device::blkdev_size;
-pub use self::device::is_stratis_device;
-pub use self::metadata::MIN_MDA_SECTORS;
-pub use self::setup::{find_all, get_metadata};
+pub use self::{
+    backstore::Backstore,
+    blockdev::StratBlockDev,
+    device::{blkdev_size, is_stratis_device},
+    metadata::MIN_MDA_SECTORS,
+    setup::{find_all, get_metadata},
+};

--- a/src/engine/strat_engine/backstore/range_alloc.rs
+++ b/src/engine/strat_engine/backstore/range_alloc.rs
@@ -2,9 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cmp::min;
-use std::collections::BTreeMap;
-use std::collections::Bound::{Included, Unbounded};
+use std::{
+    cmp::min,
+    collections::{
+        BTreeMap,
+        Bound::{Included, Unbounded},
+    },
+};
 
 use devicemapper::Sectors;
 

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -5,20 +5,31 @@
 // Code to handle initial setup steps for a pool.
 // Initial setup steps are steps that do not alter the environment.
 
-use std::collections::{HashMap, HashSet};
-use std::fs::OpenOptions;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+};
 
 use serde_json;
 
 use devicemapper::{devnode_to_devno, Device, Sectors};
 
-use crate::engine::strat_engine::backstore::metadata::{StaticHeader, BDA};
-use crate::engine::strat_engine::backstore::util::get_stratis_block_devices;
-use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev};
-use crate::engine::strat_engine::serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave};
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{
+        strat_engine::{
+            backstore::{
+                blkdev_size,
+                metadata::{StaticHeader, BDA},
+                util::get_stratis_block_devices,
+                StratBlockDev,
+            },
+            serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave},
+        },
+        BlockDevTier, DevUuid, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 /// Find all Stratis devices.
 ///

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -13,14 +13,12 @@ use serde_json;
 
 use devicemapper::{devnode_to_devno, Device, Sectors};
 
-use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
-use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev};
-use crate::engine::strat_engine::serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave};
-
 use crate::engine::strat_engine::backstore::metadata::{StaticHeader, BDA};
 use crate::engine::strat_engine::backstore::util::get_stratis_block_devices;
+use crate::engine::strat_engine::backstore::{blkdev_size, StratBlockDev};
+use crate::engine::strat_engine::serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave};
+use crate::engine::{BlockDevTier, DevUuid, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// Find all Stratis devices.
 ///

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -9,9 +9,8 @@ use std::path::{Path, PathBuf};
 
 use libudev;
 
-use crate::stratis::StratisResult;
-
 use crate::engine::strat_engine::backstore::is_stratis_device;
+use crate::stratis::StratisResult;
 
 /// Takes a libudev device entry and returns the properties as a HashMap.
 fn device_as_map(device: &libudev::Device) -> HashMap<String, String> {

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -3,14 +3,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Utilities to support Stratis.
-use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use libudev;
 
-use crate::engine::strat_engine::backstore::is_stratis_device;
-use crate::stratis::StratisResult;
+use crate::{engine::strat_engine::backstore::is_stratis_device, stratis::StratisResult};
 
 /// Takes a libudev device entry and returns the properties as a HashMap.
 fn device_as_map(device: &libudev::Device) -> HashMap<String, String> {

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -4,9 +4,10 @@
 
 // Code to handle cleanup after a failed operation.
 
-use crate::engine::strat_engine::pool::StratPool;
-use crate::engine::structures::Table;
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{strat_engine::pool::StratPool, structures::Table},
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 /// Teardown pools.
 pub fn teardown_pools(pools: Table<StratPool>) -> StratisResult<()> {

--- a/src/engine/strat_engine/cleanup.rs
+++ b/src/engine/strat_engine/cleanup.rs
@@ -4,11 +4,9 @@
 
 // Code to handle cleanup after a failed operation.
 
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
-use crate::engine::structures::Table;
-
 use crate::engine::strat_engine::pool::StratPool;
+use crate::engine::structures::Table;
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// Teardown pools.
 pub fn teardown_pools(pools: Table<StratPool>) -> StratisResult<()> {

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -14,9 +14,11 @@
 // the existence of the file is checked before the command is invoked, and
 // an explicit error is returned if the executable can not be found.
 
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use uuid::Uuid;
 

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -4,9 +4,11 @@
 
 // Functions for dealing with devices.
 
-use std::fs::{File, OpenOptions};
-use std::io::{self, BufWriter, Cursor, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, BufWriter, Cursor, Seek, SeekFrom, Write},
+    path::Path,
+};
 
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 

--- a/src/engine/strat_engine/dm.rs
+++ b/src/engine/strat_engine/dm.rs
@@ -4,13 +4,17 @@
 
 // Get ability to instantiate a devicemapper context.
 
-use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::{Once, ONCE_INIT};
+use std::{
+    os::unix::io::{AsRawFd, RawFd},
+    sync::{Once, ONCE_INIT},
+};
 
 use devicemapper::{DmResult, DM};
 
-use crate::engine::engine::Eventable;
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::engine::Eventable,
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 static INIT: Once = ONCE_INIT;
 static mut DM_CONTEXT: Option<DmResult<DM>> = None;

--- a/src/engine/strat_engine/dm.rs
+++ b/src/engine/strat_engine/dm.rs
@@ -9,9 +9,8 @@ use std::sync::{Once, ONCE_INIT};
 
 use devicemapper::{DmResult, DM};
 
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
 use crate::engine::engine::Eventable;
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 static INIT: Once = ONCE_INIT;
 static mut DM_CONTEXT: Option<DmResult<DM>> = None;

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -8,15 +8,8 @@ use std::path::{Path, PathBuf};
 
 use devicemapper::{Device, DmNameBuf};
 
-use crate::engine::{
-    devlinks, Engine, EngineEvent, Name, Pool, PoolUuid, Redundancy, RenameAction,
-};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
 use crate::engine::engine::Eventable;
 use crate::engine::event::get_engine_listener_list;
-use crate::engine::structures::Table;
-
 use crate::engine::strat_engine::backstore::{find_all, get_metadata, is_stratis_device};
 #[cfg(test)]
 use crate::engine::strat_engine::cleanup::teardown_pools;
@@ -24,6 +17,11 @@ use crate::engine::strat_engine::cmd::verify_binaries;
 use crate::engine::strat_engine::dm::{get_dm, get_dm_init};
 use crate::engine::strat_engine::names::validate_name;
 use crate::engine::strat_engine::pool::{check_metadata, StratPool};
+use crate::engine::structures::Table;
+use crate::engine::{
+    devlinks, Engine, EngineEvent, Name, Pool, PoolUuid, Redundancy, RenameAction,
+};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 const REQUIRED_DM_MINOR_VERSION: u32 = 37;
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -2,26 +2,34 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::clone::Clone;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::{
+    clone::Clone,
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use devicemapper::{Device, DmNameBuf};
 
-use crate::engine::engine::Eventable;
-use crate::engine::event::get_engine_listener_list;
-use crate::engine::strat_engine::backstore::{find_all, get_metadata, is_stratis_device};
 #[cfg(test)]
 use crate::engine::strat_engine::cleanup::teardown_pools;
-use crate::engine::strat_engine::cmd::verify_binaries;
-use crate::engine::strat_engine::dm::{get_dm, get_dm_init};
-use crate::engine::strat_engine::names::validate_name;
-use crate::engine::strat_engine::pool::{check_metadata, StratPool};
-use crate::engine::structures::Table;
-use crate::engine::{
-    devlinks, Engine, EngineEvent, Name, Pool, PoolUuid, Redundancy, RenameAction,
+
+use crate::{
+    engine::{
+        devlinks,
+        engine::Eventable,
+        event::get_engine_listener_list,
+        strat_engine::{
+            backstore::{find_all, get_metadata, is_stratis_device},
+            cmd::verify_binaries,
+            dm::{get_dm, get_dm_init},
+            names::validate_name,
+            pool::{check_metadata, StratPool},
+        },
+        structures::Table,
+        Engine, EngineEvent, Name, Pool, PoolUuid, Redundancy, RenameAction,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
 };
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 const REQUIRED_DM_MINOR_VERSION: u32 = 37;
 

--- a/src/engine/strat_engine/names.rs
+++ b/src/engine/strat_engine/names.rs
@@ -4,14 +4,17 @@
 
 // Functions for dealing with stratis and device mapper names.
 
-use std::fmt;
-use std::fmt::Display;
-use std::path::Path;
+use std::{
+    fmt::{self, Display},
+    path::Path,
+};
 
 use devicemapper::{DmNameBuf, DmUuidBuf};
 
-use crate::engine::{FilesystemUuid, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{FilesystemUuid, PoolUuid},
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 const FORMAT_VERSION: u16 = 1;
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,26 +2,32 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::collections::HashMap;
-use std::iter::FromIterator;
-use std::path::{Path, PathBuf};
-use std::vec::Vec;
+use std::{
+    collections::HashMap,
+    iter::FromIterator,
+    path::{Path, PathBuf},
+    vec::Vec,
+};
 
 use serde_json;
 use uuid::Uuid;
 
 use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
-use crate::engine::strat_engine::backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS};
-use crate::engine::strat_engine::names::validate_name;
-use crate::engine::strat_engine::serde_structs::{FlexDevsSave, PoolSave, Recordable};
-use crate::engine::strat_engine::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
-use crate::engine::{
-    BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
-    PoolUuid, Redundancy, RenameAction,
+use crate::{
+    engine::{
+        strat_engine::{
+            backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS},
+            names::validate_name,
+            serde_structs::{FlexDevsSave, PoolSave, Recordable},
+            thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE},
+        },
+        types::{FreeSpaceState, PoolExtendState, PoolState},
+        BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
+        PoolUuid, Redundancy, RenameAction,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
 };
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 /// Get the index which indicates the start of unallocated space in the cap
 /// device.
@@ -476,20 +482,23 @@ impl Pool for StratPool {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::OpenOptions;
-    use std::io::{BufWriter, Read, Write};
+    use std::{
+        fs::OpenOptions,
+        io::{BufWriter, Read, Write},
+    };
 
     use nix::mount::{mount, umount, MsFlags};
     use tempfile;
 
     use devicemapper::{Bytes, IEC, SECTOR_SIZE};
 
-    use crate::engine::devlinks;
-    use crate::engine::types::Redundancy;
+    use crate::engine::{devlinks, types::Redundancy};
 
-    use crate::engine::strat_engine::backstore::{find_all, get_metadata};
-    use crate::engine::strat_engine::cmd;
-    use crate::engine::strat_engine::tests::{loopbacked, real};
+    use crate::engine::strat_engine::{
+        backstore::{find_all, get_metadata},
+        cmd,
+        tests::{loopbacked, real},
+    };
 
     use super::*;
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -12,18 +12,16 @@ use uuid::Uuid;
 
 use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
+use crate::engine::strat_engine::backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS};
+use crate::engine::strat_engine::names::validate_name;
+use crate::engine::strat_engine::serde_structs::{FlexDevsSave, PoolSave, Recordable};
+use crate::engine::strat_engine::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
 use crate::engine::{
     BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
     PoolUuid, Redundancy, RenameAction,
 };
 use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
-
-use crate::engine::strat_engine::backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS};
-use crate::engine::strat_engine::names::validate_name;
-use crate::engine::strat_engine::serde_structs::{FlexDevsSave, PoolSave, Recordable};
-use crate::engine::strat_engine::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
 
 /// Get the index which indicates the start of unallocated space in the cap
 /// device.

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -492,12 +492,14 @@ mod tests {
 
     use devicemapper::{Bytes, IEC, SECTOR_SIZE};
 
-    use crate::engine::{devlinks, types::Redundancy};
-
-    use crate::engine::strat_engine::{
-        backstore::{find_all, get_metadata},
-        cmd,
-        tests::{loopbacked, real},
+    use crate::engine::{
+        devlinks,
+        strat_engine::{
+            backstore::{find_all, get_metadata},
+            cmd,
+            tests::{loopbacked, real},
+        },
+        types::Redundancy,
     };
 
     use super::*;

--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -2,10 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::OpenOptions;
-use std::os::unix::io::AsRawFd;
-use std::panic;
-use std::path::{Path, PathBuf};
+use std::{
+    fs::OpenOptions,
+    os::unix::io::AsRawFd,
+    panic,
+    path::{Path, PathBuf},
+};
 
 use nix;
 use tempfile;
@@ -14,8 +16,7 @@ use devicemapper::{Bytes, Sectors, IEC};
 
 use loopdev::{LoopControl, LoopDevice};
 
-use crate::engine::strat_engine::tests::logger::init_logger;
-use crate::engine::strat_engine::tests::util::clean_up;
+use crate::engine::strat_engine::tests::{logger::init_logger, util::clean_up};
 
 /// Ways of specifying range of numbers of devices to use for tests.
 /// Unlike real tests, there is no AtLeast constructor, as, at least in theory

--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -9,12 +9,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use loopdev::{LoopControl, LoopDevice};
 use nix;
 use tempfile;
 
 use devicemapper::{Bytes, Sectors, IEC};
-
-use loopdev::{LoopControl, LoopDevice};
 
 use crate::engine::strat_engine::tests::{logger::init_logger, util::clean_up};
 

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -2,23 +2,27 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::OpenOptions;
-use std::path::{Path, PathBuf};
-use std::{cmp, panic};
+use std::{
+    cmp,
+    fs::OpenOptions,
+    panic,
+    path::{Path, PathBuf},
+};
 
 use serde_json::{from_reader, Value};
 use uuid::Uuid;
 
 use devicemapper::{
-    devnode_to_devno, Bytes, Device, DmDevice, DmName, LinearDev, LinearDevTargetParams, LinearTargetParams,
-    Sectors, TargetLine, IEC,
+    devnode_to_devno, Bytes, Device, DmDevice, DmName, LinearDev, LinearDevTargetParams,
+    LinearTargetParams, Sectors, TargetLine, IEC,
 };
 
-use crate::engine::strat_engine::backstore::blkdev_size;
-use crate::engine::strat_engine::device::wipe_sectors;
-use crate::engine::strat_engine::dm::get_dm;
-use crate::engine::strat_engine::tests::logger::init_logger;
-use crate::engine::strat_engine::tests::util::clean_up;
+use crate::engine::strat_engine::{
+    backstore::blkdev_size,
+    device::wipe_sectors,
+    dm::get_dm,
+    tests::{logger::init_logger, util::clean_up},
+};
 
 use either::Either;
 

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -6,21 +6,21 @@ use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::{cmp, panic};
 
-use either::Either;
 use serde_json::{from_reader, Value};
 use uuid::Uuid;
 
 use devicemapper::{
-    devnode_to_devno, Bytes, Device, DmDevice, DmName, LinearDev, LinearDevTargetParams,
-    LinearTargetParams, Sectors, TargetLine, IEC,
+    devnode_to_devno, Bytes, Device, DmDevice, DmName, LinearDev, LinearDevTargetParams, LinearTargetParams,
+    Sectors, TargetLine, IEC,
 };
 
 use crate::engine::strat_engine::backstore::blkdev_size;
 use crate::engine::strat_engine::device::wipe_sectors;
 use crate::engine::strat_engine::dm::get_dm;
-
 use crate::engine::strat_engine::tests::logger::init_logger;
 use crate::engine::strat_engine::tests::util::clean_up;
+
+use either::Either;
 
 pub struct RealTestDev {
     dev: Either<PathBuf, LinearDev>,

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -9,6 +9,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use either::Either;
 use serde_json::{from_reader, Value};
 use uuid::Uuid;
 
@@ -23,8 +24,6 @@ use crate::engine::strat_engine::{
     dm::get_dm,
     tests::{logger::init_logger, util::clean_up},
 };
-
-use either::Either;
 
 pub struct RealTestDev {
     dev: Either<PathBuf, LinearDev>,

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -2,17 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::File;
-use std::io::Read;
-use std::path::PathBuf;
+use std::{fs::File, io::Read, path::PathBuf};
 
 use libmount;
 use nix::mount::{umount2, MntFlags};
 
 use devicemapper::{DevId, DmOptions};
 
-use crate::engine::strat_engine::cmd;
-use crate::engine::strat_engine::dm::{get_dm, get_dm_init};
+use crate::engine::strat_engine::{
+    cmd,
+    dm::{get_dm, get_dm_init},
+};
 
 // For an explanation see:
 // https://github.com/rust-lang-nursery/error-chain/issues/254.

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -20,16 +20,14 @@ use nix::mount::{mount, umount, MsFlags};
 use nix::sys::statvfs::statvfs;
 use tempfile;
 
-use crate::engine::{Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
 use crate::engine::strat_engine::cmd::{create_fs, set_uuid, udev_settle, xfs_growfs};
 use crate::engine::strat_engine::dm::get_dm;
 use crate::engine::strat_engine::names::{format_thin_ids, ThinRole};
 use crate::engine::strat_engine::serde_structs::FilesystemSave;
-use crate::engine::strat_engine::thinpool::DATA_BLOCK_SIZE;
-
 use crate::engine::strat_engine::thinpool::thinpool::DATA_LOWATER;
+use crate::engine::strat_engine::thinpool::DATA_BLOCK_SIZE;
+use crate::engine::{Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -5,29 +5,38 @@
 use chrono::{DateTime, TimeZone, Utc};
 use uuid::Uuid;
 
-use std::fs::File;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::thread::sleep;
-use std::time::Duration;
+use std::{
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+    thread::sleep,
+    time::Duration,
+};
 
 use devicemapper::{
     Bytes, DmDevice, DmName, DmUuid, Sectors, ThinDev, ThinDevId, ThinPoolDev, ThinStatus, IEC,
 };
 
 use libmount;
-use nix::mount::{mount, umount, MsFlags};
-use nix::sys::statvfs::statvfs;
+use nix::{
+    mount::{mount, umount, MsFlags},
+    sys::statvfs::statvfs,
+};
 use tempfile;
 
-use crate::engine::strat_engine::cmd::{create_fs, set_uuid, udev_settle, xfs_growfs};
-use crate::engine::strat_engine::dm::get_dm;
-use crate::engine::strat_engine::names::{format_thin_ids, ThinRole};
-use crate::engine::strat_engine::serde_structs::FilesystemSave;
-use crate::engine::strat_engine::thinpool::thinpool::DATA_LOWATER;
-use crate::engine::strat_engine::thinpool::DATA_BLOCK_SIZE;
-use crate::engine::{Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
+use crate::{
+    engine::{
+        strat_engine::{
+            cmd::{create_fs, set_uuid, udev_settle, xfs_growfs},
+            dm::get_dm,
+            names::{format_thin_ids, ThinRole},
+            serde_structs::FilesystemSave,
+            thinpool::{thinpool::DATA_LOWATER, DATA_BLOCK_SIZE},
+        },
+        Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
 
 const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -4,25 +4,32 @@
 
 // Manage the linear volume that stores metadata on pool levels 5-7.
 
-use std::convert::From;
-use std::fs::{create_dir, read_dir, remove_dir, remove_file, rename, OpenOptions};
-use std::io::prelude::*;
-use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::{
+    convert::From,
+    fs::{create_dir, read_dir, remove_dir, remove_file, rename, OpenOptions},
+    io::{prelude::*, ErrorKind},
+    path::{Path, PathBuf},
+};
 
-use nix;
-use nix::mount::{mount, umount, MsFlags};
+use nix::{
+    self,
+    mount::{mount, umount, MsFlags},
+};
 use serde_json;
 
 use devicemapper::{DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
 
-use crate::engine::engine::DEV_PATH;
-use crate::engine::strat_engine::cmd::create_fs;
-use crate::engine::strat_engine::dm::get_dm;
-use crate::engine::strat_engine::serde_structs::FilesystemSave;
-use crate::engine::strat_engine::thinpool::filesystem::StratFilesystem;
-use crate::engine::{FilesystemUuid, Name, PoolUuid};
-use crate::stratis::StratisResult;
+use crate::{
+    engine::{
+        engine::DEV_PATH,
+        strat_engine::{
+            cmd::create_fs, dm::get_dm, serde_structs::FilesystemSave,
+            thinpool::filesystem::StratFilesystem,
+        },
+        FilesystemUuid, Name, PoolUuid,
+    },
+    stratis::StratisResult,
+};
 
 // TODO: Monitor fs size and extend linear and fs if needed
 // TODO: Document format of stuff on MDV in SWDD (currently ad-hoc)

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -16,15 +16,13 @@ use serde_json;
 
 use devicemapper::{DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
 
-use crate::engine::{FilesystemUuid, Name, PoolUuid};
-use crate::stratis::StratisResult;
-
 use crate::engine::engine::DEV_PATH;
 use crate::engine::strat_engine::cmd::create_fs;
 use crate::engine::strat_engine::dm::get_dm;
 use crate::engine::strat_engine::serde_structs::FilesystemSave;
-
 use crate::engine::strat_engine::thinpool::filesystem::StratFilesystem;
+use crate::engine::{FilesystemUuid, Name, PoolUuid};
+use crate::stratis::StratisResult;
 
 // TODO: Monitor fs size and extend linear and fs if needed
 // TODO: Document format of stuff on MDV in SWDD (currently ad-hoc)

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -17,15 +17,7 @@ use devicemapper::{
     ThinPoolDev, ThinPoolStatus, ThinPoolStatusSummary, IEC,
 };
 
-use crate::engine::{
-    devlinks, EngineEvent, Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, RenameAction,
-};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
-
 use crate::engine::event::get_engine_listener_list;
-use crate::engine::structures::Table;
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
-
 use crate::engine::strat_engine::backstore::Backstore;
 use crate::engine::strat_engine::cmd::{thin_check, thin_repair, udev_settle};
 use crate::engine::strat_engine::device::wipe_sectors;
@@ -34,10 +26,15 @@ use crate::engine::strat_engine::names::{
     format_flex_ids, format_thin_ids, format_thinpool_ids, FlexRole, ThinPoolRole, ThinRole,
 };
 use crate::engine::strat_engine::serde_structs::{FlexDevsSave, Recordable, ThinPoolDevSave};
-
 use crate::engine::strat_engine::thinpool::filesystem::{FilesystemStatus, StratFilesystem};
 use crate::engine::strat_engine::thinpool::mdv::MetadataVol;
 use crate::engine::strat_engine::thinpool::thinids::ThinDevIdPool;
+use crate::engine::structures::Table;
+use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
+use crate::engine::{
+    devlinks, EngineEvent, Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, RenameAction,
+};
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
 pub const DATA_LOWATER: DataBlocks = DataBlocks(2048); // 2 GiB

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -4,10 +4,12 @@
 
 // Code to handle management of a pool's thinpool device.
 
-use std;
-use std::cmp::{max, min};
-use std::thread::sleep;
-use std::time::Duration;
+use std::{
+    self,
+    cmp::{max, min},
+    thread::sleep,
+    time::Duration,
+};
 
 use uuid::Uuid;
 
@@ -17,24 +19,32 @@ use devicemapper::{
     ThinPoolDev, ThinPoolStatus, ThinPoolStatusSummary, IEC,
 };
 
-use crate::engine::event::get_engine_listener_list;
-use crate::engine::strat_engine::backstore::Backstore;
-use crate::engine::strat_engine::cmd::{thin_check, thin_repair, udev_settle};
-use crate::engine::strat_engine::device::wipe_sectors;
-use crate::engine::strat_engine::dm::get_dm;
-use crate::engine::strat_engine::names::{
-    format_flex_ids, format_thin_ids, format_thinpool_ids, FlexRole, ThinPoolRole, ThinRole,
+use crate::{
+    engine::{
+        devlinks,
+        event::get_engine_listener_list,
+        strat_engine::{
+            backstore::Backstore,
+            cmd::{thin_check, thin_repair, udev_settle},
+            device::wipe_sectors,
+            dm::get_dm,
+            names::{
+                format_flex_ids, format_thin_ids, format_thinpool_ids, FlexRole, ThinPoolRole,
+                ThinRole,
+            },
+            serde_structs::{FlexDevsSave, Recordable, ThinPoolDevSave},
+            thinpool::{
+                filesystem::{FilesystemStatus, StratFilesystem},
+                mdv::MetadataVol,
+                thinids::ThinDevIdPool,
+            },
+        },
+        structures::Table,
+        types::{FreeSpaceState, PoolExtendState, PoolState},
+        EngineEvent, Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, RenameAction,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
 };
-use crate::engine::strat_engine::serde_structs::{FlexDevsSave, Recordable, ThinPoolDevSave};
-use crate::engine::strat_engine::thinpool::filesystem::{FilesystemStatus, StratFilesystem};
-use crate::engine::strat_engine::thinpool::mdv::MetadataVol;
-use crate::engine::strat_engine::thinpool::thinids::ThinDevIdPool;
-use crate::engine::structures::Table;
-use crate::engine::types::{FreeSpaceState, PoolExtendState, PoolState};
-use crate::engine::{
-    devlinks, EngineEvent, Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, RenameAction,
-};
-use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 pub const DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Ki);
 pub const DATA_LOWATER: DataBlocks = DataBlocks(2048); // 2 GiB
@@ -1200,9 +1210,11 @@ fn attempt_thin_repair(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::OpenOptions;
-    use std::io::{BufWriter, Read, Write};
-    use std::path::Path;
+    use std::{
+        fs::OpenOptions,
+        io::{BufWriter, Read, Write},
+        path::Path,
+    };
 
     use nix::mount::{mount, umount, MsFlags};
     use tempfile;
@@ -1210,10 +1222,12 @@ mod tests {
 
     use devicemapper::{Bytes, SECTOR_SIZE};
 
-    use crate::engine::strat_engine::backstore::MIN_MDA_SECTORS;
-    use crate::engine::strat_engine::cmd;
-    use crate::engine::strat_engine::device::SyncAll;
-    use crate::engine::strat_engine::tests::{loopbacked, real};
+    use crate::engine::strat_engine::{
+        backstore::MIN_MDA_SECTORS,
+        cmd,
+        device::SyncAll,
+        tests::{loopbacked, real},
+    };
 
     use crate::engine::strat_engine::thinpool::filesystem::{fs_usage, FILESYSTEM_LOWATER};
 

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::collections::{hash_map, HashMap};
-use std::fmt;
-use std::iter::IntoIterator;
+use std::{
+    collections::{hash_map, HashMap},
+    fmt,
+    iter::IntoIterator,
+};
 
 use uuid::Uuid;
 

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::borrow::Borrow;
-use std::fmt;
-use std::ops::Deref;
-use std::rc::Rc;
+use std::{borrow::Borrow, fmt, ops::Deref, rc::Rc};
 
 #[cfg(feature = "dbus_enabled")]
 use dbus;

--- a/src/stratis/buff_log.rs
+++ b/src/stratis/buff_log.rs
@@ -7,8 +7,10 @@
 //! `Handle::dump()`, or a `HandleGuard` can be used to dump the log when a
 //! scope is exited.
 
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
 
 use chrono::{DateTime, Duration, Utc};
 use log::{self, Level, Log, Metadata, MetadataBuilder, Record};

--- a/src/stratis/errors.rs
+++ b/src/stratis/errors.rs
@@ -2,9 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::error::Error;
-use std::str;
-use std::{fmt, io};
+use std::{error::Error, fmt, io, str};
 
 #[cfg(feature = "dbus_enabled")]
 use dbus;

--- a/src/stratis/mod.rs
+++ b/src/stratis/mod.rs
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub use self::errors::{ErrorEnum, StratisError, StratisResult};
-pub use self::stratis::VERSION;
+pub use self::{
+    errors::{ErrorEnum, StratisError, StratisResult},
+    stratis::VERSION,
+};
 
 pub mod buff_log;
 mod errors;


### PR DESCRIPTION
Use merged imports. This way, rustfmt makes many more decisions about the way the imports are formatted than it would otherwise, so we have fewer decisions to make.