### PR TITLE
Allow deprecated usage in the code produced by an error-chain macro

### DIFF
--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -14,6 +14,9 @@ use devicemapper::{DevId, DmOptions};
 use crate::engine::strat_engine::cmd;
 use crate::engine::strat_engine::dm::{get_dm, get_dm_init};
 
+// For an explanation see:
+// https://github.com/rust-lang-nursery/error-chain/issues/254.
+// FIXME: Drop dependence on error-chain entirely.
 mod cleanup_errors {
     use libmount;
     use nix;


### PR DESCRIPTION
error-chain is in maintenance mode and may not fix the deprecated usage.
In any case, we would like to move away from error-chain.

Signed-off-by: mulhern <amulhern@redhat.com>