### PR TITLE
Actually allow the deprecated usage in error-chain

### DIFF
--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -17,6 +17,7 @@ use crate::engine::strat_engine::dm::{get_dm, get_dm_init};
 // For an explanation see:
 // https://github.com/rust-lang-nursery/error-chain/issues/254.
 // FIXME: Drop dependence on error-chain entirely.
+#[allow(deprecated)]
 mod cleanup_errors {
     use libmount;
     use nix;


### PR DESCRIPTION
The comments alone are not enough.

Signed-off-by: mulhern <amulhern@redhat.com>