### PR TITLE
Precondition check for block device usage

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -216,6 +216,11 @@ pub trait Engine: Debug {
     /// Returns true if some action was necessary, otherwise false.
     fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<bool>;
 
+    /// Checks that the supplied block device path(s) are not already known to the engine.  This is
+    /// used for precondition check to ensure we aren't trying to add known device(s) to the
+    /// same pool or different pool.  This check needs visibility to the entire engine state.
+    fn ensure_devices_not_known(&self, blockdev_paths: &[&Path]) -> StratisResult<()>;
+
     /// Rename pool with uuid to new_name.
     /// Raises an error if the mapping can't be applied because
     /// new_name is already in use.

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -87,6 +87,10 @@ impl Engine for SimEngine {
         Ok(true)
     }
 
+    fn ensure_devices_not_known(&self, _blockdev_paths: &[&Path]) -> Result<(), StratisError> {
+        Ok(())
+    }
+
     fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> StratisResult<RenameAction> {
         rename_pool_pre!(self; uuid; new_name);
 


### PR DESCRIPTION
Check that a block device isn't already in use for the engine.

This works, but isn't ideal as the engine caller needs to validate
block device preconditions instead of the calls themselves. This occurs
as we don't have the entire engine context known when we are executing
code for a specific pool for example.  The following additional approaches
were attempted.

* We cannot pass the engine to the calls that need it as it is already
  borrowed mutably.
* Refactor the interface, so that we call methods on the engine instead of
  dispatching to the individual items contained in the engine, this results
  in the engine knowing too much of the internals of the pool.

Addresses: https://github.com/stratis-storage/stratisd/issues/1291

Signed-off-by: Tony Asleson <tasleson@redhat.com>