### PR TITLE
Log start and end of event handling activities in the main loop

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6,6 +6,7 @@ pub use self::devlinks::filesystem_mount_path;
 
 pub use self::engine::BlockDev;
 pub use self::engine::Engine;
+pub use self::engine::Eventable;
 pub use self::engine::Filesystem;
 pub use self::engine::Pool;
 


### PR DESCRIPTION
This ought to allow us to compare timing of, for example, D-Bus handling in
stratisd w/ D-Bus invocations in stratis CLI.

Signed-off-by: mulhern <amulhern@redhat.com>