### PR TITLE
Remove repeated 'bytes' in the error message when blockdev is too small

### DIFF
--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -422,11 +422,8 @@ fn initialize(
         for (dev, dev_result) in dev_infos {
             let (devnode, dev_size, ownership, mut f) = dev_result?;
             if dev_size < MIN_DEV_SIZE {
-                let error_message = format!(
-                    "{} too small, minimum {} bytes",
-                    devnode.display(),
-                    MIN_DEV_SIZE
-                );
+                let error_message =
+                    format!("{} too small, minimum {}", devnode.display(), MIN_DEV_SIZE);
                 return Err(StratisError::Engine(ErrorEnum::Invalid, error_message));
             };
             match ownership {


### PR DESCRIPTION
While running tests with 'stratis pool create' I got the following error:

$ stratis pool create pequenho /dev/vdb
Execution failure caused by:
ERROR: /dev/vdb too small, minimum 1073741824 bytes bytes

This patch attempts to fix the double 'bytes' output. The result of testing
it is:

Execution failure caused by:
ERROR: /dev/vdb too small, minimum 1073741824 bytes

Signed-off-by: Jose Castillo <jcastillo@redhat.com>