### PR TITLE
cmd: Include exit code/reason on failure

### DIFF
--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -83,11 +83,17 @@ fn execute_cmd(cmd: &mut Command) -> StratisResult<()> {
             if result.status.success() {
                 Ok(())
             } else {
+                let exit_reason = result
+                    .status
+                    .code()
+                    .map_or(String::from("process terminated by signal"), |ec| {
+                        ec.to_string()
+                    });
                 let std_out_txt = String::from_utf8_lossy(&result.stdout);
                 let std_err_txt = String::from_utf8_lossy(&result.stderr);
                 let err_msg = format!(
-                    "Command failed: cmd: {:?}, stdout: {} stderr: {}",
-                    cmd, std_out_txt, std_err_txt
+                    "Command failed: cmd: {:?}, exit reason: {} stdout: {} stderr: {}",
+                    cmd, exit_reason, std_out_txt, std_err_txt
                 );
                 Err(StratisError::Error(err_msg))
             }


### PR DESCRIPTION
When looking at some logs of udevadm settle failing, there is no
stdout or stderr.  It would be good to know what the exit code is
to see if we can understand this failure better.

Signed-off-by: Tony Asleson <tasleson@redhat.com>