### PR TITLE
Ignore everything starting with proptest-regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ tests/test_config.json
 htmlcov
 
 # proptest
-proptest-regression
+proptest-regression*


### PR DESCRIPTION
The name of the file or directory to ignore used to be proptest-regression,
now the directory we want to ignore is certainly called proptest-regressions.
Ignore it.

Signed-off-by: mulhern <amulhern@redhat.com>