### PR TITLE
Make assertion in test yield more helpful errors

### DIFF
--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -153,15 +153,15 @@ mod test {
 
         assert_eq!(is_stratis_device(paths[0]).unwrap(), None);
 
-        assert!(match identify(paths[0]).unwrap() {
+        match identify(paths[0]).unwrap() {
             DevOwnership::Theirs(identity) => {
                 assert!(identity.contains("ID_FS_USAGE=filesystem"));
                 assert!(identity.contains("ID_FS_TYPE=ext3"));
                 assert!(identity.contains("ID_FS_UUID"));
-                true
             }
-            _ => false,
-        });
+            // This must fail, and will give a helpful error message
+            id => assert_matches!(id, DevOwnership::Theirs(_)),
+        }
     }
 
     /// Test a blank device and ensure it comes up as device::Usage::Unowned


### PR DESCRIPTION
Right now, if the value does not match DevOwnership::Theirs(_) there is
no helpful error printed.

Signed-off-by: mulhern <amulhern@redhat.com>