### PR TITLE
If we extend the DM table return an indicator to save the fs metadata

### DIFF
--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -199,7 +199,7 @@ impl StratFilesystem {
 
     /// check if filesystem is getting full and needs to be extended
     /// TODO: deal with the thindev in a Fail state.
-    pub fn check(&mut self) -> StratisResult<FilesystemStatus> {
+    pub fn check(&mut self) -> StratisResult<(FilesystemStatus, bool)> {
         match self.thin_dev.status(get_dm())? {
             ThinStatus::Working(_) => {
                 if let Some(mount_point) = self.mount_points()?.first() {
@@ -210,10 +210,10 @@ impl StratFilesystem {
                         table.length =
                             self.thin_dev.size() + self.extend_size(self.thin_dev.size());
                         if self.thin_dev.set_table(get_dm(), table).is_err() {
-                            return Ok(FilesystemStatus::ThinDevExtendFailed);
+                            return Ok((FilesystemStatus::ThinDevExtendFailed, false));
                         }
                         if xfs_growfs(&mount_point).is_err() {
-                            return Ok(FilesystemStatus::XfsGrowFailed);
+                            return Ok((FilesystemStatus::XfsGrowFailed, true));
                         }
                     }
                 }
@@ -227,9 +227,9 @@ impl StratFilesystem {
                 );
                 return Err(StratisError::Engine(ErrorEnum::Error, error_msg));
             }
-            ThinStatus::Fail => return Ok(FilesystemStatus::Failed),
+            ThinStatus::Fail => return Ok((FilesystemStatus::Failed, false)),
         }
-        Ok(FilesystemStatus::Good)
+        Ok((FilesystemStatus::Good, true))
     }
 
     /// Return an extend size for the thindev under the filesystem


### PR DESCRIPTION
Still needs testing to address #1474