### PR TITLE
Temporarily allow Travis cross-compilation target to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     allow_failures:
         # Allow beta tasks to fail
         - rust: beta
+        # Temporarily allow cross-compilation target to fail
+        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         # Run rustfmt using the compiler currently recommended for development
         - rust: 1.31.0


### PR DESCRIPTION
It's failing due to an inability to install Oracle JDK 8.

Signed-off-by: mulhern <amulhern@redhat.com>