### PR TITLE
Downgraded 'Data tier percent used' message from info to debug

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -633,7 +633,13 @@ impl ThinPool {
         }
 
         let overall_used_pct = used_pct(*used, *used + *available);
-        info!("Data tier percent used: {}", overall_used_pct);
+        debug!("Data tier percent used: {}", overall_used_pct);
+        if overall_used_pct >= 90 {
+            info!(
+                "Percent used has reached a critical threshold level; data tier percent used: {}",
+                overall_used_pct
+            );
+        }
 
         let new_state = if overall_used_pct < SPACE_WARN_PCT {
             FreeSpaceState::Good

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -633,7 +633,10 @@ impl ThinPool {
         }
 
         let overall_used_pct = used_pct(*used, *used + *available);
-        debug!("Data tier percent used: {}", overall_used_pct);
+        debug!(
+            "Data tier percent used; thinpool device {} percent used: {}",
+            overall_used_pct, self.thin_pool.device()
+        );
 
         let new_state = if overall_used_pct < SPACE_WARN_PCT {
             FreeSpaceState::Good

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -634,18 +634,16 @@ impl ThinPool {
 
         let overall_used_pct = used_pct(*used, *used + *available);
         debug!("Data tier percent used: {}", overall_used_pct);
-        if overall_used_pct >= 90 {
-            info!(
-                "Percent used has reached a critical threshold level; data tier percent used: {}",
-                overall_used_pct
-            );
-        }
 
         let new_state = if overall_used_pct < SPACE_WARN_PCT {
             FreeSpaceState::Good
         } else if overall_used_pct < SPACE_CRIT_PCT {
             FreeSpaceState::Warn
         } else {
+            info!(
+                "Percent used has reached a critical threshold level; thinpool device {} percent used: {}",
+                self.thin_pool.device(), overall_used_pct
+            );
             FreeSpaceState::Crit
         };
 


### PR DESCRIPTION
The message 'Data tier percent used' was being displayed to the user at the
info level, which is unnecessary for users who don't use up a significant
amount of space.

In this PR, I downgraded the original message to the debug level
and added an info level message which displays the data tier percent used
only when the said percent has reached a critical level.