### PR TITLE
Revert "Temporarily allow Travis cross-compilation target to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
     allow_failures:
         # Allow beta tasks to fail
         - rust: beta
-        # Temporarily allow cross-compilation target to fail
-        - env: TASK=build TARGET=i686-unknown-linux-gnu PKG_CONFIG_ALLOW_CROSS=1 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig/
     include:
         # Run rustfmt using the compiler currently recommended for development
         - rust: 1.31.0


### PR DESCRIPTION
This reverts commit 9dc31a05c681c55f62848b96a4e5fb73cdb47813.