### PR TITLE
Allow stratisd CI test to run test-loop without test_config.json

### DIFF
--- a/tests/ci/stratisd.sh
+++ b/tests/ci/stratisd.sh
@@ -22,21 +22,24 @@ then
     exit 1
 fi
 
+if [ ! -d $WORKSPACE/tests/ ]
+then
+    echo "$WORKSPACE/tests/ does not exist.  Verify WORKSPACE is set to correct directory."
+    exit 1
+fi
 
 # Each CI system must have a TEST_BLOCKDEVS_FILE file populated with
 # block devices that are safe to use/overwrite on the system.
-if [ -s "$TEST_BLOCKDEVS_FILE" ]
+# Only check for this for "make test-real".
+if [ $TARGET == "test-real" ]
 then
-    if [ ! -d $WORKSPACE/tests/ ]
+    if [ -s "$TEST_BLOCKDEVS_FILE" ]
     then
-        echo "$WORKSPACE/tests/ does not exist.  Verify WORKSPACE is set to correct directory."
+        cp $TEST_BLOCKDEVS_FILE $WORKSPACE/tests/.
+    else
+        echo "Required file $TEST_BLOCKDEVS_FILE not found."
         exit 1
     fi
-
-    cp $TEST_BLOCKDEVS_FILE $WORKSPACE/tests/.
-else
-    echo "Required file $TEST_BLOCKDEVS_FILE not found."
-    exit 1
 fi
 
 cd $WORKSPACE


### PR DESCRIPTION
Currently, stratisd.sh exits if the ~/.test_config.json file does
not exist (or is 0 bytes).  This means it's not possible to call
"./tests/ci/stratisd.sh test-loop" to use loop devices, unless
there is a test_config.json file.

To resolve this, do the following:

- Move the check for "! -d $WORKSPACE/tests/" to unconditionally run,
  even if there is no test block device file.

- If $TARGET is "test-real", check to see if there is a test
  block device file.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>