### PR TITLE
Move to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libstratis"
 version = "1.0.3"
 authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.com>"]
+edition = "2018"
 
 [dependencies]
 dbus = {version = "0.6.4", optional = true}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible -D unused -D bare-trait-objects -D ellipsis-inclusive-range-patterns"
+DENY = "-D warnings -D future-incompatible -D unused -D bare-trait-objects -D ellipsis-inclusive-range-patterns -D unused-extern-crates"
 
 TARGET ?= "x86_64-unknown-linux-gnu"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible -D unused -D ellipsis-inclusive-range-patterns"
+DENY = "-D warnings -D future-incompatible -D unused -D bare-trait-objects -D ellipsis-inclusive-range-patterns"
 
 TARGET ?= "x86_64-unknown-linux-gnu"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-DENY = "-D warnings -D future-incompatible -D unused -D bare-trait-objects -D ellipsis-inclusive-range-patterns -D unused-extern-crates"
+RUST_2018_IDIOMS = -D bare-trait-objects \
+		   -D ellipsis-inclusive-range-patterns \
+		   -D unused-extern-crates
+
+DENY = -D warnings -D future-incompatible -D unused ${RUST_2018_IDIOMS}
 
 TARGET ?= "x86_64-unknown-linux-gnu"
 
@@ -22,25 +26,25 @@ fmt-travis:
 
 build:
 	PKG_CONFIG_ALLOW_CROSS=1 \
-	RUSTFLAGS=${DENY} \
+	RUSTFLAGS="${DENY}" \
 	cargo build --target $(TARGET)
 
 build-no-default:
 	PKG_CONFIG_ALLOW_CROSS=1 \
-	RUSTFLAGS=${DENY} \
+	RUSTFLAGS="${DENY}" \
 	cargo build --no-default-features --target $(TARGET)
 
 test-loop:
-	sudo env "PATH=${PATH}" RUSTFLAGS=${DENY} RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_
+	sudo env "PATH=${PATH}" RUSTFLAGS="${DENY}" RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_
 
 test-real:
-	sudo env "PATH=${PATH}" RUSTFLAGS=${DENY} RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test real_
+	sudo env "PATH=${PATH}" RUSTFLAGS="${DENY}" RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test real_
 
 test-travis:
-	sudo env "PATH=${PATH}" RUSTFLAGS=${DENY} RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test travis_
+	sudo env "PATH=${PATH}" RUSTFLAGS="${DENY}" RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test travis_
 
 test:
-	RUSTFLAGS=${DENY} RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_ --skip travis_
+	RUSTFLAGS="${DENY}" RUST_BACKTRACE=1 cargo test -- --skip real_ --skip loop_ --skip travis_
 
 docs: stratisd.8 docs-rust
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible -D unused"
+DENY = "-D warnings -D future-incompatible -D unused -D ellipsis-inclusive-range-patterns"
 
 TARGET ?= "x86_64-unknown-linux-gnu"
 

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -4,20 +4,8 @@
 
 #![allow(clippy::doc_markdown)]
 
-extern crate devicemapper;
-extern crate libstratis;
 #[macro_use]
 extern crate log;
-extern crate chrono;
-extern crate clap;
-#[cfg(feature = "dbus_enabled")]
-extern crate dbus;
-extern crate env_logger;
-extern crate libc;
-extern crate libudev;
-extern crate nix;
-extern crate timerfd;
-extern crate uuid;
 
 use std::cell::RefCell;
 use std::env;
@@ -334,7 +322,7 @@ impl MaybeDbusSupport {
                     let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
                     get_engine_listener_list_mut().register_listener(event_handler);
                     // Register all the pools with dbus
-                    for (_, pool_uuid, mut pool) in engine.borrow_mut().pools_mut() {
+                    for (_, pool_uuid, pool) in engine.borrow_mut().pools_mut() {
                         handle.register_pool(pool_uuid, pool)
                     }
                     self.handle = Some(handle);

--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -201,7 +201,7 @@ pub struct DbusConnectionData {
 
 impl DbusConnectionData {
     /// Connect a stratis engine to dbus.
-    pub fn connect(engine: Rc<RefCell<Engine>>) -> Result<DbusConnectionData, dbus::Error> {
+    pub fn connect(engine: Rc<RefCell<dyn Engine>>) -> Result<DbusConnectionData, dbus::Error> {
         let c = Connection::get_private(BusType::System)?;
         let (tree, object_path) = get_base_tree(DbusContext::new(engine));
         let dbus_context = tree.get_data().clone();
@@ -219,7 +219,7 @@ impl DbusConnectionData {
     }
 
     /// Given the UUID of a pool, register all the pertinent information with dbus.
-    pub fn register_pool(&mut self, pool_uuid: PoolUuid, pool: &mut Pool) {
+    pub fn register_pool(&mut self, pool_uuid: PoolUuid, pool: &mut dyn Pool) {
         let pool_path = create_dbus_pool(&self.context, self.path.clone(), pool_uuid, pool);
         for (_, fs_uuid, fs) in pool.filesystems_mut() {
             create_dbus_filesystem(&self.context, pool_path.clone(), fs_uuid, fs);

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -24,7 +24,7 @@ pub fn create_dbus_blockdev<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
     uuid: Uuid,
-    blockdev: &mut BlockDev,
+    blockdev: &mut dyn BlockDev,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
@@ -162,7 +162,7 @@ fn get_blockdev_property<F, R>(
     getter: F,
 ) -> Result<(), MethodErr>
 where
-    F: Fn(BlockDevTier, &BlockDev) -> Result<R, MethodErr>,
+    F: Fn(BlockDevTier, &dyn BlockDev) -> Result<R, MethodErr>,
     R: dbus::arg::Append,
 {
     let dbus_context = p.tree.get_data();

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -25,7 +25,7 @@ pub fn create_dbus_filesystem<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
     uuid: Uuid,
-    filesystem: &mut Filesystem,
+    filesystem: &mut dyn Filesystem,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 
@@ -148,7 +148,7 @@ fn get_filesystem_property<F, R>(
     getter: F,
 ) -> Result<(), MethodErr>
 where
-    F: Fn((Name, Name, &Filesystem)) -> Result<R, MethodErr>,
+    F: Fn((Name, Name, &dyn Filesystem)) -> Result<R, MethodErr>,
     R: dbus::arg::Append,
 {
     let dbus_context = p.tree.get_data();

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -300,7 +300,7 @@ fn get_pool_property<F, R>(
     getter: F,
 ) -> Result<(), MethodErr>
 where
-    F: Fn((Name, Uuid, &Pool)) -> Result<R, MethodErr>,
+    F: Fn((Name, Uuid, &dyn Pool)) -> Result<R, MethodErr>,
     R: dbus::arg::Append,
 {
     let dbus_context = p.tree.get_data();
@@ -333,7 +333,7 @@ fn get_pool_total_physical_used(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,
 ) -> Result<(), MethodErr> {
-    fn get_used((_, uuid, pool): (Name, Uuid, &Pool)) -> Result<String, MethodErr> {
+    fn get_used((_, uuid, pool): (Name, Uuid, &dyn Pool)) -> Result<String, MethodErr> {
         let err_func = |_| {
             MethodErr::failed(&format!(
                 "no total physical size computed for pool with uuid {}",
@@ -377,7 +377,7 @@ pub fn create_dbus_pool<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
     uuid: Uuid,
-    pool: &mut Pool,
+    pool: &mut dyn Pool,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
 

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -62,12 +62,12 @@ impl OPContext {
 #[derive(Debug, Clone)]
 pub struct DbusContext {
     pub(super) next_index: Rc<Cell<u64>>,
-    pub(super) engine: Rc<RefCell<Engine>>,
+    pub(super) engine: Rc<RefCell<dyn Engine>>,
     pub(super) actions: Rc<RefCell<ActionQueue>>,
 }
 
 impl DbusContext {
-    pub fn new(engine: Rc<RefCell<Engine>>) -> DbusContext {
+    pub fn new(engine: Rc<RefCell<dyn Engine>>) -> DbusContext {
         DbusContext {
             actions: Rc::new(RefCell::new(ActionQueue::default())),
             engine,

--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -30,7 +30,7 @@ pub fn setup_dev_path() -> StratisResult<()> {
 /// it contains.
 // Don't just remove and recreate everything in case there are processes
 // (e.g. user shells) with the current working directory within the tree.
-pub fn setup_pool_devlinks(pool_name: &str, pool: &Pool) {
+pub fn setup_pool_devlinks(pool_name: &str, pool: &dyn Pool) {
     if let Err(err) = || -> StratisResult<()> {
         let pool_path = pool_directory(pool_name);
 
@@ -66,7 +66,7 @@ pub fn setup_pool_devlinks(pool_name: &str, pool: &Pool) {
 /// config. Clear out any directory or file that doesn't correspond to a pool.
 // Don't just remove everything in case there are processes
 // (e.g. user shells) with the current working directory within the tree.
-pub fn cleanup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a Pool)>>(pools: I) {
+pub fn cleanup_devlinks<'a, I: Iterator<Item = &'a (Name, PoolUuid, &'a dyn Pool)>>(pools: I) {
     if let Err(err) = || -> StratisResult<()> {
         let mut existing_dirs = fs::read_dir(DEV_PATH)?
             .map(|dir_e| {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -125,7 +125,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)>;
+    ) -> StratisResult<(FilesystemUuid, &mut dyn Filesystem)>;
 
     /// The total number of Sectors belonging to this pool.
     /// There are no exclusions, so this number includes overhead sectors
@@ -141,29 +141,29 @@ pub trait Pool: Debug {
     fn total_physical_used(&self) -> StratisResult<Sectors>;
 
     /// Get all the filesystems belonging to this pool.
-    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)>;
+    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)>;
 
     /// Get all the filesystems belonging to this pool as mutable references.
-    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)>;
+    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut dyn Filesystem)>;
 
     /// Get the filesystem in this pool with this UUID.
-    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)>;
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &dyn Filesystem)>;
 
     /// Get the mutable filesystem in this pool with this UUID.
-    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut Filesystem)>;
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut dyn Filesystem)>;
 
     /// Get _all_ the blockdevs that belong to this pool.
     /// All really means all. For example, it does not exclude cache blockdevs.
-    fn blockdevs(&self) -> Vec<(Uuid, &BlockDev)>;
+    fn blockdevs(&self) -> Vec<(Uuid, &dyn BlockDev)>;
 
     /// Get all the blockdevs belonging to this pool as mutable references.
-    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut BlockDev)>;
+    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut dyn BlockDev)>;
 
     /// Get the blockdev in this pool with this UUID.
-    fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)>;
+    fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &dyn BlockDev)>;
 
     /// Get a mutable reference to the blockdev in this pool with this UUID.
-    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut BlockDev)>;
+    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut dyn BlockDev)>;
 
     /// Set the user-settable string associated with the blockdev specified
     /// by the uuid.
@@ -223,24 +223,24 @@ pub trait Engine: Debug {
     fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> StratisResult<RenameAction>;
 
     /// Find the pool designated by uuid.
-    fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &Pool)>;
+    fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &dyn Pool)>;
 
     /// Get a mutable referent to the pool designated by uuid.
-    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<(Name, &mut Pool)>;
+    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<(Name, &mut dyn Pool)>;
 
     /// Configure the simulator, for the real engine, this is a null op.
     /// denominator: the probably of failure is 1/denominator.
     fn configure_simulator(&mut self, denominator: u32) -> StratisResult<()>;
 
     /// Get all pools belonging to this engine.
-    fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)>;
+    fn pools(&self) -> Vec<(Name, PoolUuid, &dyn Pool)>;
 
     /// Get mutable references to all pools belonging to this engine.
-    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)>;
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut dyn Pool)>;
 
     /// If the engine would like to include an event in the message loop, it
     /// may return an Eventable from this method.
-    fn get_eventable(&self) -> Option<&'static Eventable>;
+    fn get_eventable(&self) -> Option<&'static dyn Eventable>;
 
     /// Notify the engine that an event has occurred on the Eventable.
     fn evented(&mut self) -> StratisResult<()>;

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -48,7 +48,7 @@ pub trait EngineListener: Debug {
 
 #[derive(Debug)]
 pub struct EngineListenerList {
-    listeners: Vec<Box<EngineListener>>,
+    listeners: Vec<Box<dyn EngineListener>>,
 }
 
 impl EngineListenerList {
@@ -60,7 +60,7 @@ impl EngineListenerList {
     }
 
     /// Add a listener.
-    pub fn register_listener(&mut self, listener: Box<EngineListener>) {
+    pub fn register_listener(&mut self, listener: Box<dyn EngineListener>) {
         self.listeners.push(listener);
     }
 

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -18,7 +18,7 @@ macro_rules! get_pool {
     ($s:ident; $uuid:ident) => {
         $s.pools
             .get_by_uuid($uuid)
-            .map(|(name, p)| (name.clone(), p as &Pool))
+            .map(|(name, p)| (name.clone(), p as &dyn Pool))
     };
 }
 
@@ -26,7 +26,7 @@ macro_rules! get_mut_pool {
     ($s:ident; $uuid:ident) => {
         $s.pools
             .get_mut_by_uuid($uuid)
-            .map(|(name, p)| (name.clone(), p as &mut Pool))
+            .map(|(name, p)| (name.clone(), p as &mut dyn Pool))
     };
 }
 

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate libc;
-
 use std::cell::RefCell;
 use std::collections::hash_map::RandomState;
 use std::collections::HashSet;

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -98,11 +98,11 @@ impl Engine for SimEngine {
         Ok(RenameAction::Renamed)
     }
 
-    fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &Pool)> {
+    fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &dyn Pool)> {
         get_pool!(self; uuid)
     }
 
-    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<(Name, &mut Pool)> {
+    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<(Name, &mut dyn Pool)> {
         get_mut_pool!(self; uuid)
     }
 
@@ -112,21 +112,21 @@ impl Engine for SimEngine {
         Ok(())
     }
 
-    fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)> {
+    fn pools(&self) -> Vec<(Name, PoolUuid, &dyn Pool)> {
         self.pools
             .iter()
-            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &Pool))
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &dyn Pool))
             .collect()
     }
 
-    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)> {
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut dyn Pool)> {
         self.pools
             .iter_mut()
-            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut Pool))
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut dyn Pool))
             .collect()
     }
 
-    fn get_eventable(&self) -> Option<&'static Eventable> {
+    fn get_eventable(&self) -> Option<&'static dyn Eventable> {
         None
     }
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -178,7 +178,7 @@ impl Pool for SimPool {
         _pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)> {
+    ) -> StratisResult<(FilesystemUuid, &mut dyn Filesystem)> {
         if self.filesystems.contains_name(snapshot_name) {
             return Err(StratisError::Engine(
                 ErrorEnum::AlreadyExists,
@@ -217,62 +217,62 @@ impl Pool for SimPool {
         Ok(Sectors(0))
     }
 
-    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)> {
+    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.filesystems
             .iter()
-            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &Filesystem))
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &dyn Filesystem))
             .collect()
     }
 
-    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)> {
+    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut dyn Filesystem)> {
         self.filesystems
             .iter_mut()
-            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &mut Filesystem))
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &mut dyn Filesystem))
             .collect()
     }
 
-    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)> {
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &dyn Filesystem)> {
         self.filesystems
             .get_by_uuid(uuid)
-            .map(|(name, p)| (name, p as &Filesystem))
+            .map(|(name, p)| (name, p as &dyn Filesystem))
     }
 
-    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut Filesystem)> {
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut dyn Filesystem)> {
         self.filesystems
             .get_mut_by_uuid(uuid)
-            .map(|(name, p)| (name, p as &mut Filesystem))
+            .map(|(name, p)| (name, p as &mut dyn Filesystem))
     }
 
-    fn blockdevs(&self) -> Vec<(DevUuid, &BlockDev)> {
+    fn blockdevs(&self) -> Vec<(DevUuid, &dyn BlockDev)> {
         self.block_devs
             .iter()
             .chain(self.cache_devs.iter())
-            .map(|(uuid, bd)| (*uuid, bd as &BlockDev))
+            .map(|(uuid, bd)| (*uuid, bd as &dyn BlockDev))
             .collect()
     }
 
-    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut BlockDev)> {
+    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut dyn BlockDev)> {
         self.block_devs
             .iter_mut()
             .chain(self.cache_devs.iter_mut())
-            .map(|(uuid, b)| (*uuid, b as &mut BlockDev))
+            .map(|(uuid, b)| (*uuid, b as &mut dyn BlockDev))
             .collect()
     }
 
-    fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)> {
+    fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &dyn BlockDev)> {
         self.block_devs
             .get(&uuid)
-            .and_then(|bd| Some((BlockDevTier::Data, bd as &BlockDev)))
+            .and_then(|bd| Some((BlockDevTier::Data, bd as &dyn BlockDev)))
             .or_else(move || {
                 self.cache_devs
                     .get(&uuid)
-                    .and_then(|bd| Some((BlockDevTier::Cache, bd as &BlockDev)))
+                    .and_then(|bd| Some((BlockDevTier::Cache, bd as &dyn BlockDev)))
             })
     }
 
-    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut BlockDev)> {
+    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut dyn BlockDev)> {
         self.get_mut_blockdev_internal(uuid)
-            .map(|(tier, bd)| (tier, bd as &mut BlockDev))
+            .map(|(tier, bd)| (tier, bd as &mut dyn BlockDev))
     }
 
     fn set_blockdev_user_info(

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -191,7 +191,7 @@ impl Backstore {
     ) -> StratisResult<Vec<DevUuid>> {
         match self.cache_tier {
             Some(ref mut cache_tier) => {
-                let mut cache_device = self
+                let cache_device = self
                     .cache
                     .as_mut()
                     .expect("cache_tier.is_some() <=> self.cache.is_some()");

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -420,7 +420,7 @@ fn initialize(
     {
         let mut add_devs = Vec::new();
         for (dev, dev_result) in dev_infos {
-            let (devnode, dev_size, ownership, mut f) = dev_result?;
+            let (devnode, dev_size, ownership, f) = dev_result?;
             if dev_size < MIN_DEV_SIZE {
                 let error_message =
                     format!("{} too small, minimum {}", devnode.display(), MIN_DEV_SIZE);

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -189,7 +189,7 @@ impl BlockDevMgr {
     }
 
     /// Get a function that maps UUIDs to Devices.
-    pub fn uuid_to_devno(&self) -> Box<Fn(DevUuid) -> Option<Device>> {
+    pub fn uuid_to_devno(&self) -> Box<dyn Fn(DevUuid) -> Option<Device>> {
         let uuid_map: HashMap<DevUuid, Device> = self
             .block_devs
             .iter()

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -1238,7 +1238,7 @@ mod tests {
                 (Some(p_index), Some(s_index)) => {
                     // Setup should fail to find a usable Stratis BDA
                     match (p_index, s_index) {
-                        (4...19, 4...19) => {
+                        (4..=19, 4..=19) => {
                             // When we corrupt both magics then we believe that
                             // the signature is not ours and will return Ok(None)
                             prop_assert!(setup_result.is_ok() && setup_result.unwrap().is_none());

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -312,11 +312,11 @@ impl Engine for StratEngine {
         }
     }
 
-    fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &Pool)> {
+    fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &dyn Pool)> {
         get_pool!(self; uuid)
     }
 
-    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<(Name, &mut Pool)> {
+    fn get_mut_pool(&mut self, uuid: PoolUuid) -> Option<(Name, &mut dyn Pool)> {
         get_mut_pool!(self; uuid)
     }
 
@@ -324,21 +324,21 @@ impl Engine for StratEngine {
         Ok(()) // we're not the simulator and not configurable, so just say ok
     }
 
-    fn pools(&self) -> Vec<(Name, PoolUuid, &Pool)> {
+    fn pools(&self) -> Vec<(Name, PoolUuid, &dyn Pool)> {
         self.pools
             .iter()
-            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &Pool))
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &dyn Pool))
             .collect()
     }
 
-    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut Pool)> {
+    fn pools_mut(&mut self) -> Vec<(Name, PoolUuid, &mut dyn Pool)> {
         self.pools
             .iter_mut()
-            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut Pool))
+            .map(|(name, uuid, pool)| (name.clone(), *uuid, pool as &mut dyn Pool))
             .collect()
     }
 
-    fn get_eventable(&self) -> Option<&'static Eventable> {
+    fn get_eventable(&self) -> Option<&'static dyn Eventable> {
         Some(get_dm())
     }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -365,7 +365,7 @@ impl Pool for StratPool {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)> {
+    ) -> StratisResult<(FilesystemUuid, &mut dyn Filesystem)> {
         validate_name(snapshot_name)?;
 
         if self
@@ -393,51 +393,51 @@ impl Pool for StratPool {
             .and_then(|v| Ok(v + self.backstore.datatier_metadata_size()))
     }
 
-    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)> {
+    fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.thin_pool.filesystems()
     }
 
-    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)> {
+    fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut dyn Filesystem)> {
         self.thin_pool.filesystems_mut()
     }
 
-    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &Filesystem)> {
+    fn get_filesystem(&self, uuid: FilesystemUuid) -> Option<(Name, &dyn Filesystem)> {
         self.thin_pool
             .get_filesystem_by_uuid(uuid)
-            .map(|(name, fs)| (name, fs as &Filesystem))
+            .map(|(name, fs)| (name, fs as &dyn Filesystem))
     }
 
-    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut Filesystem)> {
+    fn get_mut_filesystem(&mut self, uuid: FilesystemUuid) -> Option<(Name, &mut dyn Filesystem)> {
         self.thin_pool
             .get_mut_filesystem_by_uuid(uuid)
-            .map(|(name, fs)| (name, fs as &mut Filesystem))
+            .map(|(name, fs)| (name, fs as &mut dyn Filesystem))
     }
 
-    fn blockdevs(&self) -> Vec<(DevUuid, &BlockDev)> {
+    fn blockdevs(&self) -> Vec<(DevUuid, &dyn BlockDev)> {
         self.backstore
             .blockdevs()
             .iter()
-            .map(|&(u, b)| (u, b as &BlockDev))
+            .map(|&(u, b)| (u, b as &dyn BlockDev))
             .collect()
     }
 
-    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut BlockDev)> {
+    fn blockdevs_mut(&mut self) -> Vec<(DevUuid, &mut dyn BlockDev)> {
         self.backstore
             .blockdevs_mut()
             .into_iter()
-            .map(|(u, b)| (u, b as &mut BlockDev))
+            .map(|(u, b)| (u, b as &mut dyn BlockDev))
             .collect()
     }
 
-    fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &BlockDev)> {
+    fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &dyn BlockDev)> {
         self.get_strat_blockdev(uuid)
-            .map(|(t, b)| (t, b as &BlockDev))
+            .map(|(t, b)| (t, b as &dyn BlockDev))
     }
 
-    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut BlockDev)> {
+    fn get_mut_blockdev(&mut self, uuid: DevUuid) -> Option<(BlockDevTier, &mut dyn BlockDev)> {
         self.backstore
             .get_mut_blockdev_by_uuid(uuid)
-            .map(|(t, b)| (t, b as &mut BlockDev))
+            .map(|(t, b)| (t, b as &mut dyn BlockDev))
     }
 
     fn set_blockdev_user_info(

--- a/src/engine/strat_engine/tests/logger.rs
+++ b/src/engine/strat_engine/tests/logger.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate env_logger;
-
 use std::sync::{Once, ONCE_INIT};
 
 static LOGGER_INIT: Once = ONCE_INIT;

--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate loopdev;
-
 use std::fs::OpenOptions;
 use std::os::unix::io::AsRawFd;
 use std::panic;
@@ -14,7 +12,7 @@ use tempfile;
 
 use devicemapper::{Bytes, Sectors, IEC};
 
-use self::loopdev::{LoopControl, LoopDevice};
+use loopdev::{LoopControl, LoopDevice};
 
 use crate::engine::strat_engine::tests::logger::init_logger;
 use crate::engine::strat_engine::tests::util::clean_up;

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -2,13 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-extern crate either;
-
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::{cmp, panic};
 
-use self::either::Either;
+use either::Either;
 use serde_json::{from_reader, Value};
 use uuid::Uuid;
 

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -849,17 +849,17 @@ impl ThinPool {
         !self.filesystems.is_empty()
     }
 
-    pub fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &Filesystem)> {
+    pub fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.filesystems
             .iter()
-            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &Filesystem))
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &dyn Filesystem))
             .collect()
     }
 
-    pub fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut Filesystem)> {
+    pub fn filesystems_mut(&mut self) -> Vec<(Name, FilesystemUuid, &mut dyn Filesystem)> {
         self.filesystems
             .iter_mut()
-            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &mut Filesystem))
+            .map(|(name, uuid, x)| (name.clone(), *uuid, x as &mut dyn Filesystem))
             .collect()
     }
 
@@ -899,7 +899,7 @@ impl ThinPool {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<(FilesystemUuid, &mut Filesystem)> {
+    ) -> StratisResult<(FilesystemUuid, &mut dyn Filesystem)> {
         let snapshot_fs_uuid = Uuid::new_v4();
         let (snapshot_dm_name, snapshot_dm_uuid) =
             format_thin_ids(pool_uuid, ThinRole::Filesystem(snapshot_fs_uuid));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,12 @@
 #![allow(clippy::doc_markdown)]
 
-extern crate devicemapper;
 #[macro_use]
 extern crate nix;
-extern crate byteorder;
-extern crate chrono;
-extern crate crc;
-extern crate uuid;
 
-#[cfg(feature = "dbus_enabled")]
-extern crate dbus;
-
-#[cfg(feature = "dbus_enabled")]
-extern crate libc;
-extern crate libmount;
-extern crate rand;
-extern crate serde;
-extern crate tempfile;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 #[macro_use]
 extern crate log;
-extern crate libudev;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/stratis/errors.rs
+++ b/src/stratis/errors.rs
@@ -82,7 +82,7 @@ impl Error for StratisError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             StratisError::Error(_) | StratisError::Engine(_, _) => None,
             StratisError::Io(ref err) => Some(err),


### PR DESCRIPTION
Please consult edition 2018 blog entry for an overview of changes:
https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html.

This PR omits enforcing two rust-2018-idioms: elided-lifetime-in-paths and explicit-outlives-requirements. Both are lints which allow the programmer to elide certain lifetime annotations. At this time, these elisions seem to me not to increase the clarity of the code, so I see no reason to enforce them.

Denies exactly the same lints, i.e., enforces exactly the same edition 2018 idioms as are enforced in https://github.com/stratis-storage/devicemapper-rs/pull/466.