### PR TITLE
Remove setting default TARGET from Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ matrix:
         - rust: 1.33.0
           before_script:
               - rustup component add rustfmt
-          env: TASK=fmt-travis TARGET=x86_64-unknown-linux-gnu
+          env: TASK=fmt-travis
         # clippy
         - rust: 1.33.0
           before_script:
               - rustup component add clippy
-          env: TASK=clippy TARGET=x86_64-unknown-linux-gnu
+          env: TASK=clippy
 
         # MANDATORY TESTING USING LOWEST SUPPORTED COMPILER
         # tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
         # MANDATORY TESTING USING LOWEST SUPPORTED COMPILER
         # tests
         - rust: 1.31.0
-          env: TASK=test TARGET=x86_64-unknown-linux-gnu
+          env: TASK=test
 
 
         # MANDATORY TESTING ON STABLE
@@ -58,10 +58,10 @@ matrix:
           env: TASK=docs-travis TARGET=x86_64-unknown-linux-gnu
         # test
         - rust: stable
-          env: TASK=test TARGET=x86_64-unknown-linux-gnu
+          env: TASK=test
         # destructive tests that can be run on Travis
         - rust: stable
-          env: TASK=test-travis TARGET=x86_64-unknown-linux-gnu
+          env: TASK=test-travis
           sudo: required
 
 
@@ -86,7 +86,7 @@ matrix:
         # ALLOWED FAILURES
         # Run destructive tests on rust beta, in order to be good Rustaceans
         - rust: beta
-          env: TASK=test-travis TARGET=x86_64-unknown-linux-gnu
+          env: TASK=test-travis
           sudo: required
 branches:
     only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
             - sudo apt-get install -y gcc-multilib libdbus-1-dev:i386 libdbus-glib-1-dev:i386 libglib2.0-dev:i386 libudev-dev:i386
         # Build docs
         - rust: stable
-          env: TASK=docs-travis TARGET=x86_64-unknown-linux-gnu
+          env: TASK=docs-travis
         # test
         - rust: stable
           env: TASK=test

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+ifeq ($(origin TARGET), undefined)
+else
+  TARGET_ARGS = --target=${TARGET}
+endif
+
 RUST_2018_IDIOMS = -D bare-trait-objects \
 		   -D ellipsis-inclusive-range-patterns \
 		   -D unused-extern-crates
 
 DENY = -D warnings -D future-incompatible -D unused ${RUST_2018_IDIOMS}
-
-TARGET ?= "x86_64-unknown-linux-gnu"
 
 ${HOME}/.cargo/bin/cargo-tree:
 	cargo install cargo-tree
@@ -27,12 +30,12 @@ fmt-travis:
 build:
 	PKG_CONFIG_ALLOW_CROSS=1 \
 	RUSTFLAGS="${DENY}" \
-	cargo build --target $(TARGET)
+	cargo build ${TARGET_ARGS}
 
 build-no-default:
 	PKG_CONFIG_ALLOW_CROSS=1 \
 	RUSTFLAGS="${DENY}" \
-	cargo build --no-default-features --target $(TARGET)
+	cargo build --no-default-features ${TARGET_ARGS}
 
 test-loop:
 	sudo env "PATH=${PATH}" RUSTFLAGS="${DENY}" RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test loop_

--- a/tests/ci/stratisd.sh
+++ b/tests/ci/stratisd.sh
@@ -48,10 +48,6 @@ cargo clean
 make build
 make $TARGET
 
-# 32 bit build
-rustup target add i686-unknown-linux-gnu
-TARGET=i686-unknown-linux-gnu make build
-
 # If there is a stale STRATIS_DEPS_DIR remove it
 if [ -d $STRATIS_DEPS_DIR ]
 then

--- a/tests/ci/stratisd.sh
+++ b/tests/ci/stratisd.sh
@@ -45,8 +45,9 @@ fi
 cd $WORKSPACE
 rustup default 1.31.0
 cargo clean
-make build
 make $TARGET
+
+make build
 
 # If there is a stale STRATIS_DEPS_DIR remove it
 if [ -d $STRATIS_DEPS_DIR ]
@@ -57,7 +58,6 @@ fi
 if [ -d $WORKSPACE/tests/client-dbus ]
 then
     echo "Running client-dbus tests"
-    export STRATISD=$WORKSPACE/target/x86_64-unknown-linux-gnu/debug/stratisd
 
     if [ ! -f  /etc/dbus-1/system.d/stratisd.conf ]
     then
@@ -90,7 +90,7 @@ then
     done
     # Set the PYTHONPATH to use the dependencies
     export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
-    export STRATISD=$WORKSPACE/target/x86_64-unknown-linux-gnu/debug/stratisd
+    export STRATISD=$WORKSPACE/target/debug/stratisd
     cd $STRATIS_DEPS_DIR/dbus-client-gen
 
     cd $WORKSPACE/tests/client-dbus


### PR DESCRIPTION
Also do not set TARGET in travis config file where it is ignored by the make task.

The basic idea is to let _cargo_ decide what the target architecture should be. If that is set up, then the CI script does not need to accept the _Makefile_'s target architecture, but can instead accept cargo's default. This is simpler, and also more general.

This also means that in stratisd.sh there is only one ```TARGET``` variable, the one that specifies what kind of test to run.