### PR TITLE
Correctly calculate space available for variable length metadata

### DIFF
--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -8,7 +8,7 @@ use std::{fs::OpenOptions, path::PathBuf};
 
 use chrono::{DateTime, TimeZone, Utc};
 
-use devicemapper::{Device, Sectors};
+use devicemapper::{Bytes, Device, Sectors};
 
 use crate::{
     engine::{
@@ -134,7 +134,7 @@ impl StratBlockDev {
 
     /// The maximum size of variable length metadata that can be accommodated.
     /// self.max_metadata_size() < self.metadata_size()
-    pub fn max_metadata_size(&self) -> Sectors {
+    pub fn max_metadata_size(&self) -> Bytes {
         self.bda.max_data_size()
     }
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -326,7 +326,7 @@ impl BlockDevMgr {
             current_time
         };
 
-        let data_size = Bytes(metadata.len() as u64).sectors();
+        let data_size = Bytes(metadata.len() as u64);
         let candidates = self
             .block_devs
             .iter_mut()

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -516,10 +516,16 @@ mod mda {
     const STRAT_REGION_HDR_VERSION: u8 = 1;
     const STRAT_METADATA_VERSION: u8 = 1;
 
+    /// Manages the MDA regions which hold the variable length metadata.
     #[derive(Debug)]
     pub struct MDARegions {
-        // Spec defines 4 regions, but regions 2 & 3 are duplicates of 0 and 1 respectively
+        /// The size of a single MDA region. The MDAHeader occupies the
+        /// first few bytes of its region, the rest is available for the
+        /// variable length metadata.
         region_size: Sectors,
+        /// The MDA headers which contain information about the variable
+        /// length metadata. NUM_PRIMARY_MDA_REGIONS is 2: in the general
+        /// case one is more recently written than the other.
         mdas: [Option<MDAHeader>; NUM_PRIMARY_MDA_REGIONS],
     }
 

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -221,7 +221,7 @@ impl BDA {
     }
 
     /// The maximum size of variable length metadata that can be accommodated.
-    pub fn max_data_size(&self) -> Sectors {
+    pub fn max_data_size(&self) -> Bytes {
         self.regions.max_data_size()
     }
 
@@ -531,8 +531,8 @@ mod mda {
 
         /// The maximum size of variable length metadata that this region
         /// can accommodate.
-        pub fn max_data_size(&self) -> Sectors {
-            self.region_size
+        pub fn max_data_size(&self) -> Bytes {
+            self.region_size.bytes() - MDA_REGION_HDR_SIZE
         }
 
         /// Initialize the space allotted to the MDA regions to 0.

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -636,15 +636,12 @@ mod mda {
                 ));
             }
 
-            let region_size = self.region_size.bytes();
             let used = Bytes(data.len() as u64);
-
-            if MDA_REGION_HDR_SIZE + used > region_size {
+            let max_available = self.max_data_size();
+            if used > max_available {
                 let err_msg = format!(
                     "metadata length {} exceeds region available {}",
-                    used,
-                    // region_size > header size
-                    region_size - MDA_REGION_HDR_SIZE
+                    used, max_available
                 );
                 return Err(StratisError::Engine(ErrorEnum::Invalid, err_msg));
             };
@@ -657,6 +654,7 @@ mod mda {
             let hdr_buf = header.to_buf();
 
             // Write data to a region specified by index.
+            let region_size = self.region_size.bytes();
             let mut save_region = |index: usize| -> StratisResult<()> {
                 f.seek(SeekFrom::Start(MDARegions::mda_offset(
                     header_size,


### PR DESCRIPTION
Primarily, this fixes a bug where the value for max_data_size was a bit too large. It also adds documentation to avoid problems like this in future, and uses the corrected method internally.

This is an easy defect to identify; but the effects for stratisd's execution would be hard to reproduce. In the first case, it is necessary to cause variable length metadata to be generated that is greater than the maximum available but no more than the MDA region size. That would require some finesse. Even if that happened, the consequence at this time would only be that an attempt would be made to write the data, which would fail w/ an error in the invoked method. So, the data would still not be written. I would venture to say that the incorrect behavior associated with the code defect has never occurred so far.

The greatest danger of this code defect at this time is confusion to a reader of this and other related code stemming from the inconsistent use of the region_size field. I've tried to address that with better documentation of the MDARegions struct.