### PR TITLE
Remove some instances of constant misuse

### DIFF
--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1224,7 +1224,6 @@ mod tests {
 
     use crate::engine::strat_engine::{
         backstore::MIN_MDA_SECTORS,
-        cmd,
         device::SyncAll,
         tests::{loopbacked, real},
     };
@@ -1352,13 +1351,6 @@ mod tests {
             ThinPoolStatus::Error => panic!("Could not obtain status for thinpool."),
             ThinPoolStatus::Fail => panic!("ThinPoolStatus::Fail  Expected working/full."),
         };
-
-        // Clear anything that may be on the remaining paths to ensure we can add them
-        // to the pool
-        for p in remaining_paths {
-            wipe_sectors(p, Sectors(0), MIN_MDA_SECTORS).unwrap();
-        }
-        cmd::udev_settle().unwrap();
 
         // Add block devices to the pool and run check() to extend
         backstore.add_datadevs(pool_uuid, &remaining_paths).unwrap();


### PR DESCRIPTION
This PR addresses two places where the constant MIN_MDA_SECTORS was being used in tests not for testing MDA code or anything related to it, but because it must have seemed to be roughly the correct size. In both cases it was used as an argument to wipe_sectors, and in both cases, the starting offset was 0; the MDA itself does not start from zero, which was a hint that something might be wrong. It turns out that in both cases the call to wipe_sectors is unnecessary and the tests can be improved by removing the call entirely.