### PR TITLE
Use assert_matches! instead of assert! where it can be useful in tests

### DIFF
--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     /// When an engine has no pools, any name lookup should fail
     fn get_pool_err() {
-        assert!(SimEngine::default().get_pool(Uuid::new_v4()).is_none());
+        assert_matches!(SimEngine::default().get_pool(Uuid::new_v4()), None);
     }
 
     #[test]

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -206,7 +206,7 @@ mod tests {
             pool.create_filesystems(uuid, pool_name, &[("test", None)])
                 .unwrap();
         }
-        assert!(engine.destroy_pool(uuid).is_err());
+        assert_matches!(engine.destroy_pool(uuid), Err(_));
     }
 
     #[test]
@@ -257,9 +257,7 @@ mod tests {
     /// Creating a pool with an impossible raid level should fail
     fn create_pool_max_u16_raid() {
         let mut engine = SimEngine::default();
-        assert!(engine
-            .create_pool("name", &[], Some(std::u16::MAX))
-            .is_err());
+        assert_matches!(engine.create_pool("name", &[], Some(std::u16::MAX)), Err(_));
     }
 
     #[test]

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     /// When an engine has no pools, destroying any pool must succeed
     fn destroy_pool_empty() {
-        assert!(SimEngine::default().destroy_pool(Uuid::new_v4()).is_ok());
+        assert_matches!(SimEngine::default().destroy_pool(Uuid::new_v4()), Ok(_));
     }
 
     #[test]
@@ -180,7 +180,7 @@ mod tests {
     fn destroy_empty_pool() {
         let mut engine = SimEngine::default();
         let uuid = engine.create_pool("name", &[], None).unwrap();
-        assert!(engine.destroy_pool(uuid).is_ok());
+        assert_matches!(engine.destroy_pool(uuid), Ok(_));
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
         let uuid = engine
             .create_pool("name", &[Path::new("/s/d")], None)
             .unwrap();
-        assert!(engine.destroy_pool(uuid).is_ok());
+        assert_matches!(engine.destroy_pool(uuid), Ok(_));
     }
 
     #[test]

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -415,9 +415,10 @@ mod tests {
         let pool_name = "pool_name";
         let uuid = engine.create_pool(pool_name, &[], None).unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
-        assert!(pool
-            .destroy_filesystems(pool_name, &[Uuid::new_v4()])
-            .is_ok());
+        assert_matches!(
+            pool.destroy_filesystems(pool_name, &[Uuid::new_v4()]),
+            Ok(_)
+        );
     }
 
     #[test]

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -651,7 +651,7 @@ mod tests {
         invariant(&backstore);
 
         assert_eq!(cache_uuids.len(), initcachepaths.len());
-        assert!(backstore.linear.is_none());
+        assert_matches!(backstore.linear, None);
 
         let cache_status = backstore
             .cache
@@ -733,10 +733,12 @@ mod tests {
         let pool_uuid = Uuid::new_v4();
         let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
 
-        assert!(backstore
-            .request(pool_uuid, Sectors(IEC::Ki), Sectors(IEC::Mi))
-            .unwrap()
-            .is_none());
+        assert_matches!(
+            backstore
+                .request(pool_uuid, Sectors(IEC::Ki), Sectors(IEC::Mi))
+                .unwrap(),
+            None
+        );
 
         let request = Sectors(IEC::Ei);
         let modulus = Sectors(IEC::Ki);

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -593,7 +593,10 @@ mod tests {
             .map(|(_, v)| *v)
             .collect::<Vec<&Path>>();
 
-        assert!(BlockDevMgr::initialize(pool_uuid, &clean_paths, MIN_MDA_SECTORS).is_ok());
+        assert_matches!(
+            BlockDevMgr::initialize(pool_uuid, &clean_paths, MIN_MDA_SECTORS),
+            Ok(_)
+        );
         cmd::udev_settle().unwrap();
 
         for path in clean_paths {
@@ -651,7 +654,7 @@ mod tests {
         assert!(BlockDevMgr::initialize(uuid2, paths1, MIN_MDA_SECTORS).is_err());
 
         let original_length = bd_mgr.block_devs.len();
-        assert!(bd_mgr.add(uuid, paths1).is_ok());
+        assert_matches!(bd_mgr.add(uuid, paths1), Ok(_));
         assert_eq!(bd_mgr.block_devs.len(), original_length);
 
         BlockDevMgr::initialize(uuid, paths2, MIN_MDA_SECTORS).unwrap();

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -577,7 +577,10 @@ mod tests {
         cmd::udev_settle().unwrap();
 
         let pool_uuid = Uuid::new_v4();
-        assert!(BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS).is_err());
+        assert_matches!(
+            BlockDevMgr::initialize(pool_uuid, paths, MIN_MDA_SECTORS),
+            Err(_)
+        );
         for (i, path) in paths.iter().enumerate() {
             if i == index {
                 assert_matches!(identify(path).unwrap(), DevOwnership::Theirs(_));
@@ -651,7 +654,10 @@ mod tests {
         let mut bd_mgr = BlockDevMgr::initialize(uuid, paths1, MIN_MDA_SECTORS).unwrap();
         cmd::udev_settle().unwrap();
 
-        assert!(BlockDevMgr::initialize(uuid2, paths1, MIN_MDA_SECTORS).is_err());
+        assert_matches!(
+            BlockDevMgr::initialize(uuid2, paths1, MIN_MDA_SECTORS),
+            Err(_)
+        );
 
         let original_length = bd_mgr.block_devs.len();
         assert_matches!(bd_mgr.add(uuid, paths1), Ok(_));
@@ -660,7 +666,7 @@ mod tests {
         BlockDevMgr::initialize(uuid, paths2, MIN_MDA_SECTORS).unwrap();
         cmd::udev_settle().unwrap();
 
-        assert!(bd_mgr.add(uuid, paths2).is_err());
+        assert_matches!(bd_mgr.add(uuid, paths2), Err(_));
     }
 
     #[test]

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -1286,7 +1286,8 @@ mod tests {
             assert_ne!(reference_buf.get_ref(), buf_newer.get_ref());
 
             let setup_result = StaticHeader::setup(&mut buf_newer);
-            assert!(setup_result.is_ok() && setup_result.unwrap().is_some());
+            assert_matches!(setup_result, Ok(_));
+            assert!(setup_result.unwrap().is_some());
 
             // We should match the reference buffer
             assert_eq!(reference_buf.get_ref(), buf_newer.get_ref());

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -922,7 +922,10 @@ mod mda {
         fn test_reading_mda_regions() {
             let buf_length = *(BDA_STATIC_HDR_SIZE + MIN_MDA_SECTORS.bytes()) as usize;
             let mut buf = Cursor::new(vec![0; buf_length]);
-            assert!(MDARegions::load(BDA_STATIC_HDR_SIZE, MIN_MDA_SECTORS, &mut buf).is_err());
+            assert_matches!(
+                MDARegions::load(BDA_STATIC_HDR_SIZE, MIN_MDA_SECTORS, &mut buf),
+                Err(_)
+            );
 
             MDARegions::initialize(BDA_STATIC_HDR_SIZE, MIN_MDA_SECTORS, &mut buf).unwrap();
             let regions = MDARegions::load(BDA_STATIC_HDR_SIZE, MIN_MDA_SECTORS, &mut buf).unwrap();
@@ -969,7 +972,7 @@ mod mda {
             };
             let mut buf = header.to_buf();
             LittleEndian::write_u32(&mut buf[..4], 0u32);
-            assert!(MDAHeader::from_buf(&buf).is_err());
+            assert_matches!(MDAHeader::from_buf(&buf), Err(_));
         }
     }
 }
@@ -1107,7 +1110,7 @@ mod tests {
         bda.save_state(&timestamp1, &data, &mut buf).unwrap();
 
         // Error, because current timestamp is older than written to newer.
-        assert!(bda.save_state(&timestamp0, &data, &mut buf).is_err());
+        assert_matches!(bda.save_state(&timestamp0, &data, &mut buf), Err(_));
 
         let timestamp2 = Utc::now();
         let timestamp3 = Utc::now();
@@ -1116,7 +1119,7 @@ mod tests {
         bda.save_state(&timestamp3, &data, &mut buf).unwrap();
 
         // Error, because current timestamp is older than written to newer.
-        assert!(bda.save_state(&timestamp2, &data, &mut buf).is_err());
+        assert_matches!(bda.save_state(&timestamp2, &data, &mut buf), Err(_));
     }
 
     proptest! {

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -929,7 +929,7 @@ mod mda {
 
             MDARegions::initialize(BDA_STATIC_HDR_SIZE, MIN_MDA_SECTORS, &mut buf).unwrap();
             let regions = MDARegions::load(BDA_STATIC_HDR_SIZE, MIN_MDA_SECTORS, &mut buf).unwrap();
-            assert!(regions.last_update_time().is_none());
+            assert_matches!(regions.last_update_time(), None);
         }
 
         proptest! {

--- a/src/engine/strat_engine/backstore/range_alloc.rs
+++ b/src/engine/strat_engine/backstore/range_alloc.rs
@@ -376,7 +376,7 @@ mod tests {
         let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         let bad_insert_ranges = [(Sectors(21), Sectors(20)), (Sectors(40), Sectors(40))];
-        assert!(allocator.insert_ranges(&bad_insert_ranges).is_err())
+        assert_matches!(allocator.insert_ranges(&bad_insert_ranges), Err(_))
     }
 
     #[test]
@@ -384,7 +384,7 @@ mod tests {
         let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         let bad_insert_ranges = [(Sectors(40), Sectors(1)), (Sectors(39), Sectors(2))];
-        assert!(allocator.insert_ranges(&bad_insert_ranges).is_err())
+        assert_matches!(allocator.insert_ranges(&bad_insert_ranges), Err(_))
     }
 
     #[test]
@@ -410,9 +410,7 @@ mod tests {
         assert_eq!(request.0, Sectors(128));
         assert_eq!(request.1, &[(Sectors(0), Sectors(128))]);
 
-        assert!(allocator
-            .insert_ranges(&[(Sectors(1), Sectors(1))])
-            .is_err());
+        assert_matches!(allocator.insert_ranges(&[(Sectors(1), Sectors(1))]), Err(_));
     }
 
     #[test]
@@ -458,9 +456,10 @@ mod tests {
         let mut allocator = RangeAllocator::new(Sectors(128), &[]).unwrap();
 
         // overflow limit range
-        assert!(allocator
-            .insert_ranges(&[(Sectors(1), Sectors(128))])
-            .is_err());
+        assert_matches!(
+            allocator.insert_ranges(&[(Sectors(1), Sectors(128))]),
+            Err(_)
+        );
     }
 
     #[test]
@@ -472,8 +471,9 @@ mod tests {
         let mut allocator = RangeAllocator::new(Sectors(MAX), &[]).unwrap();
 
         // overflow max u64
-        assert!(allocator
-            .insert_ranges(&[(Sectors(MAX), Sectors(1))])
-            .is_err());
+        assert_matches!(
+            allocator.insert_ranges(&[(Sectors(MAX), Sectors(1))]),
+            Err(_)
+        );
     }
 }

--- a/src/engine/strat_engine/names.rs
+++ b/src/engine/strat_engine/names.rs
@@ -263,15 +263,15 @@ mod tests {
         assert!(validate_name("\u{0}multiple\u{0}_null\u{0}").is_err());
         assert!(validate_name(&"𐌏".repeat(64)).is_err());
 
-        assert!(validate_name(&"𐌏".repeat(63)).is_ok());
-        assert!(validate_name(&'\u{10fff8}'.to_string()).is_ok());
-        assert!(validate_name("*< ? >").is_ok());
-        assert!(validate_name("...").is_ok());
-        assert!(validate_name("ok.name").is_ok());
-        assert!(validate_name("ok name with spaces").is_ok());
-        assert!(validate_name("\\\\").is_ok());
-        assert!(validate_name("\u{211D}").is_ok());
-        assert!(validate_name("☺").is_ok());
-        assert!(validate_name("ok_name").is_ok());
+        assert_matches!(validate_name(&"𐌏".repeat(63)), Ok(_));
+        assert_matches!(validate_name(&'\u{10fff8}'.to_string()), Ok(_));
+        assert_matches!(validate_name("*< ? >"), Ok(_));
+        assert_matches!(validate_name("..."), Ok(_));
+        assert_matches!(validate_name("ok.name"), Ok(_));
+        assert_matches!(validate_name("ok name with spaces"), Ok(_));
+        assert_matches!(validate_name("\\\\"), Ok(_));
+        assert_matches!(validate_name("\u{211D}"), Ok(_));
+        assert_matches!(validate_name("☺"), Ok(_));
+        assert_matches!(validate_name("ok_name"), Ok(_));
     }
 }

--- a/src/engine/strat_engine/names.rs
+++ b/src/engine/strat_engine/names.rs
@@ -244,24 +244,24 @@ mod tests {
     #[test]
     #[allow(clippy::cyclomatic_complexity)]
     pub fn test_validate_name() {
-        assert!(validate_name(&'\u{0}'.to_string()).is_err());
-        assert!(validate_name("./some").is_err());
-        assert!(validate_name("../../root").is_err());
-        assert!(validate_name("/").is_err());
-        assert!(validate_name("\u{1c}\u{7}").is_err());
-        assert!(validate_name("./foo/bar.txt").is_err());
-        assert!(validate_name(".").is_err());
-        assert!(validate_name("..").is_err());
-        assert!(validate_name("/dev/sdb").is_err());
-        assert!(validate_name("").is_err());
-        assert!(validate_name("/").is_err());
-        assert!(validate_name(" leading_space").is_err());
-        assert!(validate_name("trailing_space ").is_err());
-        assert!(validate_name("\u{0}leading_null").is_err());
-        assert!(validate_name("trailing_null\u{0}").is_err());
-        assert!(validate_name("middle\u{0}_null").is_err());
-        assert!(validate_name("\u{0}multiple\u{0}_null\u{0}").is_err());
-        assert!(validate_name(&"𐌏".repeat(64)).is_err());
+        assert_matches!(validate_name(&'\u{0}'.to_string()), Err(_));
+        assert_matches!(validate_name("./some"), Err(_));
+        assert_matches!(validate_name("../../root"), Err(_));
+        assert_matches!(validate_name("/"), Err(_));
+        assert_matches!(validate_name("\u{1c}\u{7}"), Err(_));
+        assert_matches!(validate_name("./foo/bar.txt"), Err(_));
+        assert_matches!(validate_name("."), Err(_));
+        assert_matches!(validate_name(".."), Err(_));
+        assert_matches!(validate_name("/dev/sdb"), Err(_));
+        assert_matches!(validate_name(""), Err(_));
+        assert_matches!(validate_name("/"), Err(_));
+        assert_matches!(validate_name(" leading_space"), Err(_));
+        assert_matches!(validate_name("trailing_space "), Err(_));
+        assert_matches!(validate_name("\u{0}leading_null"), Err(_));
+        assert_matches!(validate_name("trailing_null\u{0}"), Err(_));
+        assert_matches!(validate_name("middle\u{0}_null"), Err(_));
+        assert_matches!(validate_name("\u{0}multiple\u{0}_null\u{0}"), Err(_));
+        assert_matches!(validate_name(&"𐌏".repeat(64)), Err(_));
 
         assert_matches!(validate_name(&"𐌏".repeat(63)), Ok(_));
         assert_matches!(validate_name(&'\u{10fff8}'.to_string()), Ok(_));

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -611,7 +611,7 @@ mod tests {
         invariant(&pool, &name);
 
         let metadata1 = pool.record(name);
-        assert!(metadata1.backstore.cache_tier.is_none());
+        assert_matches!(metadata1.backstore.cache_tier, None);
 
         let (_, fs_uuid) = pool
             .create_filesystems(uuid, &name, &[("stratis-filesystem", None)])

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -579,7 +579,10 @@ mod tests {
     /// space required.
     fn test_empty_pool(paths: &[&Path]) {
         assert_eq!(paths.len(), 0);
-        assert!(StratPool::initialize("stratis_test_pool", paths, Redundancy::NONE).is_err());
+        assert_matches!(
+            StratPool::initialize("stratis_test_pool", paths, Redundancy::NONE),
+            Err(_)
+        );
     }
 
     #[test]

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1643,7 +1643,7 @@ mod tests {
         // thinpool, ::setup() will fail.
         let pool = ThinPool::setup(pool_uuid, &thinpooldevsave, &flexdevs, &backstore).unwrap();
 
-        assert!(pool.get_filesystem_by_uuid(fs_uuid).is_none());
+        assert_matches!(pool.get_filesystem_by_uuid(fs_uuid), None);
     }
 
     #[test]

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -332,11 +332,11 @@ mod tests {
         let mut thing = thing.unwrap();
         thing.1.stuff = 0;
         assert!(t.is_empty());
-        assert!(t.remove_by_name(&name).is_none());
+        assert_matches!(t.remove_by_name(&name), None);
         table_invariant(&t);
 
-        assert!(t.get_by_name(&name).is_none());
-        assert!(t.get_by_uuid(uuid).is_none());
+        assert_matches!(t.get_by_name(&name), None);
+        assert_matches!(t.get_by_uuid(uuid), None);
     }
 
     #[test]
@@ -357,7 +357,7 @@ mod tests {
         table_invariant(&t);
 
         // There was nothing previously, so displaced must be empty.
-        assert!(displaced.is_none());
+        assert_matches!(displaced, None);
 
         // t now contains the inserted thing.
         assert!(t.contains_name(&name));
@@ -398,7 +398,7 @@ mod tests {
         // There was nothing in the table before, so displaced is empty.
         let displaced = t.insert(Name::new(name.to_owned()), uuid, thing);
         table_invariant(&t);
-        assert!(displaced.is_none());
+        assert_matches!(displaced, None);
 
         // t now contains thing.
         assert!(t.contains_name(&name));
@@ -442,7 +442,7 @@ mod tests {
         // There was nothing in the table before, so displaced is empty.
         let displaced = t.insert(Name::new(name.to_owned()), uuid, thing);
         table_invariant(&t);
-        assert!(displaced.is_none());
+        assert_matches!(displaced, None);
 
         // t now contains thing.
         assert!(t.contains_name(&name));
@@ -492,7 +492,7 @@ mod tests {
         // displaced is empty.
         let displaced = t.insert(Name::new(name1.to_owned()), uuid1, thing1);
         table_invariant(&t);
-        assert!(displaced.is_none());
+        assert_matches!(displaced, None);
 
         // t now contains thing1.
         assert!(t.contains_name(&name1));
@@ -501,7 +501,7 @@ mod tests {
         // Insert second item. No conflicts, so nothing is displaced.
         let displaced = t.insert(Name::new(name2.to_owned()), uuid2, thing2);
         table_invariant(&t);
-        assert!(displaced.is_none());
+        assert_matches!(displaced, None);
 
         // t now also contains thing2.
         assert!(t.contains_name(&name2));


### PR DESCRIPTION
We can transform assert!(<expr>.<function that evaluates to a bool>()) to assert_matches!(<expr>, <appropriate constructor with or w/out wildcards>). If we do this, then, on assertion failure, we get a comparison of the expected value and the actual value.

Note that there is no point in transforming assert!(<expr>.is_some()). If is_some() is false, then the value of the expression is just None, and we already know what that looks like.