### PR TITLE
Use types to distinguish between sizes that represent different parts of the MDA

### DIFF
--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -8,13 +8,13 @@ use std::{fs::OpenOptions, path::PathBuf};
 
 use chrono::{DateTime, TimeZone, Utc};
 
-use devicemapper::{Bytes, Device, Sectors};
+use devicemapper::{Device, Sectors};
 
 use crate::{
     engine::{
         event::get_engine_listener_list,
         strat_engine::{
-            backstore::{metadata::BDA, range_alloc::RangeAllocator},
+            backstore::{metadata::BDA, range_alloc::RangeAllocator, MDADataSize},
             serde_structs::{BaseBlockDevSave, Recordable},
         },
         BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath, PoolUuid,
@@ -134,7 +134,7 @@ impl StratBlockDev {
 
     /// The maximum size of variable length metadata that can be accommodated.
     /// self.max_metadata_size() < self.metadata_size()
-    pub fn max_metadata_size(&self) -> Bytes {
+    pub fn max_metadata_size(&self) -> MDADataSize {
         self.bda.max_data_size()
     }
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -331,7 +331,7 @@ impl BlockDevMgr {
         let candidates = self
             .block_devs
             .iter_mut()
-            .filter(|b| b.max_metadata_size() >= data_size);
+            .filter(|b| b.max_metadata_size().bytes() >= data_size);
 
         // TODO: consider making selection not entirely random, i.e, ensuring
         // distribution of metadata over different paths.

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -240,7 +240,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::engine::strat_engine::{
-        backstore::MIN_MDA_SECTORS,
+        backstore::MDADataSize,
         tests::{loopbacked, real},
     };
 
@@ -256,7 +256,7 @@ mod tests {
 
         let pool_uuid = Uuid::new_v4();
 
-        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MIN_MDA_SECTORS).unwrap();
+        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MDADataSize::default()).unwrap();
 
         let mut cache_tier = CacheTier::new(mgr).unwrap();
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -179,7 +179,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::engine::strat_engine::{
-        backstore::MIN_MDA_SECTORS,
+        backstore::MDADataSize,
         tests::{loopbacked, real},
     };
 
@@ -194,7 +194,7 @@ mod tests {
 
         let pool_uuid = Uuid::new_v4();
 
-        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MIN_MDA_SECTORS).unwrap();
+        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MDADataSize::default()).unwrap();
 
         let mut data_tier = DataTier::new(mgr);
 

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -221,7 +221,7 @@ impl BDA {
     }
 
     /// The maximum size of variable length metadata that can be accommodated.
-    pub fn max_data_size(&self) -> Bytes {
+    pub fn max_data_size(&self) -> MDADataSize {
         self.regions.max_data_size()
     }
 
@@ -651,8 +651,8 @@ mod mda {
 
         /// The maximum size of variable length metadata that this region
         /// can accommodate.
-        pub fn max_data_size(&self) -> Bytes {
-            self.region_size.data_size().bytes()
+        pub fn max_data_size(&self) -> MDADataSize {
+            self.region_size.data_size()
         }
 
         /// Initialize the space allotted to the MDA regions to 0.
@@ -756,7 +756,7 @@ mod mda {
             }
 
             let used = Bytes(data.len() as u64);
-            let max_available = self.max_data_size();
+            let max_available = self.max_data_size().bytes();
             if used > max_available {
                 let err_msg = format!(
                     "metadata length {} exceeds region available {}",

--- a/src/engine/strat_engine/backstore/metadata.rs
+++ b/src/engine/strat_engine/backstore/metadata.rs
@@ -502,8 +502,17 @@ mod mda {
         stratis::{ErrorEnum, StratisError, StratisResult},
     };
 
+    #[cfg(test)]
+    // The minimum size allocated for variable length metadata
+    const MIN_MDA_DATA_REGION_SIZE: Bytes = Bytes(260_064);
+
     const _MDA_REGION_HDR_SIZE: usize = 32;
     const MDA_REGION_HDR_SIZE: Bytes = Bytes(_MDA_REGION_HDR_SIZE as u64);
+
+    #[cfg(test)]
+    // The minimum size allocated for a complete MDA region
+    // MIN_MDA_DATA_REGION_SIZE + MDA_REGION_HDR_SIZE
+    const MIN_MDA_REGION_SIZE: Sectors = Sectors(508);
 
     const NUM_PRIMARY_MDA_REGIONS: usize = 2;
 
@@ -511,6 +520,8 @@ mod mda {
     // of MDA regions is twice the number of primary MDA regions.
     const NUM_MDA_REGIONS: usize = 2 * NUM_PRIMARY_MDA_REGIONS;
 
+    // The minimum size allocated for a group of MDA regions.
+    // NUM_MDA_REGIONS * MIN_MDA_REGION_SIZE.
     pub const MIN_MDA_SECTORS: Sectors = Sectors(2032);
 
     const STRAT_REGION_HDR_VERSION: u8 = 1;
@@ -902,6 +913,21 @@ mod mda {
         // 82102984128000 in decimal, approx 17 million years
         const UTC_TIMESTAMP_SECS_BOUND: i64 = 0x777_9beb_9f00;
         const UTC_TIMESTAMP_NSECS_BOUND: u32 = 2_000_000_000u32;
+
+        #[test]
+        /// Verify that constants have the correct relationship to each other.
+        fn test_constants() {
+            // The minimum size for a single region is the minimum for the
+            // variable length metadata + the amount required for the header.
+            assert_eq!(
+                MIN_MDA_REGION_SIZE.bytes(),
+                MIN_MDA_DATA_REGION_SIZE + MDA_REGION_HDR_SIZE
+            );
+
+            // The minimum size for all the MDA regions is the number of
+            // regions times the minimum size for a single region.
+            assert_eq!(MIN_MDA_SECTORS, NUM_MDA_REGIONS * MIN_MDA_REGION_SIZE);
+        }
 
         #[test]
         /// Verify that default MDAHeader is all 0s except for CRC and versions.

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -19,6 +19,6 @@ pub use self::{
     backstore::Backstore,
     blockdev::StratBlockDev,
     device::{blkdev_size, is_stratis_device},
-    metadata::MIN_MDA_SECTORS,
+    metadata::MDADataSize,
     setup::{find_all, get_metadata},
 };

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -17,7 +17,7 @@ use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 use crate::{
     engine::{
         strat_engine::{
-            backstore::{Backstore, StratBlockDev, MIN_MDA_SECTORS},
+            backstore::{Backstore, MDADataSize, StratBlockDev},
             names::validate_name,
             serde_structs::{FlexDevsSave, PoolSave, Recordable},
             thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE},
@@ -151,7 +151,7 @@ impl StratPool {
         // FIXME: Initializing with the minimum MDA size is not necessarily
         // enough. If there are enough devices specified, more space will be
         // required.
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS)?;
+        let mut backstore = Backstore::initialize(pool_uuid, paths, MDADataSize::default())?;
 
         let thinpool = ThinPool::new(
             pool_uuid,

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1223,7 +1223,7 @@ mod tests {
     use devicemapper::{Bytes, SECTOR_SIZE};
 
     use crate::engine::strat_engine::{
-        backstore::MIN_MDA_SECTORS,
+        backstore::MDADataSize,
         device::SyncAll,
         tests::{loopbacked, real},
     };
@@ -1245,7 +1245,8 @@ mod tests {
         devlinks::setup_dev_path().unwrap();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
 
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths, MDADataSize::default()).unwrap();
 
         let mut pool = ThinPool::new(
             pool_uuid,
@@ -1287,7 +1288,8 @@ mod tests {
         devlinks::setup_dev_path().unwrap();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
         let (first_path, remaining_paths) = paths.split_at(1);
-        let mut backstore = Backstore::initialize(pool_uuid, &first_path, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, &first_path, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),
@@ -1393,7 +1395,8 @@ mod tests {
     fn test_filesystem_snapshot(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),
@@ -1505,7 +1508,8 @@ mod tests {
 
         let pool_uuid = Uuid::new_v4();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),
@@ -1553,7 +1557,8 @@ mod tests {
     fn test_pool_setup(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),
@@ -1619,7 +1624,8 @@ mod tests {
     fn test_thindev_destroy(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),
@@ -1673,7 +1679,8 @@ mod tests {
         let start_thindev_size: Sectors;
         let pool_uuid = Uuid::new_v4();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),
@@ -1765,7 +1772,8 @@ mod tests {
     fn test_suspend_resume(paths: &[&Path]) {
         let pool_uuid = Uuid::new_v4();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
-        let mut backstore = Backstore::initialize(pool_uuid, paths, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),
@@ -1812,7 +1820,8 @@ mod tests {
 
         let pool_uuid = Uuid::new_v4();
         devlinks::cleanup_devlinks(Vec::new().into_iter());
-        let mut backstore = Backstore::initialize(pool_uuid, paths2, MIN_MDA_SECTORS).unwrap();
+        let mut backstore =
+            Backstore::initialize(pool_uuid, paths2, MDADataSize::default()).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::default(),


### PR DESCRIPTION
This PR accomplishes the following:

* It makes the MDA size always valid, eliminating the need for the validate_mda_size method. It does this by changing the parameter to higher level methods to represent the required size for the variable length metadata, which is more relevant to these methods, and then _calculating_ a valid MDA size from that value in some code belonging to the metadata module.
* It makes a class of bugs virtually impossible by using types to distinguish between the size of the MDA, the size of an MDA region, and the size of the region that contains the variable length metadata. Bugs like these:
   * https://github.com/stratis-storage/stratisd/pull/1524
   * https://github.com/stratis-storage/stratisd/pull/1530
* It enforces better encapsulation by not exposing internal details of the metadata externally, thereby avoiding misuse of MDA specific constants in other contexts: https://github.com/stratis-storage/stratisd/pull/1529.

It does not address the possible problem that the variable length metadata could be too large for its device. A device has minimum size of 1 GiB, so the variable length metadata would have to be huge to overrun this limit.