### PR TITLE
Eliminate duplicate closures

### DIFF
--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -196,15 +196,12 @@ impl BlockDevMgr {
         ))
     }
 
-    /// Get a function that maps UUIDs to Devices.
-    pub fn uuid_to_devno(&self) -> Box<dyn Fn(DevUuid) -> Option<Device>> {
-        let uuid_map: HashMap<DevUuid, Device> = self
-            .block_devs
+    /// Get a hashmap that maps UUIDs to Devices.
+    pub fn uuid_to_devno(&self) -> HashMap<DevUuid, Device> {
+        self.block_devs
             .iter()
             .map(|bd| (bd.uuid(), *bd.device()))
-            .collect();
-
-        Box::new(move |uuid: DevUuid| -> Option<Device> { uuid_map.get(&uuid).cloned() })
+            .collect()
     }
 
     /// Add paths to self.

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -98,48 +98,6 @@ impl Recordable<Vec<BaseDevSave>> for Vec<BlkDevSegment> {
     }
 }
 
-/// Append the second list of BlkDevSegments to the first, or if the last
-/// segment of the first argument is adjacent to the first segment of the
-/// second argument, merge those two together.
-/// Postcondition: left.len() + right.len() - 1 <= result.len()
-/// Postcondition: result.len() <= left.len() + right.len()
-// FIXME: There is a method that duplicates this algorithm called
-// coalesce_segs. These methods should either be unified into a single method
-// OR one should go away entirely in solution to:
-// https://github.com/stratis-storage/stratisd/issues/762.
-pub fn coalesce_blkdevsegs(left: &[BlkDevSegment], right: &[BlkDevSegment]) -> Vec<BlkDevSegment> {
-    if left.is_empty() {
-        return right.to_vec();
-    }
-    if right.is_empty() {
-        return left.to_vec();
-    }
-
-    let mut segments = Vec::with_capacity(left.len() + right.len());
-    segments.extend_from_slice(left);
-
-    // Last existing and first new may be contiguous.
-    let coalesced = {
-        let right_first = right.first().expect("!right.is_empty()");
-        let left_last = segments.last_mut().expect("!left.is_empty()");
-        if left_last.uuid == right_first.uuid
-            && (left_last.segment.start + left_last.segment.length == right_first.segment.start)
-        {
-            left_last.segment.length += right_first.segment.length;
-            true
-        } else {
-            false
-        }
-    };
-
-    if coalesced {
-        segments.extend_from_slice(&right[1..]);
-    } else {
-        segments.extend_from_slice(right);
-    }
-    segments
-}
-
 /// Build a linear dev target table from BlkDevSegments. This is useful for
 /// calls to the devicemapper library.
 pub fn map_to_dm(bsegs: &[BlkDevSegment]) -> Vec<TargetLine<LinearDevTargetParams>> {

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -61,7 +61,7 @@ impl CacheTier {
         let uuid_to_devno = block_mgr.uuid_to_devno();
         let mapper = |ld: &BaseDevSave| -> StratisResult<BlkDevSegment> {
             let parent = ld.parent;
-            let device = uuid_to_devno(parent).ok_or_else(|| {
+            let device = uuid_to_devno.get(&parent).ok_or_else(|| {
                 StratisError::Engine(
                     ErrorEnum::NotFound,
                     format!("missing device for UUUD {:?}", &parent),
@@ -69,7 +69,7 @@ impl CacheTier {
             })?;
             Ok(BlkDevSegment::new(
                 parent,
-                Segment::new(device, ld.start, ld.length),
+                Segment::new(*device, ld.start, ld.length),
             ))
         };
 

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -12,7 +12,8 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
-                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment},
+                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr},
+                shared::metadata_to_segment,
                 StratBlockDev,
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
@@ -60,17 +61,7 @@ impl CacheTier {
 
         let uuid_to_devno = block_mgr.uuid_to_devno();
         let mapper = |ld: &BaseDevSave| -> StratisResult<BlkDevSegment> {
-            let parent = ld.parent;
-            let device = uuid_to_devno.get(&parent).ok_or_else(|| {
-                StratisError::Engine(
-                    ErrorEnum::NotFound,
-                    format!("missing device for UUUD {:?}", &parent),
-                )
-            })?;
-            Ok(BlkDevSegment::new(
-                parent,
-                Segment::new(*device, ld.start, ld.length),
-            ))
+            metadata_to_segment(&uuid_to_devno, &ld)
         };
 
         let meta_segments = cache_tier_save.blockdev.allocs[1]

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -12,8 +12,8 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
-                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr},
-                shared::metadata_to_segment,
+                blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                shared::{coalesce_blkdevsegs, metadata_to_segment},
                 StratBlockDev,
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -12,8 +12,8 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
-                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr},
-                shared::metadata_to_segment,
+                blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                shared::{coalesce_blkdevsegs, metadata_to_segment},
                 StratBlockDev,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -38,7 +38,7 @@ impl DataTier {
         let uuid_to_devno = block_mgr.uuid_to_devno();
         let mapper = |ld: &BaseDevSave| -> StratisResult<BlkDevSegment> {
             let parent = ld.parent;
-            let device = uuid_to_devno(parent).ok_or_else(|| {
+            let device = uuid_to_devno.get(&parent).ok_or_else(|| {
                 StratisError::Engine(
                     ErrorEnum::NotFound,
                     format!("missing device for UUUD {:?}", &parent),
@@ -46,7 +46,7 @@ impl DataTier {
             })?;
             Ok(BlkDevSegment::new(
                 parent,
-                Segment::new(device, ld.start, ld.length),
+                Segment::new(*device, ld.start, ld.length),
             ))
         };
         let segments = data_tier_save.blockdev.allocs[0]

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -12,14 +12,15 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
-                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr, Segment},
+                blockdevmgr::{coalesce_blkdevsegs, BlkDevSegment, BlockDevMgr},
+                shared::metadata_to_segment,
                 StratBlockDev,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},
         },
         BlockDevTier, DevUuid, PoolUuid,
     },
-    stratis::{ErrorEnum, StratisError, StratisResult},
+    stratis::StratisResult,
 };
 
 /// Handles the lowest level, base layer of this tier.
@@ -37,17 +38,7 @@ impl DataTier {
     pub fn setup(block_mgr: BlockDevMgr, data_tier_save: &DataTierSave) -> StratisResult<DataTier> {
         let uuid_to_devno = block_mgr.uuid_to_devno();
         let mapper = |ld: &BaseDevSave| -> StratisResult<BlkDevSegment> {
-            let parent = ld.parent;
-            let device = uuid_to_devno.get(&parent).ok_or_else(|| {
-                StratisError::Engine(
-                    ErrorEnum::NotFound,
-                    format!("missing device for UUUD {:?}", &parent),
-                )
-            })?;
-            Ok(BlkDevSegment::new(
-                parent,
-                Segment::new(*device, ld.start, ld.length),
-            ))
+            metadata_to_segment(&uuid_to_devno, &ld)
         };
         let segments = data_tier_save.blockdev.allocs[0]
             .iter()

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -12,6 +12,7 @@ pub mod device;
 mod metadata;
 mod range_alloc;
 mod setup;
+mod shared;
 mod util;
 
 pub use self::{

--- a/src/engine/strat_engine/backstore/shared.rs
+++ b/src/engine/strat_engine/backstore/shared.rs
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Methods that are shared by the cache tier and the data tier.
+
+use std::collections::HashMap;
+
+use devicemapper::Device;
+
+use crate::{
+    engine::{
+        strat_engine::{
+            backstore::blockdevmgr::{BlkDevSegment, Segment},
+            serde_structs::BaseDevSave,
+        },
+        types::DevUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
+
+/// Given a function that translates a Stratis UUID to a device
+/// number, and some metadata that describes a particular segment within
+/// a device by means of its Stratis UUID, and its start and offset w/in the
+/// device, return the corresponding BlkDevSegment structure.
+// This method necessarily takes a reference to a Box because it receives
+// the value from a function, and there is no other way for the function to
+// be returned from a closure.
+// In future, it may be possible to address this better with FnBox.
+#[allow(clippy::borrowed_box)]
+pub fn metadata_to_segment(
+    uuid_to_devno: &HashMap<DevUuid, Device>,
+    base_dev_save: &BaseDevSave,
+) -> StratisResult<BlkDevSegment> {
+    let parent = base_dev_save.parent;
+    uuid_to_devno
+        .get(&parent)
+        .ok_or_else(|| {
+            StratisError::Engine(
+                ErrorEnum::NotFound,
+                format!(
+                    "No block device corresponding to stratisd UUID {:?} found",
+                    &parent
+                ),
+            )
+        })
+        .map(|device| {
+            BlkDevSegment::new(
+                parent,
+                Segment::new(*device, base_dev_save.start, base_dev_save.length),
+            )
+        })
+}

--- a/src/engine/strat_engine/backstore/shared.rs
+++ b/src/engine/strat_engine/backstore/shared.rs
@@ -51,3 +51,45 @@ pub fn metadata_to_segment(
             )
         })
 }
+
+/// Append the second list of BlkDevSegments to the first, or if the last
+/// segment of the first argument is adjacent to the first segment of the
+/// second argument, merge those two together.
+/// Postcondition: left.len() + right.len() - 1 <= result.len()
+/// Postcondition: result.len() <= left.len() + right.len()
+// FIXME: There is a method that duplicates this algorithm called
+// coalesce_segs. These methods should either be unified into a single method
+// OR one should go away entirely in solution to:
+// https://github.com/stratis-storage/stratisd/issues/762.
+pub fn coalesce_blkdevsegs(left: &[BlkDevSegment], right: &[BlkDevSegment]) -> Vec<BlkDevSegment> {
+    if left.is_empty() {
+        return right.to_vec();
+    }
+    if right.is_empty() {
+        return left.to_vec();
+    }
+
+    let mut segments = Vec::with_capacity(left.len() + right.len());
+    segments.extend_from_slice(left);
+
+    // Last existing and first new may be contiguous.
+    let coalesced = {
+        let right_first = right.first().expect("!right.is_empty()");
+        let left_last = segments.last_mut().expect("!left.is_empty()");
+        if left_last.uuid == right_first.uuid
+            && (left_last.segment.start + left_last.segment.length == right_first.segment.start)
+        {
+            left_last.segment.length += right_first.segment.length;
+            true
+        } else {
+            false
+        }
+    };
+
+    if coalesced {
+        segments.extend_from_slice(&right[1..]);
+    } else {
+        segments.extend_from_slice(right);
+    }
+    segments
+}


### PR DESCRIPTION
Resolves: #1136.

This eliminates an instance of code duplication which was caused by an apparently insurmountable restriction on the definition of closures in Rust. It turns out that with enough ingenuity, the restriction on closures can be avoided, but it seemed simpler to drop the function return type from a single method, in order to simplify the use of its result. Since the bodies of the two closures are no longer duplicated, they need a single place to be put, so this adds a new module called shared. Another method, which is shared between the cache_tier and data_tier modules is also placed there.