### PR TITLE
No longer supply properties on the D-Bus by means of external calls

### DIFF
--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -232,9 +232,5 @@ fn get_filesystem_used(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,
 ) -> Result<(), MethodErr> {
-    get_filesystem_property(i, p, |(_, _, fs)| {
-        fs.used()
-            .map(|v| (*v).to_string())
-            .map_err(|_| MethodErr::failed(&"fs used() engine call failed".to_owned()))
-    })
+    get_filesystem_property(i, p, |(_, _, fs)| Ok((*fs.used()).to_string()))
 }

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -337,20 +337,9 @@ fn get_pool_total_physical_used(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,
 ) -> Result<(), MethodErr> {
-    fn get_used((_, uuid, pool): (Name, Uuid, &dyn Pool)) -> Result<String, MethodErr> {
-        let err_func = |_| {
-            MethodErr::failed(&format!(
-                "no total physical size computed for pool with uuid {}",
-                uuid
-            ))
-        };
-
-        pool.total_physical_used()
-            .map(|u| Ok(format!("{}", *u)))
-            .map_err(err_func)?
-    }
-
-    get_pool_property(i, p, get_used)
+    get_pool_property(i, p, |(_, _, pool)| {
+        Ok((*pool.total_physical_used()).to_string())
+    })
 }
 
 fn get_pool_total_physical_size(

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -141,7 +141,7 @@ pub trait Pool: Debug {
     /// The number of Sectors in this pool that are currently in use by the
     /// pool for some purpose, be it to store metadata, to store user data,
     /// or to reserve for some other purpose.
-    fn total_physical_used(&self) -> StratisResult<Sectors>;
+    fn total_physical_used(&self) -> Sectors;
 
     /// Get all the filesystems belonging to this pool.
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)>;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -32,7 +32,7 @@ pub trait Filesystem: Debug {
     fn created(&self) -> DateTime<Utc>;
 
     /// The amount of data stored on the filesystem, including overhead.
-    fn used(&self) -> StratisResult<Bytes>;
+    fn used(&self) -> Bytes;
 
     /// Set dbus path associated with the Pool.
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -10,10 +10,7 @@ use std::path::PathBuf;
 
 use devicemapper::Bytes;
 
-use crate::{
-    engine::{Filesystem, MaybeDbusPath},
-    stratis::StratisResult,
-};
+use crate::engine::{Filesystem, MaybeDbusPath};
 
 #[derive(Debug)]
 pub struct SimFilesystem {
@@ -43,8 +40,8 @@ impl Filesystem for SimFilesystem {
         self.created
     }
 
-    fn used(&self) -> StratisResult<Bytes> {
-        Ok(Bytes(12_345_678))
+    fn used(&self) -> Bytes {
+        Bytes(12_345_678)
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -212,8 +212,8 @@ impl Pool for SimPool {
         Sectors(IEC::Ei)
     }
 
-    fn total_physical_used(&self) -> StratisResult<Sectors> {
-        Ok(Sectors(0))
+    fn total_physical_used(&self) -> Sectors {
+        Sectors(0)
     }
 
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -394,10 +394,8 @@ impl Pool for StratPool {
         self.backstore.datatier_size()
     }
 
-    fn total_physical_used(&self) -> StratisResult<Sectors> {
-        self.thin_pool
-            .total_physical_used()
-            .and_then(|v| Ok(v + self.backstore.datatier_metadata_size()))
+    fn total_physical_used(&self) -> Sectors {
+        self.thin_pool.total_physical_used() + self.backstore.datatier_metadata_size()
     }
 
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -351,8 +351,8 @@ impl Filesystem for StratFilesystem {
         self.created
     }
 
-    fn used(&self) -> StratisResult<Bytes> {
-        Ok(self.thin_dev_status.nr_mapped_sectors.bytes())
+    fn used(&self) -> Bytes {
+        self.thin_dev_status.nr_mapped_sectors.bytes()
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {


### PR DESCRIPTION
This PR's goal is to eliminate all possibility of failure in methods that are used to supply property values on the D-Bus. Currently, the consequence of a failure in obtaining one of these properties is a message with the form:

```no total physical size computed for pool with uuid <some UUID>```

when most or all of the stratis CLI commands that require interaction with stratisd are run. None of these CLI commands can succeed when this happens. One of these methods supplies its value via a devicemapper ioctl, another by means of a stat call.

The approach taken here is to cache the values used at the time when these methods are necessarily called, which occurs in the corresponding ```check``` methods for each module. The reason this seems like a good idea is that the view that the user gets of the stratisd system is consistent with the view that stratisd has of the system.

However, there is currently a defect. The view that stratisd has based on the information it got in the ```check``` methods is the last information that could be obtained. Perhaps subsequently, the ```check``` method was called, but the result returned was ```Fail``` or ```Error```. In that case, the information that is placed on the D-Bus and is cached in the objects, is not just slightly stale as is inevitable w/ a cached value, but potentially totally wrong.

Resolves: #1148.