### PR TITLE
Introduce a simple method to parse an MDAHeader buffer

### DIFF
--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -398,16 +398,13 @@ impl MDAHeader {
         match LittleEndian::read_u64(&buf[16..24]) {
             0 => None,
             secs => {
-                let used = Bytes(LittleEndian::read_u64(&buf[8..16]));
-
                 // Signed cast is safe, highest order bit of each value
                 // read is guaranteed to be 0.
                 assert!(secs <= std::i64::MAX as u64);
 
-                let nsecs = LittleEndian::read_u32(&buf[24..28]);
                 Some(MDAHeader {
-                    used,
-                    last_updated: Utc.timestamp(secs as i64, nsecs),
+                    used: Bytes(LittleEndian::read_u64(&buf[8..16])),
+                    last_updated: Utc.timestamp(secs as i64, LittleEndian::read_u32(&buf[24..28])),
                     data_crc: LittleEndian::read_u32(&buf[4..8]),
                 })
             }


### PR DESCRIPTION
This PR simplifies a spot in the code and makes future error management easier by better isolating code that can not fail from code that can.