### PR TITLE
Tidy up event handling

### DIFF
--- a/src/dbus_api/event_handler.rs
+++ b/src/dbus_api/event_handler.rs
@@ -35,7 +35,7 @@ impl EngineListener for EventHandler {
                         consts::BLOCKDEV_INTERFACE_NAME,
                     )
                     .unwrap_or_else(|()| {
-                        error!(
+                        warn!(
                             "BlockdevStateChanged: {} state: {} failed to send dbus update.",
                             dbus_path, state as u16,
                         );
@@ -56,7 +56,7 @@ impl EngineListener for EventHandler {
                         consts::FILESYSTEM_INTERFACE_NAME,
                     )
                     .unwrap_or_else(|()| {
-                        error!(
+                        warn!(
                             "FilesystemRenamed: {} from: {} to: {} failed to send dbus update.",
                             dbus_path, from, to,
                         );
@@ -73,7 +73,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_INTERFACE_NAME,
                     )
                     .unwrap_or_else(|()| {
-                        error!(
+                        warn!(
                             "PoolExtendStateChanged: {} state: {} failed to send dbus update.",
                             dbus_path, state as u16,
                         );
@@ -94,7 +94,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_INTERFACE_NAME,
                     )
                     .unwrap_or_else(|()| {
-                        error!(
+                        warn!(
                             "PoolRenamed: {} from: {} to: {} failed to send dbus update.",
                             dbus_path, from, to,
                         );
@@ -111,7 +111,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_INTERFACE_NAME,
                     )
                     .unwrap_or_else(|()| {
-                        error!(
+                        warn!(
                             "PoolSpaceStateChanged: {} state: {} failed to send dbus update.",
                             dbus_path, state as u16,
                         );
@@ -128,7 +128,7 @@ impl EngineListener for EventHandler {
                         consts::POOL_INTERFACE_NAME,
                     )
                     .unwrap_or_else(|()| {
-                        error!(
+                        warn!(
                             "PoolStateChanged: {} state: {} failed to send dbus update.",
                             dbus_path, state as u16,
                         );

--- a/src/dbus_api/event_handler.rs
+++ b/src/dbus_api/event_handler.rs
@@ -1,0 +1,140 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::{cell::RefCell, rc::Rc};
+
+use dbus::Connection;
+
+use crate::{
+    dbus_api::{consts, util::prop_changed_dispatch},
+    engine::{EngineEvent, EngineListener, MaybeDbusPath},
+};
+
+#[derive(Debug)]
+pub struct EventHandler {
+    dbus_conn: Rc<RefCell<Connection>>,
+}
+
+impl EventHandler {
+    pub fn new(dbus_conn: Rc<RefCell<Connection>>) -> EventHandler {
+        EventHandler { dbus_conn }
+    }
+}
+
+impl EngineListener for EventHandler {
+    fn notify(&self, event: &EngineEvent) {
+        match *event {
+            EngineEvent::BlockdevStateChanged { dbus_path, state } => {
+                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::BLOCKDEV_STATE_PROP,
+                        state as u16,
+                        &dbus_path,
+                        consts::BLOCKDEV_INTERFACE_NAME,
+                    )
+                    .unwrap_or_else(|()| {
+                        error!(
+                            "BlockdevStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path, state as u16,
+                        );
+                    });
+                }
+            }
+            EngineEvent::FilesystemRenamed {
+                dbus_path,
+                from,
+                to,
+            } => {
+                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::FILESYSTEM_NAME_PROP,
+                        to.to_string(),
+                        &dbus_path,
+                        consts::FILESYSTEM_INTERFACE_NAME,
+                    )
+                    .unwrap_or_else(|()| {
+                        error!(
+                            "FilesystemRenamed: {} from: {} to: {} failed to send dbus update.",
+                            dbus_path, from, to,
+                        );
+                    });
+                }
+            }
+            EngineEvent::PoolExtendStateChanged { dbus_path, state } => {
+                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_EXTEND_STATE_PROP,
+                        state as u16,
+                        &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
+                    )
+                    .unwrap_or_else(|()| {
+                        error!(
+                            "PoolExtendStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path, state as u16,
+                        );
+                    });
+                }
+            }
+            EngineEvent::PoolRenamed {
+                dbus_path,
+                from,
+                to,
+            } => {
+                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_NAME_PROP,
+                        to.to_string(),
+                        &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
+                    )
+                    .unwrap_or_else(|()| {
+                        error!(
+                            "PoolRenamed: {} from: {} to: {} failed to send dbus update.",
+                            dbus_path, from, to,
+                        );
+                    });
+                }
+            }
+            EngineEvent::PoolSpaceStateChanged { dbus_path, state } => {
+                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_SPACE_STATE_PROP,
+                        state as u16,
+                        &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
+                    )
+                    .unwrap_or_else(|()| {
+                        error!(
+                            "PoolSpaceStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path, state as u16,
+                        );
+                    });
+                }
+            }
+            EngineEvent::PoolStateChanged { dbus_path, state } => {
+                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
+                    prop_changed_dispatch(
+                        &self.dbus_conn.borrow(),
+                        consts::POOL_STATE_PROP,
+                        state as u16,
+                        &dbus_path,
+                        consts::POOL_INTERFACE_NAME,
+                    )
+                    .unwrap_or_else(|()| {
+                        error!(
+                            "PoolStateChanged: {} state: {} failed to send dbus update.",
+                            dbus_path, state as u16,
+                        );
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/dbus_api/mod.rs
+++ b/src/dbus_api/mod.rs
@@ -7,10 +7,11 @@ mod macros;
 
 mod api;
 mod blockdev;
-pub mod consts;
+mod consts;
+mod event_handler;
 mod filesystem;
 mod pool;
 mod types;
 mod util;
 
-pub use self::{api::DbusConnectionData, util::prop_changed_dispatch};
+pub use self::{api::DbusConnectionData, event_handler::EventHandler};

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -56,7 +56,7 @@ pub struct EngineListenerList {
 
 impl EngineListenerList {
     /// Create a new EngineListenerList.
-    pub fn new() -> EngineListenerList {
+    fn new() -> EngineListenerList {
         EngineListenerList {
             listeners: Vec::new(),
         }
@@ -72,12 +72,6 @@ impl EngineListenerList {
         for listener in &self.listeners {
             listener.notify(&event);
         }
-    }
-}
-
-impl Default for EngineListenerList {
-    fn default() -> EngineListenerList {
-        EngineListenerList::new()
     }
 }
 

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -79,7 +79,7 @@ pub fn get_engine_listener_list() -> &'static EngineListenerList {
     unsafe {
         INIT.call_once(|| ENGINE_LISTENER_LIST = Some(EngineListenerList::new()));
         match ENGINE_LISTENER_LIST {
-            Some(ref mut ell) => ell,
+            Some(ref ell) => ell,
             _ => panic!("ENGINE_LISTENER_LIST is None"),
         }
     }

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -67,7 +67,7 @@ impl EngineListenerList {
         self.listeners.push(listener);
     }
 
-    /// Notify a listener.
+    /// Notify all listeners of the event.
     pub fn notify(&self, event: &EngineEvent) {
         for listener in &self.listeners {
             listener.notify(&event);


### PR DESCRIPTION
* Tidies up the engine's event listener a bit
* Moves the D-Bus specific event handler into the dbus_api module, thereby improving encapsulation and shortening src/bin/stratisd.rs.
* Downgrades the level of the log messages in the D-Bus specific event handler from error to warn (as the failure to put a change event on the D-Bus, although certainly a problem, does not constitute an error in the engine).

Note that this engine listener is a bit overdesigned in the sense that it is really intended to be general purpose but it is never more than a singleton list containing a single event handler, a handler with the sole purpose of putting change events on the D-Bus. For that reason all the events more or less resemble each other, and all contain the relevant D-Bus object path. Because it is used for this specific purpose, it could be simplified a good deal further. I'm leaving it alone, as its use may be expanded in the future.