### PR TITLE
Harden implementation of MDARegions as much as possible (prelim)

### DIFF
--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -159,9 +159,9 @@ impl BDA {
         // Assume that, since a valid StaticHeader was found on the device,
         // that this implies that BDA::initialize() was succesfully executed
         // sometime in the past. Since that is the case, valid MDA headers
-        // were written to the device. If there is an error loading the
-        // MDARegions, which can only be caused by an I/O error or invalid
-        // MDA headers, return an error.
+        // were written to the device. Returns an error if there is an error
+        // when loading the MDARegions, which can only be caused by an I/O
+        // error or invalid MDA headers.
         let regions = mda::MDARegions::load(BDA_STATIC_HDR_SIZE, header.mda_size, f)?;
 
         Ok(Some(BDA { header, regions }))

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -156,6 +156,12 @@ impl BDA {
             None => return Ok(None),
         };
 
+        // Assume that, since a valid StaticHeader was found on the device,
+        // that this implies that BDA::initialize() was succesfully executed
+        // sometime in the past. Since that is the case, valid MDA headers
+        // were written to the device. If there is an error loading the
+        // MDARegions, which can only be caused by an I/O error or invalid
+        // MDA headers, return an error.
         let regions = mda::MDARegions::load(BDA_STATIC_HDR_SIZE, header.mda_size, f)?;
 
         Ok(Some(BDA { header, regions }))

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -496,12 +496,7 @@ impl fmt::Debug for StaticHeader {
 mod tests {
     use std::io::{Cursor, Write};
 
-    use proptest::{
-        collection::{vec, SizeRange},
-        num, option,
-        prelude::BoxedStrategy,
-        strategy::Strategy,
-    };
+    use proptest::{collection::vec, num, option, prelude::BoxedStrategy, strategy::Strategy};
     use uuid::Uuid;
 
     use devicemapper::{Bytes, Sectors, IEC};
@@ -650,8 +645,8 @@ mod tests {
         /// Save metadata again, and reload one more time, verifying new timestamp.
         fn check_state(
             ref sh in static_header_strategy(),
-            ref state in vec(num::u8::ANY, SizeRange::default()),
-            ref next_state in vec(num::u8::ANY, SizeRange::default())
+            ref state in vec(num::u8::ANY, 1..100),
+            ref next_state in vec(num::u8::ANY, 1..100)
         ) {
             let buf_size = *sh.mda_size.sectors().bytes() as usize + _BDA_STATIC_HDR_SIZE;
             let mut buf = Cursor::new(vec![0; buf_size]);

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -170,8 +170,11 @@ impl MDARegions {
         self.region_size.data_size()
     }
 
-    /// Initialize the space allotted to the MDA regions to 0.
-    /// Return an MDARegions object with uninitialized MDAHeader objects.
+    /// Initialize the space allotted to the MDA region headers.
+    /// For each MDA region, write the data corresponding to a default
+    /// MDAHeader to the appropriate location. This default MDA header
+    /// has all zero values. The returned MDARegions struct's optional
+    /// MDAHeader structs are all None.
     pub fn initialize<F>(
         header_size: Bytes,
         mda_size: MDASize,

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -387,7 +387,9 @@ pub struct MDAHeader {
 }
 
 // Implementing Default explicitly because DateTime<Utc> does not implement
-// Default.
+// Default. Implement Default for MDAHeader in order to overwrite MDAHeader
+// locations with values that represent no MDAHeader but where the data has
+// the correct CRC, so can be read without an error.
 impl Default for MDAHeader {
     fn default() -> MDAHeader {
         MDAHeader {

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -158,7 +158,7 @@ pub struct MDARegions {
     /// A value of None indicates that no variable length metadata has been
     /// written to the MDA regions corresponding to a given MDA header.
     /// If there is Some value, then variable length metadata has been read;
-    /// the MDA header's used attribute therefore can not be 0 bytes.
+    /// the MDA header's used field therefore can not be 0 bytes.
     mda_headers: [Option<MDAHeader>; mda_size::NUM_PRIMARY_MDA_REGIONS],
 }
 

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -201,11 +201,17 @@ impl MDARegions {
         })
     }
 
-    /// Construct MDARegions from data on the disk.
-    /// Note that this method is always called in a context where a
-    /// StaticHeader has already been read. Therefore, it
-    /// constitutes an error if it is not possible to discover two
-    /// well-formed MDAHeaders for this device.
+    /// Construct an MDARegions struct from data on the disk.
+    /// The individual MDAHeaders in the struct may all be None, as it is
+    /// possible that no variable length metadata has been written to the
+    /// device on which the metadata has been written.
+    ///
+    /// Returns an error if there is an I/O error or if the MDA header data
+    /// on the device is invalid.
+    //
+    // TODO: Consider whether the return type of this method should be
+    // refined to distinguish between I/O errors and errors resulting from
+    // invalid data representing an MDA header.
     pub fn load<F>(header_size: Bytes, mda_size: MDASize, f: &mut F) -> StratisResult<MDARegions>
     where
         F: Read + Seek,

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -155,6 +155,10 @@ pub struct MDARegions {
     /// The MDA headers which contain information about the variable
     /// length metadata. NUM_PRIMARY_MDA_REGIONS is 2: in the general
     /// case one is more recently written than the other.
+    /// A value of None indicates that no variable length metadata has been
+    /// written to the MDA regions corresponding to a given MDA header.
+    /// If there is Some value, then variable length metadata has been read;
+    /// the MDA header's used attribute therefore can not be 0 bytes.
     mdas: [Option<MDAHeader>; mda_size::NUM_PRIMARY_MDA_REGIONS],
 }
 

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -378,6 +378,18 @@ impl MDARegions {
     pub fn last_update_time(&self) -> Option<&DateTime<Utc>> {
         self.mdas[self.newer()].as_ref().map(|h| &h.last_updated)
     }
+
+    #[cfg(test)]
+    /// An invariant on MDARegions structs.
+    /// 1. If an MDAHeader in the regions is not None, then its used
+    /// attribute must be greater than 0.
+    pub fn invariant(&self) {
+        for mda in self.mdas.iter() {
+            assert!(mda
+                .as_ref()
+                .map_or_else(|| true, |mda| mda.used != Bytes(0)));
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -551,6 +563,8 @@ mod tests {
 
         MDARegions::initialize(offset, MDASize::default(), &mut buf).unwrap();
         let regions = MDARegions::load(offset, MDASize::default(), &mut buf).unwrap();
+        regions.invariant();
+
         assert_matches!(regions.last_update_time(), None);
     }
 

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -159,7 +159,7 @@ pub struct MDARegions {
     /// written to the MDA regions corresponding to a given MDA header.
     /// If there is Some value, then variable length metadata has been read;
     /// the MDA header's used attribute therefore can not be 0 bytes.
-    mdas: [Option<MDAHeader>; mda_size::NUM_PRIMARY_MDA_REGIONS],
+    mda_headers: [Option<MDAHeader>; mda_size::NUM_PRIMARY_MDA_REGIONS],
 }
 
 impl MDARegions {
@@ -204,7 +204,7 @@ impl MDARegions {
 
         Ok(MDARegions {
             region_size,
-            mdas: [None, None],
+            mda_headers: [None, None],
         })
     }
 
@@ -251,7 +251,7 @@ impl MDARegions {
 
         Ok(MDARegions {
             region_size,
-            mdas: [get_mda(0)?, get_mda(1)?],
+            mda_headers: [get_mda(0)?, get_mda(1)?],
         })
     }
 
@@ -317,7 +317,7 @@ impl MDARegions {
         save_region(older_region)?;
         save_region(older_region + mda_size::NUM_PRIMARY_MDA_REGIONS)?;
 
-        self.mdas[older_region] = Some(header);
+        self.mda_headers[older_region] = Some(header);
 
         Ok(())
     }
@@ -331,7 +331,7 @@ impl MDARegions {
         F: Read + Seek,
     {
         let newer_region = self.newer();
-        let mda = match self.mdas[newer_region] {
+        let mda = match self.mda_headers[newer_region] {
             None => return Ok(None),
             Some(ref mda) => mda,
         };
@@ -355,7 +355,7 @@ impl MDARegions {
 
     /// The index of the older region, or 0 if there is a tie.
     fn older(&self) -> usize {
-        match (&self.mdas[0], &self.mdas[1]) {
+        match (&self.mda_headers[0], &self.mda_headers[1]) {
             (&None, _) => 0,
             (_, &None) => 1,
             (&Some(ref mda0), &Some(ref mda1)) => match mda0.last_updated.cmp(&mda1.last_updated) {
@@ -376,7 +376,9 @@ impl MDARegions {
 
     /// The last update time for these MDA regions
     pub fn last_update_time(&self) -> Option<&DateTime<Utc>> {
-        self.mdas[self.newer()].as_ref().map(|h| &h.last_updated)
+        self.mda_headers[self.newer()]
+            .as_ref()
+            .map(|h| &h.last_updated)
     }
 
     #[cfg(test)]
@@ -384,7 +386,7 @@ impl MDARegions {
     /// 1. If an MDAHeader in the regions is not None, then its used
     /// attribute must be greater than 0.
     pub fn invariant(&self) {
-        for mda in self.mdas.iter() {
+        for mda in self.mda_headers.iter() {
             assert!(mda
                 .as_ref()
                 .map_or_else(|| true, |mda| mda.used != Bytes(0)));


### PR DESCRIPTION
This hardens the implementation of MDARegions to avoid future bugs.

Most of the work consists of fixing incorrect header comments and adding further explanation to
some implementations. Also:

* ```MDAHeader::parse_buf``` now checks the value of the length of the data to determine whether or not the sectors read correspond to an existing header, rather than checking the value of the timestamp, as that seems like a more direct and meaningful value.
* There is an invariant on ```MDARegions``` which is used in the one relevant test.
* Renames a field in the ```MDARegions``` struct to be less confusing.