### PR TITLE
Move static header functionality into a separate module

### DIFF
--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -499,7 +499,7 @@ mod tests {
         tests::{loopbacked, real},
     };
 
-    use crate::engine::strat_engine::backstore::metadata::StaticHeader;
+    use crate::engine::strat_engine::backstore::metadata::BDA;
 
     use super::*;
 
@@ -582,12 +582,10 @@ mod tests {
         for path in clean_paths {
             assert_eq!(
                 pool_uuid,
-                StaticHeader::device_identifiers(
-                    &mut OpenOptions::new().read(true).open(path).unwrap(),
-                )
-                .unwrap()
-                .unwrap()
-                .0
+                BDA::device_identifiers(&mut OpenOptions::new().read(true).open(path).unwrap(),)
+                    .unwrap()
+                    .unwrap()
+                    .0
             );
         }
     }
@@ -748,12 +746,10 @@ mod tests {
         for path in paths {
             assert_eq!(
                 pool_uuid,
-                StaticHeader::device_identifiers(
-                    &mut OpenOptions::new().read(true).open(path).unwrap(),
-                )
-                .unwrap()
-                .unwrap()
-                .0
+                BDA::device_identifiers(&mut OpenOptions::new().read(true).open(path).unwrap(),)
+                    .unwrap()
+                    .unwrap()
+                    .0
             );
         }
 
@@ -761,10 +757,8 @@ mod tests {
 
         for path in paths {
             assert_eq!(
-                StaticHeader::device_identifiers(
-                    &mut OpenOptions::new().read(true).open(path).unwrap(),
-                )
-                .unwrap(),
+                BDA::device_identifiers(&mut OpenOptions::new().read(true).open(path).unwrap(),)
+                    .unwrap(),
                 None
             );
         }

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, SeekFrom};
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use devicemapper::{Bytes, Sectors, SECTOR_SIZE};
+use devicemapper::{Bytes, Sectors, IEC, SECTOR_SIZE};
 
 use crate::{
     engine::{
@@ -26,6 +26,8 @@ use crate::{
 
 const _BDA_STATIC_HDR_SIZE: usize = 16 * SECTOR_SIZE;
 const BDA_STATIC_HDR_SIZE: Bytes = Bytes(_BDA_STATIC_HDR_SIZE as u64);
+
+const RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)); // = 3 MiB
 
 #[derive(Debug)]
 pub struct BDA {
@@ -50,6 +52,7 @@ impl BDA {
             pool_uuid,
             dev_uuid,
             mda_data_size.region_size().mda_size(),
+            RESERVED_SECTORS,
             blkdev_size,
             initialization_time,
         );
@@ -194,6 +197,7 @@ mod tests {
             pool_uuid,
             dev_uuid,
             mda_size,
+            RESERVED_SECTORS,
             blkdev_size,
             Utc::now().timestamp() as u64,
         )

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -155,6 +155,14 @@ impl BDA {
     pub fn initialization_time(&self) -> u64 {
         self.header.initialization_time
     }
+
+    /// Retrieve the device and pool UUIDs from a stratis device.
+    pub fn device_identifiers<F>(f: &mut F) -> StratisResult<Option<((PoolUuid, DevUuid))>>
+    where
+        F: Read + Seek + SyncAll,
+    {
+        StaticHeader::setup(f).map(|sh| sh.map(|sh| (sh.pool_uuid, sh.dev_uuid)))
+    }
 }
 
 #[cfg(test)]
@@ -221,7 +229,7 @@ mod tests {
         fn test_ownership(ref sh in static_header_strategy()) {
             let buf_size = *sh.mda_size.sectors().bytes() as usize + _BDA_STATIC_HDR_SIZE;
             let mut buf = Cursor::new(vec![0; buf_size]);
-            prop_assert!(StaticHeader::device_identifiers(&mut buf).unwrap().is_none());
+            prop_assert!(BDA::device_identifiers(&mut buf).unwrap().is_none());
 
             BDA::initialize(
                 &mut buf,
@@ -232,13 +240,13 @@ mod tests {
                 Utc::now().timestamp() as u64,
             ).unwrap();
 
-            prop_assert!(StaticHeader::device_identifiers(&mut buf)
+            prop_assert!(BDA::device_identifiers(&mut buf)
                          .unwrap()
                          .map(|(t_p, t_d)| t_p == sh.pool_uuid && t_d == sh.dev_uuid)
                          .unwrap_or(false));
 
             BDA::wipe(&mut buf).unwrap();
-            prop_assert!(StaticHeader::device_identifiers(&mut buf).unwrap().is_none());
+            prop_assert!(BDA::device_identifiers(&mut buf).unwrap().is_none());
         }
     }
 

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -160,9 +160,9 @@ impl BDA {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Cursor, SeekFrom, Write};
+    use std::io::Cursor;
 
-    use proptest::{collection::vec, num, option, prelude::BoxedStrategy, strategy::Strategy};
+    use proptest::{collection::vec, num, prelude::BoxedStrategy, strategy::Strategy};
     use uuid::Uuid;
 
     use devicemapper::{Bytes, Sectors, IEC};
@@ -170,21 +170,6 @@ mod tests {
     use crate::engine::strat_engine::backstore::metadata::static_header::_BDA_STATIC_HDR_SIZE;
 
     use super::*;
-
-    /// Corrupt a byte at the specified position.
-    fn corrupt_byte<F>(f: &mut F, position: u64) -> io::Result<()>
-    where
-        F: Read + Seek + SyncAll,
-    {
-        let mut byte_to_corrupt = [0; 1];
-        f.seek(SeekFrom::Start(position))?;
-        f.read_exact(&mut byte_to_corrupt)?;
-        byte_to_corrupt[0] = !byte_to_corrupt[0];
-        f.seek(SeekFrom::Start(position))?;
-        f.write_all(&byte_to_corrupt)?;
-        f.sync_all()?;
-        Ok(())
-    }
 
     /// Return a static header with random block device and MDA size.
     /// The block device is less than the minimum, for efficiency in testing.
@@ -347,136 +332,4 @@ mod tests {
 
         }
     }
-
-    proptest! {
-        #[test]
-        /// Construct an arbitrary StaticHeader object.
-        /// Write it to a buffer, read it out and make sure you get the same thing.
-        fn static_header(ref sh1 in static_header_strategy()) {
-            let buf = sh1.sigblock_to_buf();
-            let sh2 = StaticHeader::sigblock_from_buf(&buf).unwrap().unwrap();
-            prop_assert_eq!(sh1.pool_uuid, sh2.pool_uuid);
-            prop_assert_eq!(sh1.dev_uuid, sh2.dev_uuid);
-            prop_assert_eq!(sh1.blkdev_size, sh2.blkdev_size);
-            prop_assert_eq!(sh1.mda_size, sh2.mda_size);
-            prop_assert_eq!(sh1.reserved_size, sh2.reserved_size);
-            prop_assert_eq!(sh1.flags, sh2.flags);
-            prop_assert_eq!(sh1.initialization_time, sh2.initialization_time);
-        }
-    }
-
-    proptest! {
-        #[test]
-        /// Verify correct reading of the static header if only one of
-        /// the two static headers is corrupted. Verify expected behavior
-        /// if both are corrupted, which varies depending on whether the
-        /// Stratis magic number or some other part of the header is corrupted.
-        fn bda_test_recovery(primary in option::of(0..SECTOR_SIZE),
-                             secondary in option::of(0..SECTOR_SIZE)) {
-            let sh = random_static_header(10000, 4);
-            let buf_size = *sh.mda_size.sectors().bytes() as usize + _BDA_STATIC_HDR_SIZE;
-            let mut buf = Cursor::new(vec![0; buf_size]);
-            BDA::initialize(
-                &mut buf,
-                sh.pool_uuid,
-                sh.dev_uuid,
-                sh.mda_size.region_size().data_size(),
-                sh.blkdev_size,
-                Utc::now().timestamp() as u64,
-            ).unwrap();
-
-            let reference_buf = buf.clone();
-
-            if let Some(index) = primary {
-                // Corrupt primary copy
-                corrupt_byte(&mut buf, (SECTOR_SIZE + index) as u64).unwrap();
-            }
-
-            if let Some(index) = secondary {
-                // Corrupt secondary copy
-                corrupt_byte(&mut buf, (9 * SECTOR_SIZE + index) as u64).unwrap();
-            }
-
-            let setup_result = StaticHeader::setup(&mut buf);
-
-            match (primary, secondary) {
-                (Some(p_index), Some(s_index)) => {
-                    // Setup should fail to find a usable Stratis BDA
-                    match (p_index, s_index) {
-                        (4..=19, 4..=19) => {
-                            // When we corrupt both magics then we believe that
-                            // the signature is not ours and will return Ok(None)
-                            prop_assert!(setup_result.is_ok() && setup_result.unwrap().is_none());
-                        }
-                        _ => {
-                            prop_assert!(setup_result.is_err());
-                        }
-                    }
-
-                    // Check buffer, should be different
-                    prop_assert_ne!(reference_buf.get_ref(), buf.get_ref());
-
-                }
-                _ => {
-                    // Setup should work and buffer should be corrected
-                    prop_assert!(setup_result.is_ok() && setup_result.unwrap().is_some());
-
-                    // Check buffer, should be corrected.
-                    prop_assert_eq!(reference_buf.get_ref(), buf.get_ref());
-                }
-            }
-        }
-    }
-
-    #[test]
-    /// Test that we re-write the older of two BDAs if they don't match.
-    fn bda_test_rewrite_older() {
-        let sh = random_static_header(10000, 4);
-        let buf_size = *sh.mda_size.sectors().bytes() as usize + _BDA_STATIC_HDR_SIZE;
-        let mut buf = Cursor::new(vec![0; buf_size]);
-        let ts = Utc::now().timestamp() as u64;
-
-        BDA::initialize(
-            &mut buf,
-            sh.pool_uuid,
-            sh.dev_uuid,
-            sh.mda_size.region_size().data_size(),
-            sh.blkdev_size,
-            ts,
-        )
-        .unwrap();
-
-        let mut buf_newer = Cursor::new(vec![0; buf_size]);
-        BDA::initialize(
-            &mut buf_newer,
-            sh.pool_uuid,
-            sh.dev_uuid,
-            sh.mda_size.region_size().data_size(),
-            sh.blkdev_size,
-            ts + 1,
-        )
-        .unwrap();
-
-        // We should always match this reference buffer as it's the newer one.
-        let reference_buf = buf_newer.clone();
-
-        for offset in &[SECTOR_SIZE, 9 * SECTOR_SIZE] {
-            // Copy the older BDA to newer BDA buffer
-            buf.seek(SeekFrom::Start(*offset as u64)).unwrap();
-            buf_newer.seek(SeekFrom::Start(*offset as u64)).unwrap();
-            let mut sector = [0u8; SECTOR_SIZE];
-            buf.read_exact(&mut sector).unwrap();
-            buf_newer.write_all(&sector).unwrap();
-
-            assert_ne!(reference_buf.get_ref(), buf_newer.get_ref());
-
-            let setup_result = StaticHeader::setup(&mut buf_newer);
-            assert_matches!(setup_result, Ok(_));
-            assert!(setup_result.unwrap().is_some());
-
-            // We should match the reference buffer
-            assert_eq!(reference_buf.get_ref(), buf_newer.get_ref());
-        }
-    }
-
 }

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -14,7 +14,7 @@ use crate::{
         strat_engine::{
             backstore::metadata::{
                 mda,
-                static_header::{MetadataLocation, StaticHeader, BDA_STATIC_HDR_SIZE},
+                static_header::{self, MetadataLocation, StaticHeader, BDA_STATIC_HDR_SIZE},
                 MDADataSize,
             },
             device::SyncAll,
@@ -67,7 +67,7 @@ impl BDA {
     where
         F: Read + Seek + SyncAll,
     {
-        let header = match StaticHeader::setup(f)? {
+        let header = match static_header::setup(f)? {
             Some(header) => header,
             None => return Ok(None),
         };
@@ -88,7 +88,7 @@ impl BDA {
     where
         F: Seek + SyncAll,
     {
-        StaticHeader::wipe(f)
+        static_header::wipe(f)
     }
 
     /// Save metadata to the disk
@@ -154,7 +154,7 @@ impl BDA {
     where
         F: Read + Seek + SyncAll,
     {
-        StaticHeader::setup(f).map(|sh| sh.map(|sh| (sh.pool_uuid, sh.dev_uuid)))
+        static_header::setup(f).map(|sh| sh.map(|sh| (sh.pool_uuid, sh.dev_uuid)))
     }
 }
 

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -7,14 +7,14 @@ use std::io::{Read, Seek};
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-use devicemapper::{Bytes, Sectors, IEC, SECTOR_SIZE};
+use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
 use crate::{
     engine::{
         strat_engine::{
             backstore::metadata::{
                 mda,
-                static_header::{MetadataLocation, StaticHeader},
+                static_header::{MetadataLocation, StaticHeader, BDA_STATIC_HDR_SIZE},
                 MDADataSize,
             },
             device::SyncAll,
@@ -23,9 +23,6 @@ use crate::{
     },
     stratis::StratisResult,
 };
-
-const _BDA_STATIC_HDR_SIZE: usize = 16 * SECTOR_SIZE;
-const BDA_STATIC_HDR_SIZE: Bytes = Bytes(_BDA_STATIC_HDR_SIZE as u64);
 
 const RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)); // = 3 MiB
 
@@ -169,6 +166,8 @@ mod tests {
     use uuid::Uuid;
 
     use devicemapper::{Bytes, Sectors, IEC};
+
+    use crate::engine::strat_engine::backstore::metadata::static_header::_BDA_STATIC_HDR_SIZE;
 
     use super::*;
 

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -54,7 +54,7 @@ impl BDA {
             initialization_time,
         );
 
-        StaticHeader::write(f, &header.sigblock_to_buf(), MetadataLocation::Both)?;
+        header.write(f, MetadataLocation::Both)?;
 
         let regions = mda::MDARegions::initialize(BDA_STATIC_HDR_SIZE, header.mda_size, f)?;
 

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -2,50 +2,35 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{
-    fmt,
-    io::{self, Read, Seek, SeekFrom},
-    str::from_utf8,
-};
+use std::io::{Read, Seek, SeekFrom};
 
-use byteorder::{ByteOrder, LittleEndian};
 use chrono::{DateTime, Utc};
-use crc::crc32;
 use uuid::Uuid;
 
-use devicemapper::{Bytes, Sectors, IEC, SECTOR_SIZE};
+use devicemapper::{Bytes, Sectors, SECTOR_SIZE};
 
 use crate::{
     engine::{
         strat_engine::{
-            backstore::metadata::{mda, MDADataSize},
+            backstore::metadata::{
+                mda,
+                static_header::{MetadataLocation, StaticHeader},
+                MDADataSize,
+            },
             device::SyncAll,
         },
         DevUuid, PoolUuid,
     },
-    stratis::{ErrorEnum, StratisError, StratisResult},
+    stratis::StratisResult,
 };
 
 const _BDA_STATIC_HDR_SIZE: usize = 16 * SECTOR_SIZE;
 const BDA_STATIC_HDR_SIZE: Bytes = Bytes(_BDA_STATIC_HDR_SIZE as u64);
 
-const RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)); // = 3 MiB
-
-const STRAT_MAGIC: &[u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
-
-const STRAT_SIGBLOCK_VERSION: u8 = 1;
-
 #[derive(Debug)]
 pub struct BDA {
     header: StaticHeader,
     regions: mda::MDARegions,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum MetadataLocation {
-    Both,
-    First,
-    Second,
 }
 
 impl BDA {
@@ -169,321 +154,9 @@ impl BDA {
     }
 }
 
-#[derive(Eq, PartialEq)]
-pub struct StaticHeader {
-    blkdev_size: Sectors,
-    pool_uuid: PoolUuid,
-    dev_uuid: DevUuid,
-    mda_size: mda::MDASize,
-    reserved_size: Sectors,
-    flags: u64,
-    /// Seconds portion of DateTime<Utc> value.
-    initialization_time: u64,
-}
-
-impl StaticHeader {
-    fn new(
-        pool_uuid: PoolUuid,
-        dev_uuid: DevUuid,
-        mda_size: mda::MDASize,
-        blkdev_size: Sectors,
-        initialization_time: u64,
-    ) -> StaticHeader {
-        StaticHeader {
-            blkdev_size,
-            pool_uuid,
-            dev_uuid,
-            mda_size,
-            reserved_size: RESERVED_SECTORS,
-            flags: 0,
-            initialization_time,
-        }
-    }
-
-    /// Read the bytes corresponding to the two signature blocks in the static
-    /// header from the device. Return a tuple indicating the success or
-    /// failure for reading either location.
-    fn read<F>(f: &mut F) -> (io::Result<[u8; SECTOR_SIZE]>, io::Result<[u8; SECTOR_SIZE]>)
-    where
-        F: Read + Seek,
-    {
-        // Theory of read procedure
-        // We write the BDA in two operations with a sync in between.  The write operation
-        // could fail (loss of power) for either write leaving sector(s) with potentially hard
-        // read errors. It's best to read each of the specific BDA blocks individually, to limit
-        // the probability of hitting a read error on a non-essential sector.
-
-        let mut buf_loc_1 = [0u8; SECTOR_SIZE];
-        let mut buf_loc_2 = [0u8; SECTOR_SIZE];
-
-        /// Read a bda sector worth of data at the specified offset into buffer.
-        fn read_sector_at_offset<F>(f: &mut F, offset: usize, mut buf: &mut [u8]) -> io::Result<()>
-        where
-            F: Read + Seek,
-        {
-            f.seek(SeekFrom::Start(offset as u64))?;
-            f.read_exact(&mut buf)?;
-            Ok(())
-        }
-
-        (
-            read_sector_at_offset(f, SECTOR_SIZE, &mut buf_loc_1).map(|_| buf_loc_1),
-            read_sector_at_offset(f, 9 * SECTOR_SIZE, &mut buf_loc_2).map(|_| buf_loc_2),
-        )
-    }
-
-    // Write signature block data according to the value of the which argument.
-    // If first location is specified, write zeroes to empty regions in the
-    // first 8 sectors. If the second location is specified, writes zeroes to
-    // empty regions in the second 8 sectors.
-    fn write<F>(f: &mut F, sig_buf: &[u8], which: MetadataLocation) -> io::Result<()>
-    where
-        F: Seek + SyncAll,
-    {
-        let zeroed = [0u8; 6 * SECTOR_SIZE];
-        f.seek(SeekFrom::Start(0))?;
-
-        // Write to a single region in the header. Zeroes the first sector,
-        // writes sig_buf to the second sector, and then zeroes the remaining
-        // six sectors.
-        fn write_region<F>(f: &mut F, sig_buf: &[u8], zeroed: &[u8]) -> io::Result<()>
-        where
-            F: Seek + SyncAll,
-        {
-            f.write_all(&zeroed[..SECTOR_SIZE])?; // Zero 1 unused sector
-            f.write_all(sig_buf)?;
-            f.write_all(&zeroed[..SECTOR_SIZE * 6])?; // Zero 6 unused sectors
-            f.sync_all()?;
-            Ok(())
-        };
-
-        if which == MetadataLocation::Both || which == MetadataLocation::First {
-            write_region(f, sig_buf, &zeroed)?;
-        } else {
-            f.seek(SeekFrom::Start(8 * SECTOR_SIZE as u64))?;
-        }
-
-        if which == MetadataLocation::Both || which == MetadataLocation::Second {
-            write_region(f, sig_buf, &zeroed)?;
-        }
-        Ok(())
-    }
-
-    /// Try to find a valid StaticHeader on a device.
-    /// Return the latest copy that validates as a Stratis BDA, however verify both
-    /// copies and if one validates but one does not, re-write the one that is incorrect.  If both
-    /// copies are valid, but one is newer than the other, rewrite the older one to match.
-    /// Return None if it's not a Stratis device.
-    /// Return an error if the metadata seems to indicate that the device is
-    /// a Stratis device, but no well-formed signature block could be read.
-    /// Return an error if neither sigblock location can be read.
-    /// Return an error if the sigblocks differ in some unaccountable way.
-    /// Returns an error if a write intended to repair an ill-formed,
-    /// unreadable, or stale signature block failed.
-    fn setup<F>(f: &mut F) -> StratisResult<Option<StaticHeader>>
-    where
-        F: Read + Seek + SyncAll,
-    {
-        match StaticHeader::read(f) {
-            (Ok(buf_loc_1), Ok(buf_loc_2)) => {
-                // We read both copies without an IO error.
-                match (
-                    StaticHeader::sigblock_from_buf(&buf_loc_1),
-                    StaticHeader::sigblock_from_buf(&buf_loc_2),
-                ) {
-                    (Ok(loc_1), Ok(loc_2)) => {
-                        match (loc_1, loc_2) {
-                            (Some(loc_1), Some(loc_2)) => {
-                                if loc_1 == loc_2 {
-                                    Ok(Some(loc_1))
-                                } else if loc_1.initialization_time == loc_2.initialization_time {
-                                    // Inexplicable disagreement among static headers
-                                    let err_str = "Appeared to be a Stratis device, but signature blocks disagree.";
-                                    Err(StratisError::Engine(ErrorEnum::Invalid, err_str.into()))
-                                } else if loc_1.initialization_time > loc_2.initialization_time {
-                                    // If the first header block is newer, overwrite second with
-                                    // contents of first.
-                                    StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
-                                    Ok(Some(loc_1))
-                                } else {
-                                    // The second header block must be newer, so overwrite first
-                                    // with contents of second.
-                                    StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
-                                    Ok(Some(loc_2))
-                                }
-                            }
-                            (None, None) => Ok(None),
-                            (Some(loc_1), None) => {
-                                // Copy 1 has valid Stratis BDA, copy 2 has no magic, re-write copy 2
-                                StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
-                                Ok(Some(loc_1))
-                            }
-                            (None, Some(loc_2)) => {
-                                // Copy 2 has valid Stratis BDA, copy 1 has no magic, re-write copy 1
-                                StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
-                                Ok(Some(loc_2))
-                            }
-                        }
-                    }
-                    (Ok(loc_1), Err(loc_2)) => {
-                        // Re-write copy 2
-                        if loc_1.is_some() {
-                            StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
-                            Ok(loc_1)
-                        } else {
-                            // Location 1 doesn't have a signature, but location 2 did, but it got an error,
-                            // lets return the error instead as this appears to be a stratis device that
-                            // has gotten in a bad state.
-                            Err(loc_2)
-                        }
-                    }
-                    (Err(loc_1), Ok(loc_2)) => {
-                        // Re-write copy 1
-                        if loc_2.is_some() {
-                            StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
-                            Ok(loc_2)
-                        } else {
-                            // Location 2 doesn't have a signature, but location 1 did, but it got an error,
-                            // lets return the error instead as this appears to be a stratis device that
-                            // has gotten in a bad state.
-                            Err(loc_1)
-                        }
-                    }
-                    (Err(_), Err(_)) => {
-                        let err_str =
-                            "Appeared to be a Stratis device, but no valid sigblock found";
-                        Err(StratisError::Engine(ErrorEnum::Invalid, err_str.into()))
-                    }
-                }
-            }
-            (Ok(buf_loc_1), Err(_)) => {
-                // Copy 1 read OK, 2 resulted in an IO error
-                match StaticHeader::sigblock_from_buf(&buf_loc_1) {
-                    Ok(loc_1) => {
-                        if loc_1.is_some() {
-                            StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
-                        }
-                        Ok(loc_1)
-                    }
-                    Err(e) => {
-                        // Unable to determine if location 2 has a signature, but location 1 did,
-                        // but it got an error, lets return the error instead as this appears to
-                        // be a stratis device that has gotten in a bad state.
-                        Err(e)
-                    }
-                }
-            }
-            (Err(_), Ok(buf_loc_2)) => {
-                // Copy 2 read OK, 1 resulted in IO Error
-                match StaticHeader::sigblock_from_buf(&buf_loc_2) {
-                    Ok(loc_2) => {
-                        if loc_2.is_some() {
-                            StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
-                        }
-                        Ok(loc_2)
-                    }
-                    Err(e) => {
-                        // Unable to determine if location 1 has a signature, but location 2 did,
-                        // but it got an error, lets return the error instead as this appears to
-                        // be a stratis device that has gotten in a bad state.
-                        Err(e)
-                    }
-                }
-            }
-            (Err(_), Err(_)) => {
-                // Unable to read the device at all.
-                let err_str = "Unable to read data at sigblock locations.";
-                Err(StratisError::Engine(ErrorEnum::Invalid, err_str.into()))
-            }
-        }
-    }
-
-    /// Retrieve the device and pool UUIDs from a stratis device.
-    pub fn device_identifiers<F>(f: &mut F) -> StratisResult<Option<((PoolUuid, DevUuid))>>
-    where
-        F: Read + Seek + SyncAll,
-    {
-        StaticHeader::setup(f).map(|sh| sh.map(|sh| (sh.pool_uuid, sh.dev_uuid)))
-    }
-
-    /// Generate a buf suitable for writing to blockdev
-    fn sigblock_to_buf(&self) -> [u8; SECTOR_SIZE] {
-        let mut buf = [0u8; SECTOR_SIZE];
-        buf[4..20].clone_from_slice(STRAT_MAGIC);
-        LittleEndian::write_u64(&mut buf[20..28], *self.blkdev_size);
-        buf[28] = STRAT_SIGBLOCK_VERSION;
-        buf[32..64].clone_from_slice(self.pool_uuid.to_simple_ref().to_string().as_bytes());
-        buf[64..96].clone_from_slice(self.dev_uuid.to_simple_ref().to_string().as_bytes());
-        LittleEndian::write_u64(&mut buf[96..104], *self.mda_size.sectors());
-        LittleEndian::write_u64(&mut buf[104..112], *self.reserved_size);
-        LittleEndian::write_u64(&mut buf[120..128], self.initialization_time);
-
-        let hdr_crc = crc32::checksum_castagnoli(&buf[4..SECTOR_SIZE]);
-        LittleEndian::write_u32(&mut buf[..4], hdr_crc);
-        buf
-    }
-
-    /// Build a StaticHeader from a SECTOR_SIZE buf that was read from
-    /// a blockdev.
-    fn sigblock_from_buf(buf: &[u8]) -> StratisResult<Option<StaticHeader>> {
-        assert_eq!(buf.len(), SECTOR_SIZE);
-
-        if &buf[4..20] != STRAT_MAGIC {
-            return Ok(None);
-        }
-
-        let crc = crc32::checksum_castagnoli(&buf[4..SECTOR_SIZE]);
-        if crc != LittleEndian::read_u32(&buf[..4]) {
-            return Err(StratisError::Engine(
-                ErrorEnum::Invalid,
-                "header CRC invalid".into(),
-            ));
-        }
-
-        let blkdev_size = Sectors(LittleEndian::read_u64(&buf[20..28]));
-
-        let version = buf[28];
-        if version != STRAT_SIGBLOCK_VERSION {
-            return Err(StratisError::Engine(
-                ErrorEnum::Invalid,
-                format!("Unknown sigblock version: {}", version),
-            ));
-        }
-
-        let pool_uuid = Uuid::parse_str(from_utf8(&buf[32..64])?)?;
-        let dev_uuid = Uuid::parse_str(from_utf8(&buf[64..96])?)?;
-
-        let mda_size = mda::MDASize(Sectors(LittleEndian::read_u64(&buf[96..104])));
-
-        Ok(Some(StaticHeader {
-            pool_uuid,
-            dev_uuid,
-            blkdev_size,
-            mda_size,
-            reserved_size: Sectors(LittleEndian::read_u64(&buf[104..112])),
-            flags: 0,
-            initialization_time: LittleEndian::read_u64(&buf[120..128]),
-        }))
-    }
-}
-
-impl fmt::Debug for StaticHeader {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("StaticHeader")
-            .field("blkdev_size", &self.blkdev_size)
-            .field("pool_uuid", &self.pool_uuid.to_simple_ref())
-            .field("dev_uuid", &self.dev_uuid.to_simple_ref())
-            .field("mda_size", &self.mda_size)
-            .field("reserved_size", &self.reserved_size)
-            .field("flags", &self.flags)
-            .field("initialization_time", &self.initialization_time)
-            .finish()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::io::{Cursor, Write};
+    use std::io::{self, Cursor, Write};
 
     use proptest::{collection::vec, num, option, prelude::BoxedStrategy, strategy::Strategy};
     use uuid::Uuid;

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Read, Seek};
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
@@ -91,11 +91,7 @@ impl BDA {
     where
         F: Seek + SyncAll,
     {
-        let zeroed = [0u8; _BDA_STATIC_HDR_SIZE];
-        f.seek(SeekFrom::Start(0))?;
-        f.write_all(&zeroed)?;
-        f.sync_all()?;
-        Ok(())
+        StaticHeader::wipe(f)
     }
 
     /// Save metadata to the disk
@@ -167,7 +163,7 @@ impl BDA {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Cursor, Write};
+    use std::io::{self, Cursor, SeekFrom, Write};
 
     use proptest::{collection::vec, num, option, prelude::BoxedStrategy, strategy::Strategy};
     use uuid::Uuid;

--- a/src/engine/strat_engine/backstore/metadata/mod.rs
+++ b/src/engine/strat_engine/backstore/metadata/mod.rs
@@ -4,8 +4,6 @@
 
 mod bda;
 mod mda;
+mod static_header;
 
-pub use self::{
-    bda::{StaticHeader, BDA},
-    mda::MDADataSize,
-};
+pub use self::{bda::BDA, mda::MDADataSize, static_header::StaticHeader};

--- a/src/engine/strat_engine/backstore/metadata/mod.rs
+++ b/src/engine/strat_engine/backstore/metadata/mod.rs
@@ -6,4 +6,4 @@ mod bda;
 mod mda;
 mod static_header;
 
-pub use self::{bda::BDA, mda::MDADataSize, static_header::StaticHeader};
+pub use self::{bda::BDA, mda::MDADataSize};

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -2,6 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+/*!
+Module that manages writing, reading, and validating the BDA's static header
+region.
+
+It is implicit within this module that the static header is always exactly
+aligned with the start of the device on which the BDA is located.
+
+For that reason, all methods that read from or write to a device implicitly
+or explicitly seek to the start of the device before initiating any reading
+or writing operations.
+*/
+
 use std::{
     fmt,
     io::{self, Read, Seek, SeekFrom},

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -12,7 +12,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use crc::crc32;
 use uuid::Uuid;
 
-use devicemapper::{Sectors, SECTOR_SIZE};
+use devicemapper::{Bytes, Sectors, SECTOR_SIZE};
 
 use crate::{
     engine::{
@@ -22,7 +22,8 @@ use crate::{
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
 
-const _BDA_STATIC_HDR_SIZE: usize = 16 * SECTOR_SIZE;
+pub const _BDA_STATIC_HDR_SIZE: usize = 16 * SECTOR_SIZE;
+pub const BDA_STATIC_HDR_SIZE: Bytes = Bytes(_BDA_STATIC_HDR_SIZE as u64);
 
 const STRAT_MAGIC: &[u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
 

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -1,0 +1,350 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::{
+    fmt,
+    io::{self, Read, Seek, SeekFrom},
+    str::from_utf8,
+};
+
+use byteorder::{ByteOrder, LittleEndian};
+use crc::crc32;
+use uuid::Uuid;
+
+use devicemapper::{Sectors, IEC, SECTOR_SIZE};
+
+use crate::{
+    engine::{
+        strat_engine::{backstore::metadata::mda::MDASize, device::SyncAll},
+        DevUuid, PoolUuid,
+    },
+    stratis::{ErrorEnum, StratisError, StratisResult},
+};
+
+const _BDA_STATIC_HDR_SIZE: usize = 16 * SECTOR_SIZE;
+
+const RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)); // = 3 MiB
+
+const STRAT_MAGIC: &[u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
+
+const STRAT_SIGBLOCK_VERSION: u8 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MetadataLocation {
+    Both,
+    First,
+    Second,
+}
+
+#[derive(Eq, PartialEq)]
+pub struct StaticHeader {
+    pub blkdev_size: Sectors,
+    pub pool_uuid: PoolUuid,
+    pub dev_uuid: DevUuid,
+    pub mda_size: MDASize,
+    pub reserved_size: Sectors,
+    pub flags: u64,
+    /// Seconds portion of DateTime<Utc> value.
+    pub initialization_time: u64,
+}
+
+impl StaticHeader {
+    pub fn new(
+        pool_uuid: PoolUuid,
+        dev_uuid: DevUuid,
+        mda_size: MDASize,
+        blkdev_size: Sectors,
+        initialization_time: u64,
+    ) -> StaticHeader {
+        StaticHeader {
+            blkdev_size,
+            pool_uuid,
+            dev_uuid,
+            mda_size,
+            reserved_size: RESERVED_SECTORS,
+            flags: 0,
+            initialization_time,
+        }
+    }
+
+    /// Read the bytes corresponding to the two signature blocks in the static
+    /// header from the device. Return a tuple indicating the success or
+    /// failure for reading either location.
+    fn read<F>(f: &mut F) -> (io::Result<[u8; SECTOR_SIZE]>, io::Result<[u8; SECTOR_SIZE]>)
+    where
+        F: Read + Seek,
+    {
+        // Theory of read procedure
+        // We write the BDA in two operations with a sync in between.  The write operation
+        // could fail (loss of power) for either write leaving sector(s) with potentially hard
+        // read errors. It's best to read each of the specific BDA blocks individually, to limit
+        // the probability of hitting a read error on a non-essential sector.
+
+        let mut buf_loc_1 = [0u8; SECTOR_SIZE];
+        let mut buf_loc_2 = [0u8; SECTOR_SIZE];
+
+        /// Read a bda sector worth of data at the specified offset into buffer.
+        fn read_sector_at_offset<F>(f: &mut F, offset: usize, mut buf: &mut [u8]) -> io::Result<()>
+        where
+            F: Read + Seek,
+        {
+            f.seek(SeekFrom::Start(offset as u64))?;
+            f.read_exact(&mut buf)?;
+            Ok(())
+        }
+
+        (
+            read_sector_at_offset(f, SECTOR_SIZE, &mut buf_loc_1).map(|_| buf_loc_1),
+            read_sector_at_offset(f, 9 * SECTOR_SIZE, &mut buf_loc_2).map(|_| buf_loc_2),
+        )
+    }
+
+    /// Write signature block data according to the value of the which argument.
+    /// If first location is specified, write zeroes to empty regions in the
+    /// first 8 sectors. If the second location is specified, writes zeroes to
+    /// empty regions in the second 8 sectors.
+    pub fn write<F>(f: &mut F, sig_buf: &[u8], which: MetadataLocation) -> io::Result<()>
+    where
+        F: Seek + SyncAll,
+    {
+        let zeroed = [0u8; 6 * SECTOR_SIZE];
+        f.seek(SeekFrom::Start(0))?;
+
+        // Write to a single region in the header. Zeroes the first sector,
+        // writes sig_buf to the second sector, and then zeroes the remaining
+        // six sectors.
+        fn write_region<F>(f: &mut F, sig_buf: &[u8], zeroed: &[u8]) -> io::Result<()>
+        where
+            F: Seek + SyncAll,
+        {
+            f.write_all(&zeroed[..SECTOR_SIZE])?; // Zero 1 unused sector
+            f.write_all(sig_buf)?;
+            f.write_all(&zeroed[..SECTOR_SIZE * 6])?; // Zero 6 unused sectors
+            f.sync_all()?;
+            Ok(())
+        };
+
+        if which == MetadataLocation::Both || which == MetadataLocation::First {
+            write_region(f, sig_buf, &zeroed)?;
+        } else {
+            f.seek(SeekFrom::Start(8 * SECTOR_SIZE as u64))?;
+        }
+
+        if which == MetadataLocation::Both || which == MetadataLocation::Second {
+            write_region(f, sig_buf, &zeroed)?;
+        }
+        Ok(())
+    }
+
+    /// Try to find a valid StaticHeader on a device.
+    /// Return the latest copy that validates as a Stratis BDA, however verify both
+    /// copies and if one validates but one does not, re-write the one that is incorrect.  If both
+    /// copies are valid, but one is newer than the other, rewrite the older one to match.
+    /// Return None if it's not a Stratis device.
+    /// Return an error if the metadata seems to indicate that the device is
+    /// a Stratis device, but no well-formed signature block could be read.
+    /// Return an error if neither sigblock location can be read.
+    /// Return an error if the sigblocks differ in some unaccountable way.
+    /// Returns an error if a write intended to repair an ill-formed,
+    /// unreadable, or stale signature block failed.
+    pub fn setup<F>(f: &mut F) -> StratisResult<Option<StaticHeader>>
+    where
+        F: Read + Seek + SyncAll,
+    {
+        match StaticHeader::read(f) {
+            (Ok(buf_loc_1), Ok(buf_loc_2)) => {
+                // We read both copies without an IO error.
+                match (
+                    StaticHeader::sigblock_from_buf(&buf_loc_1),
+                    StaticHeader::sigblock_from_buf(&buf_loc_2),
+                ) {
+                    (Ok(loc_1), Ok(loc_2)) => {
+                        match (loc_1, loc_2) {
+                            (Some(loc_1), Some(loc_2)) => {
+                                if loc_1 == loc_2 {
+                                    Ok(Some(loc_1))
+                                } else if loc_1.initialization_time == loc_2.initialization_time {
+                                    // Inexplicable disagreement among static headers
+                                    let err_str = "Appeared to be a Stratis device, but signature blocks disagree.";
+                                    Err(StratisError::Engine(ErrorEnum::Invalid, err_str.into()))
+                                } else if loc_1.initialization_time > loc_2.initialization_time {
+                                    // If the first header block is newer, overwrite second with
+                                    // contents of first.
+                                    StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
+                                    Ok(Some(loc_1))
+                                } else {
+                                    // The second header block must be newer, so overwrite first
+                                    // with contents of second.
+                                    StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
+                                    Ok(Some(loc_2))
+                                }
+                            }
+                            (None, None) => Ok(None),
+                            (Some(loc_1), None) => {
+                                // Copy 1 has valid Stratis BDA, copy 2 has no magic, re-write copy 2
+                                StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
+                                Ok(Some(loc_1))
+                            }
+                            (None, Some(loc_2)) => {
+                                // Copy 2 has valid Stratis BDA, copy 1 has no magic, re-write copy 1
+                                StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
+                                Ok(Some(loc_2))
+                            }
+                        }
+                    }
+                    (Ok(loc_1), Err(loc_2)) => {
+                        // Re-write copy 2
+                        if loc_1.is_some() {
+                            StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
+                            Ok(loc_1)
+                        } else {
+                            // Location 1 doesn't have a signature, but location 2 did, but it got an error,
+                            // lets return the error instead as this appears to be a stratis device that
+                            // has gotten in a bad state.
+                            Err(loc_2)
+                        }
+                    }
+                    (Err(loc_1), Ok(loc_2)) => {
+                        // Re-write copy 1
+                        if loc_2.is_some() {
+                            StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
+                            Ok(loc_2)
+                        } else {
+                            // Location 2 doesn't have a signature, but location 1 did, but it got an error,
+                            // lets return the error instead as this appears to be a stratis device that
+                            // has gotten in a bad state.
+                            Err(loc_1)
+                        }
+                    }
+                    (Err(_), Err(_)) => {
+                        let err_str =
+                            "Appeared to be a Stratis device, but no valid sigblock found";
+                        Err(StratisError::Engine(ErrorEnum::Invalid, err_str.into()))
+                    }
+                }
+            }
+            (Ok(buf_loc_1), Err(_)) => {
+                // Copy 1 read OK, 2 resulted in an IO error
+                match StaticHeader::sigblock_from_buf(&buf_loc_1) {
+                    Ok(loc_1) => {
+                        if loc_1.is_some() {
+                            StaticHeader::write(f, &buf_loc_1, MetadataLocation::Second)?;
+                        }
+                        Ok(loc_1)
+                    }
+                    Err(e) => {
+                        // Unable to determine if location 2 has a signature, but location 1 did,
+                        // but it got an error, lets return the error instead as this appears to
+                        // be a stratis device that has gotten in a bad state.
+                        Err(e)
+                    }
+                }
+            }
+            (Err(_), Ok(buf_loc_2)) => {
+                // Copy 2 read OK, 1 resulted in IO Error
+                match StaticHeader::sigblock_from_buf(&buf_loc_2) {
+                    Ok(loc_2) => {
+                        if loc_2.is_some() {
+                            StaticHeader::write(f, &buf_loc_2, MetadataLocation::First)?;
+                        }
+                        Ok(loc_2)
+                    }
+                    Err(e) => {
+                        // Unable to determine if location 1 has a signature, but location 2 did,
+                        // but it got an error, lets return the error instead as this appears to
+                        // be a stratis device that has gotten in a bad state.
+                        Err(e)
+                    }
+                }
+            }
+            (Err(_), Err(_)) => {
+                // Unable to read the device at all.
+                let err_str = "Unable to read data at sigblock locations.";
+                Err(StratisError::Engine(ErrorEnum::Invalid, err_str.into()))
+            }
+        }
+    }
+
+    /// Retrieve the device and pool UUIDs from a stratis device.
+    pub fn device_identifiers<F>(f: &mut F) -> StratisResult<Option<((PoolUuid, DevUuid))>>
+    where
+        F: Read + Seek + SyncAll,
+    {
+        StaticHeader::setup(f).map(|sh| sh.map(|sh| (sh.pool_uuid, sh.dev_uuid)))
+    }
+
+    /// Generate a buf suitable for writing to blockdev
+    pub fn sigblock_to_buf(&self) -> [u8; SECTOR_SIZE] {
+        let mut buf = [0u8; SECTOR_SIZE];
+        buf[4..20].clone_from_slice(STRAT_MAGIC);
+        LittleEndian::write_u64(&mut buf[20..28], *self.blkdev_size);
+        buf[28] = STRAT_SIGBLOCK_VERSION;
+        buf[32..64].clone_from_slice(self.pool_uuid.to_simple_ref().to_string().as_bytes());
+        buf[64..96].clone_from_slice(self.dev_uuid.to_simple_ref().to_string().as_bytes());
+        LittleEndian::write_u64(&mut buf[96..104], *self.mda_size.sectors());
+        LittleEndian::write_u64(&mut buf[104..112], *self.reserved_size);
+        LittleEndian::write_u64(&mut buf[120..128], self.initialization_time);
+
+        let hdr_crc = crc32::checksum_castagnoli(&buf[4..SECTOR_SIZE]);
+        LittleEndian::write_u32(&mut buf[..4], hdr_crc);
+        buf
+    }
+
+    /// Build a StaticHeader from a SECTOR_SIZE buf that was read from
+    /// a blockdev.
+    pub fn sigblock_from_buf(buf: &[u8]) -> StratisResult<Option<StaticHeader>> {
+        assert_eq!(buf.len(), SECTOR_SIZE);
+
+        if &buf[4..20] != STRAT_MAGIC {
+            return Ok(None);
+        }
+
+        let crc = crc32::checksum_castagnoli(&buf[4..SECTOR_SIZE]);
+        if crc != LittleEndian::read_u32(&buf[..4]) {
+            return Err(StratisError::Engine(
+                ErrorEnum::Invalid,
+                "header CRC invalid".into(),
+            ));
+        }
+
+        let blkdev_size = Sectors(LittleEndian::read_u64(&buf[20..28]));
+
+        let version = buf[28];
+        if version != STRAT_SIGBLOCK_VERSION {
+            return Err(StratisError::Engine(
+                ErrorEnum::Invalid,
+                format!("Unknown sigblock version: {}", version),
+            ));
+        }
+
+        let pool_uuid = Uuid::parse_str(from_utf8(&buf[32..64])?)?;
+        let dev_uuid = Uuid::parse_str(from_utf8(&buf[64..96])?)?;
+
+        let mda_size = MDASize(Sectors(LittleEndian::read_u64(&buf[96..104])));
+
+        Ok(Some(StaticHeader {
+            pool_uuid,
+            dev_uuid,
+            blkdev_size,
+            mda_size,
+            reserved_size: Sectors(LittleEndian::read_u64(&buf[104..112])),
+            flags: 0,
+            initialization_time: LittleEndian::read_u64(&buf[120..128]),
+        }))
+    }
+}
+
+impl fmt::Debug for StaticHeader {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("StaticHeader")
+            .field("blkdev_size", &self.blkdev_size)
+            .field("pool_uuid", &self.pool_uuid.to_simple_ref())
+            .field("dev_uuid", &self.dev_uuid.to_simple_ref())
+            .field("mda_size", &self.mda_size)
+            .field("reserved_size", &self.reserved_size)
+            .field("flags", &self.flags)
+            .field("initialization_time", &self.initialization_time)
+            .finish()
+    }
+}

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -265,6 +265,18 @@ impl StaticHeader {
         }
     }
 
+    /// Write 0s on the entire extent of the static header.
+    pub fn wipe<F>(f: &mut F) -> StratisResult<()>
+    where
+        F: Seek + SyncAll,
+    {
+        let zeroed = [0u8; _BDA_STATIC_HDR_SIZE];
+        f.seek(SeekFrom::Start(0))?;
+        f.write_all(&zeroed)?;
+        f.sync_all()?;
+        Ok(())
+    }
+
     /// Generate a buf suitable for writing to blockdev
     pub fn sigblock_to_buf(&self) -> [u8; SECTOR_SIZE] {
         let mut buf = [0u8; SECTOR_SIZE];

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -265,14 +265,6 @@ impl StaticHeader {
         }
     }
 
-    /// Retrieve the device and pool UUIDs from a stratis device.
-    pub fn device_identifiers<F>(f: &mut F) -> StratisResult<Option<((PoolUuid, DevUuid))>>
-    where
-        F: Read + Seek + SyncAll,
-    {
-        StaticHeader::setup(f).map(|sh| sh.map(|sh| (sh.pool_uuid, sh.dev_uuid)))
-    }
-
     /// Generate a buf suitable for writing to blockdev
     pub fn sigblock_to_buf(&self) -> [u8; SECTOR_SIZE] {
         let mut buf = [0u8; SECTOR_SIZE];

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -12,7 +12,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use crc::crc32;
 use uuid::Uuid;
 
-use devicemapper::{Sectors, IEC, SECTOR_SIZE};
+use devicemapper::{Sectors, SECTOR_SIZE};
 
 use crate::{
     engine::{
@@ -23,8 +23,6 @@ use crate::{
 };
 
 const _BDA_STATIC_HDR_SIZE: usize = 16 * SECTOR_SIZE;
-
-const RESERVED_SECTORS: Sectors = Sectors(3 * IEC::Mi / (SECTOR_SIZE as u64)); // = 3 MiB
 
 const STRAT_MAGIC: &[u8] = b"!Stra0tis\x86\xff\x02^\x41rh";
 
@@ -54,6 +52,7 @@ impl StaticHeader {
         pool_uuid: PoolUuid,
         dev_uuid: DevUuid,
         mda_size: MDASize,
+        reserved_size: Sectors,
         blkdev_size: Sectors,
         initialization_time: u64,
     ) -> StaticHeader {
@@ -62,7 +61,7 @@ impl StaticHeader {
             pool_uuid,
             dev_uuid,
             mda_size,
-            reserved_size: RESERVED_SECTORS,
+            reserved_size,
             flags: 0,
             initialization_time,
         }

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -19,10 +19,7 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
-                blkdev_size,
-                metadata::{StaticHeader, BDA},
-                util::get_stratis_block_devices,
-                StratBlockDev,
+                blkdev_size, metadata::BDA, util::get_stratis_block_devices, StratBlockDev,
             },
             serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave},
         },
@@ -44,9 +41,9 @@ pub fn find_all() -> StratisResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> 
         match devnode_to_devno(&devnode)? {
             None => continue,
             Some(devno) => {
-                if let Some((pool_uuid, _)) = StaticHeader::device_identifiers(
-                    &mut OpenOptions::new().read(true).open(&devnode)?,
-                )? {
+                if let Some((pool_uuid, _)) =
+                    BDA::device_identifiers(&mut OpenOptions::new().read(true).open(&devnode)?)?
+                {
                     pool_map
                         .entry(pool_uuid)
                         .or_insert_with(HashMap::new)


### PR DESCRIPTION
This accomplishes the following:

* Better encapsulation:
  * Since all static header related functionality is now in a separate module, the dependencies of the bda module on static header functionality is made more explicit and obvious.
  * Some constants that were previously shared among all parts of the BDA are now confined to the static header module. The two constants are the stratis magic number and the metadata version.
  * Since it is now obvious that StaticHeader need not be exported, the metadata module has better encapsulation.
  * A number of tests that solely tested static header behavior are now incorporated into the static header tests module and simplified.

* Better documentation: It is now explicitly stated that all methods that read or write the static header seek to the 0 location before beginning. This was not at all obvious before.

* StaticHeader::write is made an instance method, insuring, at the level of the StaticHeader impl, that only a valid signature block can be written to the device by our code. Previously it was necessary to rely on all code that invoked the write method, since the method could take an arbitrary buffer.