### PR TITLE
Use types and defined constant for BDA sizes

### DIFF
--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -14,7 +14,10 @@ use crate::{
     engine::{
         event::get_engine_listener_list,
         strat_engine::{
-            backstore::{metadata::BDA, range_alloc::RangeAllocator, MDADataSize},
+            backstore::{
+                metadata::{BDAExtendedSize, MDADataSize, BDA},
+                range_alloc::RangeAllocator,
+            },
             serde_structs::{BaseBlockDevSave, Recordable},
         },
         BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath,
@@ -58,7 +61,7 @@ impl StratBlockDev {
         user_info: Option<String>,
         hardware_info: Option<String>,
     ) -> StratisResult<StratBlockDev> {
-        let mut segments = vec![(Sectors(0), bda.size())];
+        let mut segments = vec![(Sectors(0), bda.size().sectors())];
         segments.extend(upper_segments);
         let allocator = RangeAllocator::new(bda.dev_size(), &segments)?;
 
@@ -110,7 +113,7 @@ impl StratBlockDev {
 
     // ALL SIZE METHODS (except size(), which is in BlockDev impl.)
     /// The number of Sectors on this device used by Stratis for metadata
-    pub fn metadata_size(&self) -> Sectors {
+    pub fn metadata_size(&self) -> BDAExtendedSize {
         self.bda.size()
     }
 
@@ -161,7 +164,7 @@ impl BlockDev for StratBlockDev {
 
     fn state(&self) -> BlockDevState {
         // TODO: Implement support for other BlockDevStates
-        if self.used.used() > self.bda.size() {
+        if self.used.used() > self.bda.size().sectors() {
             BlockDevState::InUse
         } else {
             BlockDevState::NotInUse

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -164,7 +164,7 @@ impl BlockDev for StratBlockDev {
 
     fn state(&self) -> BlockDevState {
         // TODO: Implement support for other BlockDevStates
-        if self.used.used() > self.bda.size().sectors() {
+        if self.used.used() > self.metadata_size().sectors() {
             BlockDevState::InUse
         } else {
             BlockDevState::NotInUse

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -61,7 +61,7 @@ impl StratBlockDev {
         user_info: Option<String>,
         hardware_info: Option<String>,
     ) -> StratisResult<StratBlockDev> {
-        let mut segments = vec![(Sectors(0), bda.size().sectors())];
+        let mut segments = vec![(Sectors(0), bda.extended_size().sectors())];
         segments.extend(upper_segments);
         let allocator = RangeAllocator::new(bda.dev_size(), &segments)?;
 
@@ -114,7 +114,7 @@ impl StratBlockDev {
     // ALL SIZE METHODS (except size(), which is in BlockDev impl.)
     /// The number of Sectors on this device used by Stratis for metadata
     pub fn metadata_size(&self) -> BDAExtendedSize {
-        self.bda.size()
+        self.bda.extended_size()
     }
 
     /// The number of Sectors on this device not allocated for any purpose.

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -342,7 +342,10 @@ impl BlockDevMgr {
     /// The number of sectors given over to Stratis metadata
     /// self.size() - self.metadata_size() >= self.avail_space()
     pub fn metadata_size(&self) -> Sectors {
-        self.block_devs.iter().map(|bd| bd.metadata_size()).sum()
+        self.block_devs
+            .iter()
+            .map(|bd| bd.metadata_size().sectors())
+            .sum()
     }
 }
 

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -79,8 +79,18 @@ impl BDA {
         }
 
         (
-            read_sector_at_offset(f, SECTOR_SIZE, &mut buf_loc_1).map(|_| buf_loc_1),
-            read_sector_at_offset(f, 9 * SECTOR_SIZE, &mut buf_loc_2).map(|_| buf_loc_2),
+            read_sector_at_offset(
+                f,
+                static_header_size::FIRST_SIGBLOCK_START_SECTORS * SECTOR_SIZE,
+                &mut buf_loc_1,
+            )
+            .map(|_| buf_loc_1),
+            read_sector_at_offset(
+                f,
+                static_header_size::SECOND_SIGBLOCK_START_SECTORS * SECTOR_SIZE,
+                &mut buf_loc_2,
+            )
+            .map(|_| buf_loc_2),
         )
     }
 
@@ -715,12 +725,12 @@ mod tests {
 
             if let Some(index) = primary {
                 // Corrupt primary copy
-                corrupt_byte(&mut buf, (SECTOR_SIZE + index) as u64).unwrap();
+                corrupt_byte(&mut buf, (static_header_sectors::FIRST_SIGBLOCK_START_SECTORS * SECTOR_SIZE + index) as u64).unwrap();
             }
 
             if let Some(index) = secondary {
                 // Corrupt secondary copy
-                corrupt_byte(&mut buf, (9 * SECTOR_SIZE + index) as u64).unwrap();
+                corrupt_byte(&mut buf, (static_header_size::SECOND_SIGBLOCK_START_SECTORS * SECTOR_SIZE + index) as u64).unwrap();
             }
 
             let setup_result = StaticHeader::setup(&mut buf);
@@ -786,7 +796,10 @@ mod tests {
         // We should always match this reference buffer as it's the newer one.
         let reference_buf = buf_newer.clone();
 
-        for offset in &[SECTOR_SIZE, 9 * SECTOR_SIZE] {
+        for offset in &[
+            static_header_size::FIRST_SIGBLOCK_START_SECTORS * SECTOR_SIZE,
+            static_header_size::SECOND_SIGBLOCK_START_SECTORS * SECTOR_SIZE,
+        ] {
             // Copy the older BDA to newer BDA buffer
             buf.seek(SeekFrom::Start(*offset as u64)).unwrap();
             buf_newer.seek(SeekFrom::Start(*offset as u64)).unwrap();

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -237,7 +237,7 @@ impl BDA {
 
     /// The number of sectors the BDA itself occupies.
     pub fn size(&self) -> Sectors {
-        BDA_STATIC_HDR_SIZE.sectors() + self.header.mda_size.sectors() + self.header.reserved_size
+        self.header.mda_size.bda_size().sectors() + self.header.reserved_size
     }
 
     /// The maximum size of variable length metadata that can be accommodated.

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -20,7 +20,7 @@ use crate::{
         strat_engine::{
             backstore::metadata::{
                 mda,
-                sizes::{static_header_size, MDADataSize, MDASize},
+                sizes::{static_header_size, BDAExtendedSize, MDADataSize, MDASize},
             },
             device::SyncAll,
         },
@@ -237,7 +237,7 @@ impl BDA {
 
     /// The number of sectors the BDA itself occupies.
     pub fn size(&self) -> Sectors {
-        self.header.mda_size.bda_size().sectors() + self.header.reserved_size
+        self.header.bda_extended_size().sectors()
     }
 
     /// The maximum size of variable length metadata that can be accommodated.
@@ -290,6 +290,10 @@ impl StaticHeader {
             flags: 0,
             initialization_time,
         }
+    }
+
+    pub fn bda_extended_size(&self) -> BDAExtendedSize {
+        BDAExtendedSize::new(self.mda_size.bda_size().sectors() + self.reserved_size)
     }
 
     /// Try to find a valid StaticHeader on a device.
@@ -725,7 +729,7 @@ mod tests {
 
             if let Some(index) = primary {
                 // Corrupt primary copy
-                corrupt_byte(&mut buf, (static_header_sectors::FIRST_SIGBLOCK_START_SECTORS * SECTOR_SIZE + index) as u64).unwrap();
+                corrupt_byte(&mut buf, (static_header_size::FIRST_SIGBLOCK_START_SECTORS * SECTOR_SIZE + index) as u64).unwrap();
             }
 
             if let Some(index) = secondary {

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -126,7 +126,9 @@ impl BDA {
         if which == MetadataLocation::Both || which == MetadataLocation::First {
             write_region(f, bda_buf, &zeroed)?;
         } else {
-            f.seek(SeekFrom::Start(8 * SECTOR_SIZE as u64))?;
+            f.seek(SeekFrom::Start(
+                (static_header_size::SIGBLOCK_REGION_SECTORS * SECTOR_SIZE) as u64,
+            ))?;
         }
 
         if which == MetadataLocation::Both || which == MetadataLocation::Second {

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -246,8 +246,8 @@ impl BDA {
     }
 
     /// The number of sectors the BDA itself occupies.
-    pub fn size(&self) -> Sectors {
-        self.header.bda_extended_size().sectors()
+    pub fn size(&self) -> BDAExtendedSize {
+        self.header.bda_extended_size()
     }
 
     /// The maximum size of variable length metadata that can be accommodated.

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -251,7 +251,7 @@ impl BDA {
     }
 
     /// The number of sectors the BDA itself occupies.
-    pub fn size(&self) -> BDAExtendedSize {
+    pub fn extended_size(&self) -> BDAExtendedSize {
         self.header.bda_extended_size()
     }
 

--- a/src/engine/strat_engine/backstore/metadata/mda.rs
+++ b/src/engine/strat_engine/backstore/metadata/mda.rs
@@ -15,139 +15,15 @@ use crc::crc32;
 use devicemapper::Bytes;
 
 use crate::{
-    engine::strat_engine::device::SyncAll,
+    engine::strat_engine::{
+        backstore::metadata::sizes::{mda_size, MDADataSize, MDARegionSize, MDASize},
+        device::SyncAll,
+    },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
 
-pub use self::mda_size::{MDADataSize, MDARegionSize, MDASize, MIN_MDA_DATA_REGION_SIZE};
-
 const STRAT_REGION_HDR_VERSION: u8 = 1;
 const STRAT_METADATA_VERSION: u8 = 1;
-
-/// A module which defines types for three different regions of the MDA:
-/// * MDADataSize: the size of the region for variable length metadata
-/// * MDARegionSize: the size a single MDA region
-/// * MDASize: the size of the whole MDA
-mod mda_size {
-
-    use devicemapper::{Bytes, Sectors};
-
-    pub const _MDA_REGION_HDR_SIZE: usize = 32;
-    const MDA_REGION_HDR_SIZE: Bytes = Bytes(_MDA_REGION_HDR_SIZE as u64);
-
-    // The minimum size allocated for variable length metadata
-    pub const MIN_MDA_DATA_REGION_SIZE: Bytes = Bytes(260_064);
-
-    pub const NUM_PRIMARY_MDA_REGIONS: usize = 2;
-
-    // There are two copies of every primary MDA region, so the total number
-    // of MDA regions is twice the number of primary MDA regions.
-    pub const NUM_MDA_REGIONS: usize = 2 * NUM_PRIMARY_MDA_REGIONS;
-
-    /// A value representing the size of the entire MDA.
-    /// It is constructed in one of two ways:
-    /// * By reading a value from a device in constructing a StaticHeader
-    /// * MDARegionSize::mda_size
-    /// Since only a valid MDASize can be constructed, only a valid MDASize
-    /// can be written. An error on reading ought to be detected by
-    /// checksums.
-    /// Since MDARegionSize is always at least the minimum, the result of
-    /// MDARegionSize::mda_size is at least the minimum. The method, by
-    /// definition, constructs a valid MDASize value.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct MDASize(pub Sectors);
-
-    impl Default for MDASize {
-        fn default() -> MDASize {
-            MDARegionSize::default().mda_size()
-        }
-    }
-
-    impl MDASize {
-        pub fn sectors(self) -> Sectors {
-            self.0
-        }
-
-        pub fn region_size(self) -> MDARegionSize {
-            MDARegionSize(self.0 / NUM_MDA_REGIONS)
-        }
-    }
-
-    /// A value representing the size of one MDA region.
-    /// Values of this type are created by one of two methods:
-    /// * MDASize::region_size
-    /// * MDADataSize::region_size
-    /// Since an MDADataSize is always at least the minimum required by the
-    /// design specification, MDADataSize::region_size() always yields a
-    /// value of at least the minimum required size.
-    /// Since an MDASize is always valid, and at least the minimum,
-    /// MDASize::region_size() always yields a valid and sufficiently large
-    /// region.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct MDARegionSize(pub Sectors);
-
-    impl Default for MDARegionSize {
-        fn default() -> MDARegionSize {
-            MDADataSize::default().region_size()
-        }
-    }
-
-    impl MDARegionSize {
-        pub fn sectors(self) -> Sectors {
-            self.0
-        }
-
-        pub fn mda_size(self) -> MDASize {
-            MDASize(self.0 * NUM_MDA_REGIONS)
-        }
-
-        pub fn data_size(self) -> MDADataSize {
-            MDADataSize(self.0.bytes() - MDA_REGION_HDR_SIZE)
-        }
-    }
-
-    /// A type representing the size of the region for storing variable length
-    /// metadata. A newly created value is never less than the minimum required
-    /// by the design specification.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct MDADataSize(Bytes);
-
-    impl Default for MDADataSize {
-        fn default() -> MDADataSize {
-            MDADataSize(MIN_MDA_DATA_REGION_SIZE)
-        }
-    }
-
-    impl MDADataSize {
-        /// Create a new value, bounded from below by the minimum allowed.
-        // Note that this code is dead due to GitHub issue:
-        // https://github.com/stratis-storage/stratisd/issues/754.
-        // To fix that bug it is necessary for client code to specify a
-        // size. It will use this method to do that.
-        #[allow(dead_code)]
-        pub fn new(value: Bytes) -> MDADataSize {
-            if value > MIN_MDA_DATA_REGION_SIZE {
-                MDADataSize(value)
-            } else {
-                MDADataSize::default()
-            }
-        }
-
-        pub fn region_size(self) -> MDARegionSize {
-            let bytes = self.0 + MDA_REGION_HDR_SIZE;
-            let sectors = bytes.sectors();
-            MDARegionSize(if sectors.bytes() != bytes {
-                sectors + Sectors(1)
-            } else {
-                sectors
-            })
-        }
-
-        pub fn bytes(self) -> Bytes {
-            self.0
-        }
-    }
-}
 
 /// Manages the MDA regions which hold the variable length metadata.
 #[derive(Debug)]

--- a/src/engine/strat_engine/backstore/metadata/mod.rs
+++ b/src/engine/strat_engine/backstore/metadata/mod.rs
@@ -6,4 +6,7 @@ mod bda;
 mod mda;
 mod sizes;
 
-pub use self::{bda::BDA, sizes::MDADataSize};
+pub use self::{
+    bda::BDA,
+    sizes::{BDAExtendedSize, MDADataSize},
+};

--- a/src/engine/strat_engine/backstore/metadata/mod.rs
+++ b/src/engine/strat_engine/backstore/metadata/mod.rs
@@ -4,5 +4,6 @@
 
 mod bda;
 mod mda;
+mod sizes;
 
-pub use self::{bda::BDA, mda::MDADataSize};
+pub use self::{bda::BDA, sizes::MDADataSize};

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -16,7 +16,7 @@ pub mod static_header_size {
     pub const PRE_SIGBLOCK_PADDING_SECTORS: usize = 1;
     pub const SIGBLOCK_SECTORS: usize = 1;
     pub const POST_SIGBLOCK_PADDING_SECTORS: usize = 6;
-    const SIGBLOCK_REGION_SECTORS: usize =
+    pub const SIGBLOCK_REGION_SECTORS: usize =
         PRE_SIGBLOCK_PADDING_SECTORS + SIGBLOCK_SECTORS + POST_SIGBLOCK_PADDING_SECTORS;
     pub const STATIC_HEADER_SECTORS: usize = 2 * SIGBLOCK_REGION_SECTORS;
 

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -12,6 +12,10 @@ pub mod static_header_size {
     const SIGBLOCK_REGION_SECTORS: usize =
         PRE_SIGBLOCK_PADDING_SECTORS + SIGBLOCK_SECTORS + POST_SIGBLOCK_PADDING_SECTORS;
     pub const STATIC_HEADER_SECTORS: usize = 2 * SIGBLOCK_REGION_SECTORS;
+
+    pub const FIRST_SIGBLOCK_START_SECTORS: usize = PRE_SIGBLOCK_PADDING_SECTORS;
+    pub const SECOND_SIGBLOCK_START_SECTORS: usize =
+        SIGBLOCK_REGION_SECTORS + PRE_SIGBLOCK_PADDING_SECTORS;
 }
 
 /// A module which defines types for three different regions of the MDA:

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -5,10 +5,14 @@
 pub use self::{
     bda_size::BDAExtendedSize,
     mda_size::{MDADataSize, MDARegionSize, MDASize},
+    static_header_size::{StaticHeaderSize, STATIC_HEADER_SIZE},
 };
 
 /// A module which defines constants and types related to static header sizes.
 pub mod static_header_size {
+
+    use devicemapper::Sectors;
+
     pub const PRE_SIGBLOCK_PADDING_SECTORS: usize = 1;
     const SIGBLOCK_SECTORS: usize = 1;
     pub const POST_SIGBLOCK_PADDING_SECTORS: usize = 6;
@@ -19,6 +23,19 @@ pub mod static_header_size {
     pub const FIRST_SIGBLOCK_START_SECTORS: usize = PRE_SIGBLOCK_PADDING_SECTORS;
     pub const SECOND_SIGBLOCK_START_SECTORS: usize =
         SIGBLOCK_REGION_SECTORS + PRE_SIGBLOCK_PADDING_SECTORS;
+
+    /// Type for the unique static header size which is a constant.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct StaticHeaderSize(Sectors);
+
+    pub const STATIC_HEADER_SIZE: StaticHeaderSize =
+        StaticHeaderSize(Sectors(STATIC_HEADER_SECTORS as u64));
+
+    impl StaticHeaderSize {
+        pub fn sectors(self) -> Sectors {
+            self.0
+        }
+    }
 }
 
 /// A module which defines types for three different regions of the MDA:

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -1,0 +1,130 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+pub use self::mda_size::{MDADataSize, MDARegionSize, MDASize};
+
+/// A module which defines types for three different regions of the MDA:
+/// * MDADataSize: the size of the region for variable length metadata
+/// * MDARegionSize: the size a single MDA region
+/// * MDASize: the size of the whole MDA
+pub mod mda_size {
+
+    use devicemapper::{Bytes, Sectors};
+
+    pub const _MDA_REGION_HDR_SIZE: usize = 32;
+    const MDA_REGION_HDR_SIZE: Bytes = Bytes(_MDA_REGION_HDR_SIZE as u64);
+
+    // The minimum size allocated for variable length metadata
+    pub const MIN_MDA_DATA_REGION_SIZE: Bytes = Bytes(260_064);
+
+    pub const NUM_PRIMARY_MDA_REGIONS: usize = 2;
+
+    // There are two copies of every primary MDA region, so the total number
+    // of MDA regions is twice the number of primary MDA regions.
+    pub const NUM_MDA_REGIONS: usize = 2 * NUM_PRIMARY_MDA_REGIONS;
+
+    /// A value representing the size of the entire MDA.
+    /// It is constructed in one of two ways:
+    /// * By reading a value from a device in constructing a StaticHeader
+    /// * MDARegionSize::mda_size
+    /// Since only a valid MDASize can be constructed, only a valid MDASize
+    /// can be written. An error on reading ought to be detected by
+    /// checksums.
+    /// Since MDARegionSize is always at least the minimum, the result of
+    /// MDARegionSize::mda_size is at least the minimum. The method, by
+    /// definition, constructs a valid MDASize value.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct MDASize(pub Sectors);
+
+    impl Default for MDASize {
+        fn default() -> MDASize {
+            MDARegionSize::default().mda_size()
+        }
+    }
+
+    impl MDASize {
+        pub fn sectors(self) -> Sectors {
+            self.0
+        }
+
+        pub fn region_size(self) -> MDARegionSize {
+            MDARegionSize(self.0 / NUM_MDA_REGIONS)
+        }
+    }
+
+    /// A value representing the size of one MDA region.
+    /// Values of this type are created by one of two methods:
+    /// * MDASize::region_size
+    /// * MDADataSize::region_size
+    /// Since an MDADataSize is always at least the minimum required by the
+    /// design specification, MDADataSize::region_size() always yields a
+    /// value of at least the minimum required size.
+    /// Since an MDASize is always valid, and at least the minimum,
+    /// MDASize::region_size() always yields a valid and sufficiently large
+    /// region.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct MDARegionSize(pub Sectors);
+
+    impl Default for MDARegionSize {
+        fn default() -> MDARegionSize {
+            MDADataSize::default().region_size()
+        }
+    }
+
+    impl MDARegionSize {
+        pub fn sectors(self) -> Sectors {
+            self.0
+        }
+
+        pub fn mda_size(self) -> MDASize {
+            MDASize(self.0 * NUM_MDA_REGIONS)
+        }
+
+        pub fn data_size(self) -> MDADataSize {
+            MDADataSize(self.0.bytes() - MDA_REGION_HDR_SIZE)
+        }
+    }
+
+    /// A type representing the size of the region for storing variable length
+    /// metadata. A newly created value is never less than the minimum required
+    /// by the design specification.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct MDADataSize(Bytes);
+
+    impl Default for MDADataSize {
+        fn default() -> MDADataSize {
+            MDADataSize(MIN_MDA_DATA_REGION_SIZE)
+        }
+    }
+
+    impl MDADataSize {
+        /// Create a new value, bounded from below by the minimum allowed.
+        // Note that this code is dead due to GitHub issue:
+        // https://github.com/stratis-storage/stratisd/issues/754.
+        // To fix that bug it is necessary for client code to specify a
+        // size. It will use this method to do that.
+        #[allow(dead_code)]
+        pub fn new(value: Bytes) -> MDADataSize {
+            if value > MIN_MDA_DATA_REGION_SIZE {
+                MDADataSize(value)
+            } else {
+                MDADataSize::default()
+            }
+        }
+
+        pub fn region_size(self) -> MDARegionSize {
+            let bytes = self.0 + MDA_REGION_HDR_SIZE;
+            let sectors = bytes.sectors();
+            MDARegionSize(if sectors.bytes() != bytes {
+                sectors + Sectors(1)
+            } else {
+                sectors
+            })
+        }
+
+        pub fn bytes(self) -> Bytes {
+            self.0
+        }
+    }
+}

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -65,6 +65,12 @@ pub mod mda_size {
         pub fn region_size(self) -> MDARegionSize {
             MDARegionSize(self.0 / NUM_MDA_REGIONS)
         }
+
+        pub fn bda_size(self) -> super::bda_size::BDASize {
+            super::bda_size::BDASize::new(
+                self.0 + Sectors(super::static_header_size::STATIC_HEADER_SECTORS as u64),
+            )
+        }
     }
 
     /// A value representing the size of one MDA region.
@@ -138,6 +144,27 @@ pub mod mda_size {
         }
 
         pub fn bytes(self) -> Bytes {
+            self.0
+        }
+    }
+}
+
+/// A module which defines constants and types related to BDA sizes.
+pub mod bda_size {
+
+    use devicemapper::Sectors;
+
+    /// Defines the size of the whole BDA which does not not include reserved
+    /// space.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct BDASize(Sectors);
+
+    impl BDASize {
+        pub fn new(value: Sectors) -> BDASize {
+            BDASize(value)
+        }
+
+        pub fn sectors(self) -> Sectors {
             self.0
         }
     }

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub use self::mda_size::{MDADataSize, MDARegionSize, MDASize};
+pub use self::{
+    bda_size::BDAExtendedSize,
+    mda_size::{MDADataSize, MDARegionSize, MDASize},
+};
 
 /// A module which defines constants and types related to static header sizes.
 pub mod static_header_size {
@@ -162,6 +165,20 @@ pub mod bda_size {
     impl BDASize {
         pub fn new(value: Sectors) -> BDASize {
             BDASize(value)
+        }
+
+        pub fn sectors(self) -> Sectors {
+            self.0
+        }
+    }
+
+    /// The size of the whole BDA + reserved space.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct BDAExtendedSize(Sectors);
+
+    impl BDAExtendedSize {
+        pub fn new(value: Sectors) -> BDAExtendedSize {
+            BDAExtendedSize(value)
         }
 
         pub fn sectors(self) -> Sectors {

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -14,7 +14,7 @@ pub mod static_header_size {
     use devicemapper::Sectors;
 
     pub const PRE_SIGBLOCK_PADDING_SECTORS: usize = 1;
-    const SIGBLOCK_SECTORS: usize = 1;
+    pub const SIGBLOCK_SECTORS: usize = 1;
     pub const POST_SIGBLOCK_PADDING_SECTORS: usize = 6;
     const SIGBLOCK_REGION_SECTORS: usize =
         PRE_SIGBLOCK_PADDING_SECTORS + SIGBLOCK_SECTORS + POST_SIGBLOCK_PADDING_SECTORS;

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -4,6 +4,16 @@
 
 pub use self::mda_size::{MDADataSize, MDARegionSize, MDASize};
 
+/// A module which defines constants and types related to static header sizes.
+pub mod static_header_size {
+    pub const PRE_SIGBLOCK_PADDING_SECTORS: usize = 1;
+    const SIGBLOCK_SECTORS: usize = 1;
+    pub const POST_SIGBLOCK_PADDING_SECTORS: usize = 6;
+    const SIGBLOCK_REGION_SECTORS: usize =
+        PRE_SIGBLOCK_PADDING_SECTORS + SIGBLOCK_SECTORS + POST_SIGBLOCK_PADDING_SECTORS;
+    pub const STATIC_HEADER_SECTORS: usize = 2 * SIGBLOCK_REGION_SECTORS;
+}
+
 /// A module which defines types for three different regions of the MDA:
 /// * MDADataSize: the size of the region for variable length metadata
 /// * MDARegionSize: the size a single MDA region

--- a/src/engine/strat_engine/backstore/metadata/sizes.rs
+++ b/src/engine/strat_engine/backstore/metadata/sizes.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub use self::{
-    bda_size::BDAExtendedSize,
+    bda_size::{BDAExtendedSize, ReservedSize},
     mda_size::{MDADataSize, MDARegionSize, MDASize},
     static_header_size::{StaticHeaderSize, STATIC_HEADER_SIZE},
 };
@@ -196,6 +196,20 @@ pub mod bda_size {
     impl BDAExtendedSize {
         pub fn new(value: Sectors) -> BDAExtendedSize {
             BDAExtendedSize(value)
+        }
+
+        pub fn sectors(self) -> Sectors {
+            self.0
+        }
+    }
+
+    /// The reserved space located immediately after the BDA proper.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct ReservedSize(Sectors);
+
+    impl ReservedSize {
+        pub fn new(value: Sectors) -> ReservedSize {
+            ReservedSize(value)
         }
 
         pub fn sectors(self) -> Sectors {


### PR DESCRIPTION
Use types and defined constants for all sizes associated with Stratis metadata.

The metadata stores some sizes which do not describe Stratis metadata regions, they describe Stratis blockdev's, etc. These sizes are still just Sectors or Bytes, they will be distinguished from each other using types in a later PR. All sizes which represent sizes of regions in the metadata or of values stored in those regions are distinguished by types, and related in functions between those types as much as possible.