### PR TITLE
Tidy up imports

### DIFF
--- a/src/engine/devlinks.rs
+++ b/src/engine/devlinks.rs
@@ -13,9 +13,8 @@ use std::{
 
 use crate::{
     engine::{
-        engine::DEV_PATH,
+        engine::{Pool, DEV_PATH},
         types::{Name, PoolUuid},
-        Pool,
     },
     stratis::StratisResult,
 };

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -14,10 +14,9 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Device, Sectors};
 
 use crate::{
-    engine::{
-        types::{FreeSpaceState, PoolExtendState, PoolState},
-        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
-        RenameAction,
+    engine::types::{
+        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
+        PoolExtendState, PoolState, PoolUuid, RenameAction,
     },
     stratis::StratisResult,
 };

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -7,9 +7,8 @@ use std::{
     sync::{Once, ONCE_INIT},
 };
 
-use crate::engine::{
-    types::{BlockDevState, FreeSpaceState, PoolExtendState, PoolState},
-    MaybeDbusPath,
+use crate::engine::types::{
+    BlockDevState, FreeSpaceState, MaybeDbusPath, PoolExtendState, PoolState,
 };
 
 static INIT: Once = ONCE_INIT;

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -14,7 +14,9 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Sectors, IEC};
 
 use crate::engine::{
-    sim_engine::randomization::Randomizer, BlockDev, BlockDevState, MaybeDbusPath,
+    engine::BlockDev,
+    sim_engine::randomization::Randomizer,
+    types::{BlockDevState, MaybeDbusPath},
 };
 
 #[derive(Debug)]

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -14,10 +14,10 @@ use devicemapper::Device;
 
 use crate::{
     engine::{
-        engine::Eventable,
+        engine::{Engine, Eventable, Pool},
         sim_engine::{pool::SimPool, randomization::Randomizer},
         structures::Table,
-        Engine, Name, Pool, PoolUuid, Redundancy, RenameAction,
+        types::{Name, PoolUuid, Redundancy, RenameAction},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use devicemapper::Bytes;
 
 use crate::{
-    engine::{Filesystem, MaybeDbusPath},
+    engine::{types::MaybeDbusPath, Filesystem},
     stratis::StratisResult,
 };
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -17,11 +17,13 @@ use devicemapper::{Sectors, IEC};
 
 use crate::{
     engine::{
+        engine::{BlockDev, Filesystem, Pool},
         sim_engine::{blockdev::SimDev, filesystem::SimFilesystem, randomization::Randomizer},
         structures::Table,
-        types::{FreeSpaceState, PoolExtendState, PoolState},
-        BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
-        PoolUuid, Redundancy, RenameAction,
+        types::{
+            BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
+            PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction,
+        },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -12,7 +12,8 @@ use devicemapper::{Device, Sectors};
 
 use crate::{
     engine::{
-        event::get_engine_listener_list,
+        engine::BlockDev,
+        event::{get_engine_listener_list, EngineEvent},
         strat_engine::{
             backstore::{
                 metadata::{BDAExtendedSize, MDADataSize, BDA},
@@ -20,7 +21,7 @@ use crate::{
             },
             serde_structs::{BaseBlockDevSave, Recordable},
         },
-        BlockDev, BlockDevState, DevUuid, EngineEvent, MaybeDbusPath,
+        types::{BlockDevState, DevUuid, MaybeDbusPath},
     },
     stratis::StratisResult,
 };

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -21,17 +21,18 @@ use devicemapper::{
 
 use crate::{
     engine::{
+        engine::BlockDev,
         strat_engine::{
             backstore::{
-                blkdev_size,
                 device::{identify, resolve_devices, DevOwnership},
                 metadata::{MDADataSize, BDA},
                 util::hw_lookup,
                 StratBlockDev,
             },
+            device::blkdev_size,
             serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable},
         },
-        BlockDev, DevUuid, PoolUuid,
+        types::{DevUuid, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -12,13 +12,13 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
+                blockdev::StratBlockDev,
                 blockdevmgr::{BlkDevSegment, BlockDevMgr},
                 shared::{coalesce_blkdevsegs, metadata_to_segment},
-                StratBlockDev,
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
         },
-        BlockDevTier, DevUuid, PoolUuid,
+        types::{BlockDevTier, DevUuid, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -12,13 +12,13 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
+                blockdev::StratBlockDev,
                 blockdevmgr::{BlkDevSegment, BlockDevMgr},
                 shared::{coalesce_blkdevsegs, metadata_to_segment},
-                StratBlockDev,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},
         },
-        BlockDevTier, DevUuid, PoolUuid,
+        types::{BlockDevTier, DevUuid, PoolUuid},
     },
     stratis::StratisResult,
 };

--- a/src/engine/strat_engine/backstore/device.rs
+++ b/src/engine/strat_engine/backstore/device.rs
@@ -4,33 +4,17 @@
 
 // Functions for dealing with devices.
 
-use std::{
-    collections::HashMap,
-    fs::{File, OpenOptions},
-    os::unix::prelude::AsRawFd,
-    path::Path,
-};
+use std::{collections::HashMap, fs::OpenOptions, path::Path};
 
-use devicemapper::{devnode_to_devno, Bytes, Device};
+use devicemapper::{devnode_to_devno, Device};
 
 use crate::{
     engine::{
         strat_engine::backstore::{metadata::BDA, util::get_udev_block_device},
-        DevUuid, PoolUuid,
+        types::{DevUuid, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
-
-ioctl_read!(blkgetsize64, 0x12, 114, u64);
-
-pub fn blkdev_size(file: &File) -> StratisResult<Bytes> {
-    let mut val: u64 = 0;
-
-    match unsafe { blkgetsize64(file.as_raw_fd(), &mut val) } {
-        Err(x) => Err(StratisError::Nix(x)),
-        Ok(_) => Ok(Bytes(val)),
-    }
-}
 
 /// Resolve a list of Paths of some sort to a set of unique Devices.
 /// Return an IOError if there was a problem resolving any particular device.

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -27,7 +27,7 @@ use crate::{
             },
             device::SyncAll,
         },
-        DevUuid, PoolUuid,
+        types::{DevUuid, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -8,7 +8,7 @@ mod blockdev;
 mod blockdevmgr;
 mod cache_tier;
 mod data_tier;
-pub mod device;
+mod device;
 mod metadata;
 mod range_alloc;
 mod setup;
@@ -18,7 +18,7 @@ mod util;
 pub use self::{
     backstore::Backstore,
     blockdev::StratBlockDev,
-    device::{blkdev_size, is_stratis_device},
+    device::is_stratis_device,
     metadata::MDADataSize,
     setup::{find_all, get_metadata},
 };

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -18,12 +18,11 @@ use devicemapper::{devnode_to_devno, Device, Sectors};
 use crate::{
     engine::{
         strat_engine::{
-            backstore::{
-                blkdev_size, metadata::BDA, util::get_stratis_block_devices, StratBlockDev,
-            },
+            backstore::{blockdev::StratBlockDev, metadata::BDA, util::get_stratis_block_devices},
+            device::blkdev_size,
             serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave},
         },
-        BlockDevTier, DevUuid, PoolUuid,
+        types::{BlockDevTier, DevUuid, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/names.rs
+++ b/src/engine/strat_engine/names.rs
@@ -12,7 +12,7 @@ use std::{
 use devicemapper::{DmNameBuf, DmUuidBuf};
 
 use crate::{
-    engine::{FilesystemUuid, PoolUuid},
+    engine::types::{FilesystemUuid, PoolUuid},
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -22,9 +22,11 @@ use crate::{
             serde_structs::{FlexDevsSave, PoolSave, Recordable},
             thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE},
         },
-        types::{FreeSpaceState, PoolExtendState, PoolState},
-        BlockDev, BlockDevTier, DevUuid, Filesystem, FilesystemUuid, MaybeDbusPath, Name, Pool,
-        PoolUuid, Redundancy, RenameAction,
+        types::{
+            BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
+            PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction,
+        },
+        BlockDev, Filesystem, Pool,
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -16,6 +16,7 @@ use devicemapper::{Device, DmName, DmNameBuf, Sectors};
 
 use crate::{
     engine::{
+        engine::{BlockDev, Filesystem, Pool},
         strat_engine::{
             backstore::{Backstore, MDADataSize, StratBlockDev},
             names::validate_name,
@@ -26,7 +27,6 @@ use crate::{
             BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
             PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction,
         },
-        BlockDev, Filesystem, Pool,
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 use devicemapper::{Sectors, ThinDevId};
 
-use crate::engine::{DevUuid, FilesystemUuid};
+use crate::engine::types::{DevUuid, FilesystemUuid};
 
 /// Implements saving struct data to a serializable form. The form should be
 /// sufficient, in conjunction with the environment, to reconstruct the

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -19,8 +19,7 @@ use devicemapper::{
 };
 
 use crate::engine::strat_engine::{
-    backstore::blkdev_size,
-    device::wipe_sectors,
+    device::{blkdev_size, wipe_sectors},
     dm::get_dm,
     tests::{logger::init_logger, util::clean_up},
 };

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -10,7 +10,7 @@ use nix::mount::{umount2, MntFlags};
 use devicemapper::{DevId, DmOptions};
 
 use crate::engine::strat_engine::{
-    cmd,
+    cmd::udev_settle,
     dm::{get_dm, get_dm_init},
 };
 
@@ -71,7 +71,7 @@ fn dm_stratis_devices_remove() -> Result<()> {
     }
 
     || -> Result<()> {
-        cmd::udev_settle().unwrap();
+        udev_settle().unwrap();
         get_dm_init().map_err(|err| Error::with_chain(err, "Unable to initialize DM"))?;
         do_while_progress().and_then(|remain| {
             if !remain.is_empty() {

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -26,6 +26,7 @@ use tempfile;
 
 use crate::{
     engine::{
+        engine::Filesystem,
         strat_engine::{
             cmd::{create_fs, set_uuid, udev_settle, xfs_growfs},
             dm::get_dm,
@@ -33,7 +34,7 @@ use crate::{
             serde_structs::FilesystemSave,
             thinpool::{thinpool::DATA_LOWATER, DATA_BLOCK_SIZE},
         },
-        Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+        types::{FilesystemUuid, MaybeDbusPath, Name, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -26,7 +26,7 @@ use crate::{
             cmd::create_fs, dm::get_dm, serde_structs::FilesystemSave,
             thinpool::filesystem::StratFilesystem,
         },
-        FilesystemUuid, Name, PoolUuid,
+        types::{FilesystemUuid, Name, PoolUuid},
     },
     stratis::StratisResult,
 };

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -22,7 +22,8 @@ use devicemapper::{
 use crate::{
     engine::{
         devlinks,
-        event::get_engine_listener_list,
+        engine::Filesystem,
+        event::{get_engine_listener_list, EngineEvent},
         strat_engine::{
             backstore::Backstore,
             cmd::{thin_check, thin_repair, udev_settle},
@@ -40,8 +41,10 @@ use crate::{
             },
         },
         structures::Table,
-        types::{FreeSpaceState, PoolExtendState, PoolState},
-        EngineEvent, Filesystem, FilesystemUuid, MaybeDbusPath, Name, PoolUuid, RenameAction,
+        types::{
+            FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState,
+            PoolUuid, RenameAction,
+        },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/39

The imports weren't that bad so the main accomplishments were to improve encapsulation in the backstore module by no longer defining ```blkdev_size``` within that module and no longer publicly exporting its ```device``` sub-module.