### PR TITLE
Fix issue with Stratis metadata handling when the two host machines have different times

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -588,7 +588,7 @@ mod tests {
     use devicemapper::{CacheDevStatus, DataBlocks, IEC};
 
     use crate::engine::strat_engine::{
-        backstore::{find_all, setup::get_metadata},
+        backstore::find_all,
         cmd,
         tests::{loopbacked, real},
     };
@@ -818,8 +818,7 @@ mod tests {
         cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = &map[&pool_uuid];
-        let (timestamp, _) = get_metadata(pool_uuid, map).unwrap().unwrap();
-        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, timestamp).unwrap();
+        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, Utc::now()).unwrap();
         invariant(&backstore);
 
         let backstore_save2 = backstore.record();
@@ -831,8 +830,7 @@ mod tests {
         cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = &map[&pool_uuid];
-        let (timestamp, _) = get_metadata(pool_uuid, map).unwrap().unwrap();
-        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, timestamp).unwrap();
+        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, Utc::now()).unwrap();
         invariant(&backstore);
 
         let backstore_save2 = backstore.record();

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -119,10 +119,10 @@ impl Backstore {
         pool_uuid: PoolUuid,
         backstore_save: &BackstoreSave,
         devnodes: &HashMap<Device, PathBuf>,
-        last_update_time: Option<DateTime<Utc>>,
+        last_update_time: DateTime<Utc>,
     ) -> StratisResult<Backstore> {
         let (datadevs, cachedevs) = get_blockdevs(pool_uuid, backstore_save, devnodes)?;
-        let block_mgr = BlockDevMgr::new(datadevs, last_update_time);
+        let block_mgr = BlockDevMgr::new(datadevs, Some(last_update_time));
         let data_tier = DataTier::setup(block_mgr, &backstore_save.data_tier)?;
         let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
         let origin = LinearDev::setup(
@@ -133,7 +133,7 @@ impl Backstore {
         )?;
 
         let (cache_tier, cache, origin) = if !cachedevs.is_empty() {
-            let block_mgr = BlockDevMgr::new(cachedevs, last_update_time);
+            let block_mgr = BlockDevMgr::new(cachedevs, Some(last_update_time));
             match backstore_save.cache_tier {
                 Some(ref cache_tier_save) => {
                     let cache_tier = CacheTier::setup(block_mgr, &cache_tier_save)?;
@@ -588,7 +588,7 @@ mod tests {
     use devicemapper::{CacheDevStatus, DataBlocks, IEC};
 
     use crate::engine::strat_engine::{
-        backstore::find_all,
+        backstore::{find_all, setup::get_metadata},
         cmd,
         tests::{loopbacked, real},
     };
@@ -818,7 +818,8 @@ mod tests {
         cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = &map[&pool_uuid];
-        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
+        let (timestamp, _) = get_metadata(pool_uuid, map).unwrap().unwrap();
+        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, timestamp).unwrap();
         invariant(&backstore);
 
         let backstore_save2 = backstore.record();
@@ -830,7 +831,8 @@ mod tests {
         cmd::udev_settle().unwrap();
         let map = find_all().unwrap();
         let map = &map[&pool_uuid];
-        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, None).unwrap();
+        let (timestamp, _) = get_metadata(pool_uuid, map).unwrap().unwrap();
+        let mut backstore = Backstore::setup(pool_uuid, &backstore_save, &map, timestamp).unwrap();
         invariant(&backstore);
 
         let backstore_save2 = backstore.record();

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -101,18 +101,19 @@ pub fn get_metadata(
                     .read(true)
                     .open(devnode)
                     .ok()
-                    .and_then(|mut f| bda.load_state(&mut f).ok())
-                    .and_then(|opt| opt)
+                    .and_then(|mut f| bda.load_state(&mut f).unwrap_or(None))
                     .and_then(|data| serde_json::from_slice(&data).ok())
             } else {
                 None
             }
         })
         .next()
-        .ok_or(StratisError::Engine(
-            ErrorEnum::NotFound,
-            "timestamp indicates data was written, but no data successfully read".into(),
-        ))
+        .ok_or_else(|| {
+            StratisError::Engine(
+                ErrorEnum::NotFound,
+                "timestamp indicates data was written, but no data successfully read".into(),
+            )
+        })
         .map(|psave| Some((*most_recent_time, psave)))
 }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -58,7 +58,7 @@ pub fn setup_pool(
         format!("(pool UUID: {}, devnodes: {})", pool_uuid, dev_paths)
     };
 
-    let metadata = get_metadata(pool_uuid, devices)?.ok_or_else(|| {
+    let (timestamp, metadata) = get_metadata(pool_uuid, devices)?.ok_or_else(|| {
         let err_msg = format!("no metadata found for {}", info_string());
         StratisError::Engine(ErrorEnum::NotFound, err_msg)
     })?;
@@ -82,7 +82,7 @@ pub fn setup_pool(
             Err(StratisError::Engine(ErrorEnum::Error, err_msg))
         })
         .and_then(|_| {
-            StratPool::setup(pool_uuid, devices, &metadata).or_else(|e| {
+            StratPool::setup(pool_uuid, devices, timestamp, &metadata).or_else(|e| {
                 let err_msg = format!(
                     "failed to set up pool for {}: reason: {:?}",
                     info_string(),

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -9,6 +9,7 @@ use std::{
     vec::Vec,
 };
 
+use chrono::{DateTime, Utc};
 use serde_json;
 use uuid::Uuid;
 
@@ -191,9 +192,10 @@ impl StratPool {
     pub fn setup(
         uuid: PoolUuid,
         devnodes: &HashMap<Device, PathBuf>,
+        timestamp: DateTime<Utc>,
         metadata: &PoolSave,
     ) -> StratisResult<(Name, StratPool)> {
-        let mut backstore = Backstore::setup(uuid, &metadata.backstore, devnodes, None)?;
+        let mut backstore = Backstore::setup(uuid, &metadata.backstore, devnodes, Some(timestamp))?;
         let mut thinpool = ThinPool::setup(
             uuid,
             &metadata.thinpool_dev,
@@ -542,8 +544,8 @@ mod tests {
         assert_eq!(pools.len(), 2);
         let devnodes1 = &pools[&uuid1];
         let devnodes2 = &pools[&uuid2];
-        let pool_save1 = get_metadata(uuid1, devnodes1).unwrap().unwrap();
-        let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
+        let (_, pool_save1) = get_metadata(uuid1, devnodes1).unwrap().unwrap();
+        let (_, pool_save2) = get_metadata(uuid2, devnodes2).unwrap().unwrap();
         assert_eq!(pool_save1, metadata1);
         assert_eq!(pool_save2, metadata2);
 
@@ -555,8 +557,8 @@ mod tests {
         assert_eq!(pools.len(), 2);
         let devnodes1 = &pools[&uuid1];
         let devnodes2 = &pools[&uuid2];
-        let pool_save1 = get_metadata(uuid1, devnodes1).unwrap().unwrap();
-        let pool_save2 = get_metadata(uuid2, devnodes2).unwrap().unwrap();
+        let (_, pool_save1) = get_metadata(uuid1, devnodes1).unwrap().unwrap();
+        let (_, pool_save2) = get_metadata(uuid2, devnodes2).unwrap().unwrap();
         assert_eq!(pool_save1, metadata1);
         assert_eq!(pool_save2, metadata2);
     }
@@ -673,10 +675,13 @@ mod tests {
         let pools = find_all().unwrap();
         assert_eq!(pools.len(), 1);
         let devices = &pools[&uuid];
+
+        let (timestamp, metadata) = get_metadata(uuid, &devices).unwrap().unwrap();
         let (name, pool) = StratPool::setup(
             uuid,
             &devices,
-            &get_metadata(uuid, &devices).unwrap().unwrap(),
+            timestamp,
+            &metadata
         )
         .unwrap();
         invariant(&pool, &name);

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -677,13 +677,7 @@ mod tests {
         let devices = &pools[&uuid];
 
         let (timestamp, metadata) = get_metadata(uuid, &devices).unwrap().unwrap();
-        let (name, pool) = StratPool::setup(
-            uuid,
-            &devices,
-            timestamp,
-            &metadata
-        )
-        .unwrap();
+        let (name, pool) = StratPool::setup(uuid, &devices, timestamp, &metadata).unwrap();
         invariant(&pool, &name);
 
         let mut buf = [0u8; 10];

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -195,7 +195,7 @@ impl StratPool {
         timestamp: DateTime<Utc>,
         metadata: &PoolSave,
     ) -> StratisResult<(Name, StratPool)> {
-        let mut backstore = Backstore::setup(uuid, &metadata.backstore, devnodes, Some(timestamp))?;
+        let mut backstore = Backstore::setup(uuid, &metadata.backstore, devnodes, timestamp)?;
         let mut thinpool = ThinPool::setup(
             uuid,
             &metadata.thinpool_dev,


### PR DESCRIPTION
This PR should fix the problem we were seeing in #1509 by changing `get_metadata` to always return the associated timestamp with the parsed metadata. Only the timestamp is returned from the `MDAHeader` as it is the only part of that struct that is useful outside of the `impl MDAHeader` block. Given that there should always be a timestamp if metadata is present, the timestamp and parsed metadata are wrapped in an `Option` as you should never get one back but not the other. `Backstore::setup` is always provided with `Some(timestamp)` as the precondition for this function is that metadata verification has always been done according to the comments so it should always be present if the metadata is present.