### PR TITLE
Change to idempotent engine API

### DIFF
--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -37,7 +37,7 @@ pub fn create_dbus_filesystem<'a>(
     let rename_method = f
         .method("SetName", (), rename_filesystem)
         .in_arg(("name", "s"))
-        .out_arg(("result", "bbs"))
+        .out_arg(("result", "(bs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
@@ -108,7 +108,7 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return = (false, false, uuid_to_string!(Uuid::nil()));
+    let default_return = (false, uuid_to_string!(Uuid::nil()));
 
     let filesystem_path = m
         .tree
@@ -131,8 +131,8 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             let (rc, rs) = (DbusErrorEnum::INTERNAL_ERROR as u16, error_message);
             return_message.append3(default_return, rc, rs)
         }
-        Ok(RenameAction::Identity(uuid)) => return_message.append3(
-            (true, false, uuid_to_string!(uuid)),
+        Ok(RenameAction::Identity) => return_message.append3(
+            (false, uuid_to_string!(Uuid::nil())),
             msg_code_ok(),
             msg_string_ok(),
         ),

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -15,8 +15,9 @@ use devicemapper::{Bytes, Device, Sectors};
 
 use crate::{
     engine::types::{
-        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
-        PoolExtendState, PoolState, PoolUuid, RenameAction,
+        BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid,
+        FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState, PoolUuid, RenameAction,
+        SetCreateAction,
     },
     stratis::StratisResult,
 };
@@ -78,7 +79,7 @@ pub trait Pool: Debug {
         pool_uuid: PoolUuid,
         pool_name: &str,
         specs: &[(&'b str, Option<Sectors>)],
-    ) -> StratisResult<Vec<(&'b str, FilesystemUuid)>>;
+    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>>;
 
     /// Adds blockdevs specified by paths to pool.
     /// Returns a list of uuids corresponding to devices actually added.
@@ -117,7 +118,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         uuid: FilesystemUuid,
         new_name: &str,
-    ) -> StratisResult<RenameAction>;
+    ) -> StratisResult<RenameAction<FilesystemUuid>>;
 
     /// Snapshot filesystem
     /// Create a CoW snapshot of the origin
@@ -202,7 +203,7 @@ pub trait Engine: Debug {
         name: &str,
         blockdev_paths: &[&Path],
         redundancy: Option<u16>,
-    ) -> StratisResult<PoolUuid>;
+    ) -> StratisResult<CreateAction<PoolUuid>>;
 
     /// Evaluate a device node & devicemapper::Device to see if it's a valid
     /// stratis device.  If all the devices are present in the pool and the pool isn't already
@@ -216,13 +217,17 @@ pub trait Engine: Debug {
     /// Destroy a pool.
     /// Ensures that the pool of the given UUID is absent on completion.
     /// Returns true if some action was necessary, otherwise false.
-    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<bool>;
+    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<DeleteAction<PoolUuid>>;
 
     /// Rename pool with uuid to new_name.
     /// Raises an error if the mapping can't be applied because
     /// new_name is already in use.
     /// Returns true if it was necessary to perform an action, false if not.
-    fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> StratisResult<RenameAction>;
+    fn rename_pool(
+        &mut self,
+        uuid: PoolUuid,
+        new_name: &str,
+    ) -> StratisResult<RenameAction<PoolUuid>>;
 
     /// Find the pool designated by uuid.
     fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &dyn Pool)>;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -17,7 +17,7 @@ use crate::{
     engine::types::{
         BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid,
         FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState, PoolUuid, RenameAction,
-        SetCreateAction,
+        SetCreateAction, SetDeleteAction,
     },
     stratis::StratisResult,
 };
@@ -106,7 +106,7 @@ pub trait Pool: Debug {
         &'a mut self,
         pool_name: &str,
         fs_uuids: &[FilesystemUuid],
-    ) -> StratisResult<Vec<FilesystemUuid>>;
+    ) -> StratisResult<SetDeleteAction<FilesystemUuid>>;
 
     /// Rename filesystem
     /// Rename pool with uuid to new_name.

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -38,7 +38,7 @@ macro_rules! rename_filesystem_pre {
         };
 
         if &*old_name == $new_name {
-            return Ok(RenameAction::Identity);
+            return Ok(RenameAction::Identity($uuid));
         }
 
         if $s.filesystems.contains_name($new_name) {
@@ -59,7 +59,7 @@ macro_rules! rename_pool_pre {
         };
 
         if &*old_name == $new_name {
-            return Ok(RenameAction::Identity);
+            return Ok(RenameAction::Identity($uuid));
         }
 
         if $s.pools.contains_name($new_name) {

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -38,7 +38,7 @@ macro_rules! rename_filesystem_pre {
         };
 
         if &*old_name == $new_name {
-            return Ok(RenameAction::Identity($uuid));
+            return Ok(RenameAction::Identity);
         }
 
         if $s.filesystems.contains_name($new_name) {
@@ -59,7 +59,7 @@ macro_rules! rename_pool_pre {
         };
 
         if &*old_name == $new_name {
-            return Ok(RenameAction::Identity($uuid));
+            return Ok(RenameAction::Identity);
         }
 
         if $s.pools.contains_name($new_name) {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -9,8 +9,9 @@ pub use self::{
     sim_engine::SimEngine,
     strat_engine::StratEngine,
     types::{
-        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
-        Redundancy, RenameAction,
+        BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, EngineActions,
+        FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction, SetCreateAction,
+        SetDeleteAction,
     },
 };
 

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -17,7 +17,7 @@ use crate::{
         engine::{Engine, Eventable, Pool},
         sim_engine::{pool::SimPool, randomization::Randomizer},
         structures::Table,
-        types::{Name, PoolUuid, Redundancy, RenameAction},
+        types::{CreateAction, DeleteAction, Name, PoolUuid, Redundancy, RenameAction},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
@@ -36,26 +36,27 @@ impl Engine for SimEngine {
         name: &str,
         blockdev_paths: &[&Path],
         redundancy: Option<u16>,
-    ) -> StratisResult<PoolUuid> {
+    ) -> StratisResult<CreateAction<PoolUuid>> {
         let redundancy = calculate_redundancy!(redundancy);
 
-        if self.pools.contains_name(name) {
-            return Err(StratisError::Engine(ErrorEnum::AlreadyExists, name.into()));
+        match self.pools.get_by_name(name) {
+            Some((pool_uuid, _)) => Ok(CreateAction::Identity(pool_uuid)),
+            None => {
+                let device_set: HashSet<_, RandomState> = HashSet::from_iter(blockdev_paths);
+                let devices = device_set.into_iter().cloned().collect::<Vec<&Path>>();
+
+                let (pool_uuid, pool) = SimPool::new(&Rc::clone(&self.rdm), &devices, redundancy);
+
+                if self.rdm.borrow_mut().throw_die() {
+                    return Err(StratisError::Engine(ErrorEnum::Error, "X".into()));
+                }
+
+                self.pools
+                    .insert(Name::new(name.to_owned()), pool_uuid, pool);
+
+                Ok(CreateAction::Created(pool_uuid))
+            }
         }
-
-        let device_set: HashSet<_, RandomState> = HashSet::from_iter(blockdev_paths);
-        let devices = device_set.into_iter().cloned().collect::<Vec<&Path>>();
-
-        let (pool_uuid, pool) = SimPool::new(&Rc::clone(&self.rdm), &devices, redundancy);
-
-        if self.rdm.borrow_mut().throw_die() {
-            return Err(StratisError::Engine(ErrorEnum::Error, "X".into()));
-        }
-
-        self.pools
-            .insert(Name::new(name.to_owned()), pool_uuid, pool);
-
-        Ok(pool_uuid)
     }
 
     fn block_evaluate(
@@ -68,7 +69,7 @@ impl Engine for SimEngine {
         Ok(None)
     }
 
-    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<bool> {
+    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<DeleteAction<PoolUuid>> {
         if let Some((_, pool)) = self.pools.get_by_uuid(uuid) {
             if pool.has_filesystems() {
                 return Err(StratisError::Engine(
@@ -77,17 +78,21 @@ impl Engine for SimEngine {
                 ));
             };
         } else {
-            return Ok(false);
+            return Ok(DeleteAction::Identity(uuid));
         }
         self.pools
             .remove_by_uuid(uuid)
             .expect("Must succeed since self.pool.get_by_uuid() returned a value")
             .1
             .destroy()?;
-        Ok(true)
+        Ok(DeleteAction::Deleted(uuid))
     }
 
-    fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> StratisResult<RenameAction> {
+    fn rename_pool(
+        &mut self,
+        uuid: PoolUuid,
+        new_name: &str,
+    ) -> StratisResult<RenameAction<PoolUuid>> {
         rename_pool_pre!(self; uuid; new_name);
 
         let (_, pool) = self
@@ -97,7 +102,7 @@ impl Engine for SimEngine {
 
         self.pools
             .insert(Name::new(new_name.to_owned()), uuid, pool);
-        Ok(RenameAction::Renamed)
+        Ok(RenameAction::Renamed(uuid))
     }
 
     fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &dyn Pool)> {
@@ -146,7 +151,10 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
-        engine::{Engine, RenameAction},
+        engine::{
+            types::{EngineActions, RenameAction},
+            Engine,
+        },
         stratis::{ErrorEnum, StratisError},
     };
 
@@ -179,7 +187,11 @@ mod tests {
     /// Destroying an empty pool should succeed.
     fn destroy_empty_pool() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("name", &[], None).unwrap();
+        let uuid = engine
+            .create_pool("name", &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         assert_matches!(engine.destroy_pool(uuid), Ok(_));
     }
 
@@ -189,6 +201,8 @@ mod tests {
         let mut engine = SimEngine::default();
         let uuid = engine
             .create_pool("name", &[Path::new("/s/d")], None)
+            .unwrap()
+            .changed()
             .unwrap();
         assert_matches!(engine.destroy_pool(uuid), Ok(_));
     }
@@ -200,6 +214,8 @@ mod tests {
         let pool_name = "pool_name";
         let uuid = engine
             .create_pool(pool_name, &[Path::new("/s/d")], None)
+            .unwrap()
+            .changed()
             .unwrap();
         {
             let pool = engine.get_mut_pool(uuid).unwrap().1;
@@ -216,9 +232,13 @@ mod tests {
         let name = "name";
         let mut engine = SimEngine::default();
         engine.create_pool(name, &[], None).unwrap();
-        assert!(match engine.create_pool(name, &[], None) {
-            Ok(uuid) => engine.get_pool(uuid).unwrap().1.blockdevs().is_empty(),
-            Err(_) => false,
+        assert!(match engine
+            .create_pool(name, &[], None)
+            .ok()
+            .and_then(|uuid| uuid.changed())
+        {
+            Some(uuid) => engine.get_pool(uuid).unwrap().1.blockdevs().is_empty(),
+            _ => false,
         });
     }
 
@@ -232,7 +252,7 @@ mod tests {
             .unwrap();
         assert_matches!(
             engine.create_pool(name, &[], None),
-            Err(StratisError::Engine(ErrorEnum::AlreadyExists, _))
+            Ok(CreateAction::Identity(_))
         );
     }
 
@@ -243,13 +263,12 @@ mod tests {
         let mut engine = SimEngine::default();
         let devices = vec![Path::new(path), Path::new(path)];
         assert_matches!(
-            engine.create_pool("name", &devices, None).map(|uuid| engine
-                .get_pool(uuid)
+            engine
+                .create_pool("name", &devices, None)
                 .unwrap()
-                .1
-                .blockdevs()
-                .len()),
-            Ok(1)
+                .changed()
+                .map(|uuid| engine.get_pool(uuid).unwrap().1.blockdevs().len()),
+            Some(1)
         );
     }
 
@@ -275,18 +294,29 @@ mod tests {
     fn rename_identity() {
         let name = "name";
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool(name, &[], None).unwrap();
-        assert_matches!(engine.rename_pool(uuid, name), Ok(RenameAction::Identity));
+        let uuid = engine
+            .create_pool(name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
+        assert_eq!(
+            engine.rename_pool(uuid, name).unwrap(),
+            RenameAction::Identity(uuid)
+        );
     }
 
     #[test]
     /// Renaming a pool to another pool should work if new name not taken
     fn rename_happens() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("old_name", &[], None).unwrap();
-        assert_matches!(
-            engine.rename_pool(uuid, "new_name"),
-            Ok(RenameAction::Renamed)
+        let uuid = engine
+            .create_pool("old_name", &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
+        assert_eq!(
+            engine.rename_pool(uuid, "new_name").unwrap(),
+            RenameAction::Renamed(uuid)
         );
     }
 
@@ -295,7 +325,11 @@ mod tests {
     fn rename_fails() {
         let new_name = "new_name";
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("old_name", &[], None).unwrap();
+        let uuid = engine
+            .create_pool("old_name", &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         engine.create_pool(new_name, &[], None).unwrap();
         assert_matches!(
             engine.rename_pool(uuid, new_name),

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -40,7 +40,7 @@ impl Engine for SimEngine {
         let redundancy = calculate_redundancy!(redundancy);
 
         match self.pools.get_by_name(name) {
-            Some((pool_uuid, _)) => Ok(CreateAction::Identity(pool_uuid)),
+            Some(_) => Ok(CreateAction::Identity),
             None => {
                 let device_set: HashSet<_, RandomState> = HashSet::from_iter(blockdev_paths);
                 let devices = device_set.into_iter().cloned().collect::<Vec<&Path>>();
@@ -78,7 +78,7 @@ impl Engine for SimEngine {
                 ));
             };
         } else {
-            return Ok(DeleteAction::Identity(uuid));
+            return Ok(DeleteAction::Identity);
         }
         self.pools
             .remove_by_uuid(uuid)
@@ -252,7 +252,7 @@ mod tests {
             .unwrap();
         assert_matches!(
             engine.create_pool(name, &[], None),
-            Ok(CreateAction::Identity(_))
+            Ok(CreateAction::Identity)
         );
     }
 
@@ -301,7 +301,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             engine.rename_pool(uuid, name).unwrap(),
-            RenameAction::Identity(uuid)
+            RenameAction::Identity
         );
     }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -189,7 +189,7 @@ impl Engine for StratEngine {
                 self.pools.insert(name, uuid, pool);
                 Ok(CreateAction::Created(uuid))
             }
-            Some((uuid, _)) => Ok(CreateAction::Identity(uuid)),
+            Some(_) => Ok(CreateAction::Identity),
         }
     }
 
@@ -277,7 +277,7 @@ impl Engine for StratEngine {
                 ));
             };
         } else {
-            return Ok(DeleteAction::Identity(uuid));
+            return Ok(DeleteAction::Identity);
         }
 
         let (pool_name, mut pool) = self

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1019,7 +1019,7 @@ impl ThinPool {
         pool_name: &str,
         uuid: FilesystemUuid,
         new_name: &str,
-    ) -> StratisResult<RenameAction> {
+    ) -> StratisResult<RenameAction<Uuid>> {
         let old_name = rename_filesystem_pre!(self; uuid; new_name);
         let new_name = Name::new(new_name.to_owned());
 
@@ -1040,7 +1040,7 @@ impl ThinPool {
             });
             self.filesystems.insert(new_name.clone(), uuid, filesystem);
             devlinks::filesystem_renamed(pool_name, &old_name, &new_name);
-            Ok(RenameAction::Renamed)
+            Ok(RenameAction::Renamed(uuid))
         }
     }
 
@@ -1549,7 +1549,7 @@ mod tests {
             .unwrap();
 
         let action = pool.rename_filesystem(pool_name, fs_uuid, name2).unwrap();
-        assert_eq!(action, RenameAction::Renamed);
+        assert_matches!(action, RenameAction::Renamed(_));
         let flexdevs: FlexDevsSave = pool.record();
         let thinpoolsave: ThinPoolDevSave = pool.record();
         pool.teardown().unwrap();

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -42,8 +42,8 @@ use crate::{
         },
         structures::Table,
         types::{
-            FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState,
-            PoolUuid, RenameAction,
+            DeleteAction, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState,
+            PoolState, PoolUuid, RenameAction,
         },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
@@ -978,7 +978,7 @@ impl ThinPool {
         &mut self,
         pool_name: &str,
         uuid: FilesystemUuid,
-    ) -> StratisResult<()> {
+    ) -> StratisResult<DeleteAction<FilesystemUuid>> {
         match self.filesystems.remove_by_uuid(uuid) {
             Some((fs_name, mut fs)) => match fs.destroy(&self.thin_pool) {
                 Ok(_) => {
@@ -990,14 +990,14 @@ impl ThinPool {
                                err);
                     }
                     devlinks::filesystem_removed(pool_name, &fs_name);
-                    Ok(())
+                    Ok(DeleteAction::Deleted(uuid))
                 }
                 Err(err) => {
                     self.filesystems.insert(fs_name, uuid, fs);
                     Err(err)
                 }
             },
-            None => Ok(()),
+            None => Ok(DeleteAction::Identity),
         }
     }
 

--- a/src/engine/types/actions.rs
+++ b/src/engine/types/actions.rs
@@ -1,0 +1,264 @@
+pub trait EngineActions {
+    type Return;
+    type Inner;
+
+    fn is_changed(&self) -> bool;
+    fn changed(self) -> Option<Self::Return>;
+    fn changed_ref(&self) -> Option<&Self::Return>;
+    fn unchanged(self) -> Option<Self::Return>;
+    fn unchanged_ref(&self) -> Option<&Self::Return>;
+    fn destructure(self) -> (Option<Self::Return>, Option<Self::Return>);
+    fn into_inner(self) -> Self::Inner;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CreateAction<T> {
+    Identity(T),
+    Created(T),
+}
+
+impl<T> EngineActions for CreateAction<T> {
+    type Return = T;
+    type Inner = T;
+
+    fn is_changed(&self) -> bool {
+        match *self {
+            CreateAction::Identity(_) => false,
+            _ => true,
+        }
+    }
+
+    fn changed(self) -> Option<T> {
+        match self {
+            CreateAction::Created(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn changed_ref(&self) -> Option<&T> {
+        match *self {
+            CreateAction::Created(ref t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn unchanged(self) -> Option<T> {
+        match self {
+            CreateAction::Identity(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn unchanged_ref(&self) -> Option<&T> {
+        match *self {
+            CreateAction::Identity(ref t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn destructure(self) -> (Option<T>, Option<T>) {
+        match self {
+            CreateAction::Identity(t) => (None, Some(t)),
+            CreateAction::Created(t) => (Some(t), None),
+        }
+    }
+
+    fn into_inner(self) -> T {
+        match self {
+            CreateAction::Identity(t) => t,
+            CreateAction::Created(t) => t,
+        }
+    }
+}
+
+pub struct SetCreateAction<T> {
+    changed: Vec<T>,
+    unchanged: Vec<T>,
+}
+
+impl<T> SetCreateAction<T> {
+    pub fn new(changed: Vec<T>, unchanged: Vec<T>) -> Self {
+        SetCreateAction { changed, unchanged }
+    }
+}
+
+impl<T> EngineActions for SetCreateAction<T> {
+    type Return = Vec<T>;
+    type Inner = Vec<T>;
+
+    fn is_changed(&self) -> bool {
+        self.changed.is_empty()
+    }
+
+    fn changed(self) -> Option<Vec<T>> {
+        if self.changed.is_empty() {
+            None
+        } else {
+            Some(self.changed)
+        }
+    }
+
+    fn changed_ref(&self) -> Option<&Vec<T>> {
+        if self.changed.is_empty() {
+            None
+        } else {
+            Some(&self.changed)
+        }
+    }
+
+    fn unchanged(self) -> Option<Vec<T>> {
+        if self.unchanged.is_empty() {
+            None
+        } else {
+            Some(self.unchanged)
+        }
+    }
+
+    fn unchanged_ref(&self) -> Option<&Vec<T>> {
+        if self.unchanged.is_empty() {
+            None
+        } else {
+            Some(&self.unchanged)
+        }
+    }
+
+    fn destructure(self) -> (Option<Vec<T>>, Option<Vec<T>>) {
+        match (self.changed.is_empty(), self.unchanged.is_empty()) {
+            (false, false) => (Some(self.changed), Some(self.unchanged)),
+            (true, false) => (None, Some(self.unchanged)),
+            (false, true) => (Some(self.changed), None),
+            (_, _) => (None, None),
+        }
+    }
+
+    fn into_inner(self) -> Vec<T> {
+        let (mut all, mut unchanged) = (self.changed, self.unchanged);
+        all.append(&mut unchanged);
+        all
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RenameAction<T> {
+    Identity(T),
+    Renamed(T),
+    NoSource,
+}
+
+impl<T> EngineActions for RenameAction<T> {
+    type Return = T;
+    type Inner = Option<T>;
+
+    fn is_changed(&self) -> bool {
+        match *self {
+            RenameAction::Renamed(_) => true,
+            _ => false,
+        }
+    }
+
+    fn changed(self) -> Option<T> {
+        match self {
+            RenameAction::Renamed(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn changed_ref(&self) -> Option<&T> {
+        match *self {
+            RenameAction::Renamed(ref t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn unchanged(self) -> Option<T> {
+        match self {
+            RenameAction::Identity(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn unchanged_ref(&self) -> Option<&T> {
+        match *self {
+            RenameAction::Identity(ref t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn destructure(self) -> (Option<T>, Option<T>) {
+        match self {
+            RenameAction::NoSource => (None, None),
+            RenameAction::Identity(t) => (None, Some(t)),
+            RenameAction::Renamed(t) => (Some(t), None),
+        }
+    }
+
+    fn into_inner(self) -> Option<T> {
+        match self {
+            RenameAction::NoSource => None,
+            RenameAction::Identity(t) => Some(t),
+            RenameAction::Renamed(t) => Some(t),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeleteAction<T> {
+    Identity(T),
+    Deleted(T),
+}
+
+impl<T> EngineActions for DeleteAction<T> {
+    type Return = T;
+    type Inner = T;
+
+    fn is_changed(&self) -> bool {
+        match *self {
+            DeleteAction::Deleted(_) => true,
+            _ => false,
+        }
+    }
+
+    fn changed(self) -> Option<T> {
+        match self {
+            DeleteAction::Deleted(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn changed_ref(&self) -> Option<&T> {
+        match *self {
+            DeleteAction::Deleted(ref t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn unchanged(self) -> Option<T> {
+        match self {
+            DeleteAction::Identity(t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn unchanged_ref(&self) -> Option<&T> {
+        match *self {
+            DeleteAction::Identity(ref t) => Some(t),
+            _ => None,
+        }
+    }
+
+    fn destructure(self) -> (Option<T>, Option<T>) {
+        match self {
+            DeleteAction::Identity(t) => (None, Some(t)),
+            DeleteAction::Deleted(t) => (Some(t), None),
+        }
+    }
+
+    fn into_inner(self) -> T {
+        match self {
+            DeleteAction::Identity(t) => t,
+            DeleteAction::Deleted(t) => t,
+        }
+    }
+}
+
+pub type SetDeleteAction<T> = SetCreateAction<T>;

--- a/src/engine/types/actions.rs
+++ b/src/engine/types/actions.rs
@@ -1,29 +1,23 @@
 pub trait EngineActions {
     type Return;
-    type Inner;
 
     fn is_changed(&self) -> bool;
     fn changed(self) -> Option<Self::Return>;
     fn changed_ref(&self) -> Option<&Self::Return>;
-    fn unchanged(self) -> Option<Self::Return>;
-    fn unchanged_ref(&self) -> Option<&Self::Return>;
-    fn destructure(self) -> (Option<Self::Return>, Option<Self::Return>);
-    fn into_inner(self) -> Self::Inner;
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum CreateAction<T> {
-    Identity(T),
+    Identity,
     Created(T),
 }
 
 impl<T> EngineActions for CreateAction<T> {
     type Return = T;
-    type Inner = T;
 
     fn is_changed(&self) -> bool {
         match *self {
-            CreateAction::Identity(_) => false,
+            CreateAction::Identity => false,
             _ => true,
         }
     }
@@ -41,53 +35,24 @@ impl<T> EngineActions for CreateAction<T> {
             _ => None,
         }
     }
-
-    fn unchanged(self) -> Option<T> {
-        match self {
-            CreateAction::Identity(t) => Some(t),
-            _ => None,
-        }
-    }
-
-    fn unchanged_ref(&self) -> Option<&T> {
-        match *self {
-            CreateAction::Identity(ref t) => Some(t),
-            _ => None,
-        }
-    }
-
-    fn destructure(self) -> (Option<T>, Option<T>) {
-        match self {
-            CreateAction::Identity(t) => (None, Some(t)),
-            CreateAction::Created(t) => (Some(t), None),
-        }
-    }
-
-    fn into_inner(self) -> T {
-        match self {
-            CreateAction::Identity(t) => t,
-            CreateAction::Created(t) => t,
-        }
-    }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct SetCreateAction<T> {
     changed: Vec<T>,
-    unchanged: Vec<T>,
 }
 
 impl<T> SetCreateAction<T> {
-    pub fn new(changed: Vec<T>, unchanged: Vec<T>) -> Self {
-        SetCreateAction { changed, unchanged }
+    pub fn new(changed: Vec<T>) -> Self {
+        SetCreateAction { changed }
     }
 }
 
 impl<T> EngineActions for SetCreateAction<T> {
     type Return = Vec<T>;
-    type Inner = Vec<T>;
 
     fn is_changed(&self) -> bool {
-        self.changed.is_empty()
+        !self.changed.is_empty()
     }
 
     fn changed(self) -> Option<Vec<T>> {
@@ -105,49 +70,17 @@ impl<T> EngineActions for SetCreateAction<T> {
             Some(&self.changed)
         }
     }
-
-    fn unchanged(self) -> Option<Vec<T>> {
-        if self.unchanged.is_empty() {
-            None
-        } else {
-            Some(self.unchanged)
-        }
-    }
-
-    fn unchanged_ref(&self) -> Option<&Vec<T>> {
-        if self.unchanged.is_empty() {
-            None
-        } else {
-            Some(&self.unchanged)
-        }
-    }
-
-    fn destructure(self) -> (Option<Vec<T>>, Option<Vec<T>>) {
-        match (self.changed.is_empty(), self.unchanged.is_empty()) {
-            (false, false) => (Some(self.changed), Some(self.unchanged)),
-            (true, false) => (None, Some(self.unchanged)),
-            (false, true) => (Some(self.changed), None),
-            (_, _) => (None, None),
-        }
-    }
-
-    fn into_inner(self) -> Vec<T> {
-        let (mut all, mut unchanged) = (self.changed, self.unchanged);
-        all.append(&mut unchanged);
-        all
-    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RenameAction<T> {
-    Identity(T),
+    Identity,
     Renamed(T),
     NoSource,
 }
 
 impl<T> EngineActions for RenameAction<T> {
     type Return = T;
-    type Inner = Option<T>;
 
     fn is_changed(&self) -> bool {
         match *self {
@@ -169,47 +102,16 @@ impl<T> EngineActions for RenameAction<T> {
             _ => None,
         }
     }
-
-    fn unchanged(self) -> Option<T> {
-        match self {
-            RenameAction::Identity(t) => Some(t),
-            _ => None,
-        }
-    }
-
-    fn unchanged_ref(&self) -> Option<&T> {
-        match *self {
-            RenameAction::Identity(ref t) => Some(t),
-            _ => None,
-        }
-    }
-
-    fn destructure(self) -> (Option<T>, Option<T>) {
-        match self {
-            RenameAction::NoSource => (None, None),
-            RenameAction::Identity(t) => (None, Some(t)),
-            RenameAction::Renamed(t) => (Some(t), None),
-        }
-    }
-
-    fn into_inner(self) -> Option<T> {
-        match self {
-            RenameAction::NoSource => None,
-            RenameAction::Identity(t) => Some(t),
-            RenameAction::Renamed(t) => Some(t),
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DeleteAction<T> {
-    Identity(T),
+    Identity,
     Deleted(T),
 }
 
 impl<T> EngineActions for DeleteAction<T> {
     type Return = T;
-    type Inner = T;
 
     fn is_changed(&self) -> bool {
         match *self {
@@ -229,34 +131,6 @@ impl<T> EngineActions for DeleteAction<T> {
         match *self {
             DeleteAction::Deleted(ref t) => Some(t),
             _ => None,
-        }
-    }
-
-    fn unchanged(self) -> Option<T> {
-        match self {
-            DeleteAction::Identity(t) => Some(t),
-            _ => None,
-        }
-    }
-
-    fn unchanged_ref(&self) -> Option<&T> {
-        match *self {
-            DeleteAction::Identity(ref t) => Some(t),
-            _ => None,
-        }
-    }
-
-    fn destructure(self) -> (Option<T>, Option<T>) {
-        match self {
-            DeleteAction::Identity(t) => (None, Some(t)),
-            DeleteAction::Deleted(t) => (Some(t), None),
-        }
-    }
-
-    fn into_inner(self) -> T {
-        match self {
-            DeleteAction::Identity(t) => t,
-            DeleteAction::Deleted(t) => t,
         }
     }
 }

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -5,7 +5,7 @@
 use std::{borrow::Borrow, fmt, ops::Deref, rc::Rc};
 
 mod actions;
-pub use actions::{
+pub use crate::engine::types::actions::{
     CreateAction, DeleteAction, EngineActions, RenameAction, SetCreateAction, SetDeleteAction,
 };
 

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -4,6 +4,11 @@
 
 use std::{borrow::Borrow, fmt, ops::Deref, rc::Rc};
 
+mod actions;
+pub use actions::{
+    CreateAction, DeleteAction, EngineActions, RenameAction, SetCreateAction, SetDeleteAction,
+};
+
 #[cfg(feature = "dbus_enabled")]
 use dbus;
 use uuid::Uuid;
@@ -11,13 +16,6 @@ use uuid::Uuid;
 pub type DevUuid = Uuid;
 pub type FilesystemUuid = Uuid;
 pub type PoolUuid = Uuid;
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum RenameAction {
-    Identity,
-    NoSource,
-    Renamed,
-}
 
 /// A DM pool operates in 4 modes.  See drivers/md/dm-thin.c (enum pool_mode).
 /// The 4 modes map to Running, OutOfDataSpace, ReadOnly and Failed - in degrading

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -34,13 +34,13 @@ SPECS = {
 <arg name="name" type="s" direction="in"/>
 <arg name="redundancy" type="(bq)" direction="in"/>
 <arg name="devices" type="as" direction="in"/>
-<arg name="result" type="(s(b(oao)))" direction="out"/>
+<arg name="result" type="(b(oao))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="DestroyPool">
 <arg name="pool" type="o" direction="in"/>
-<arg name="result" type="(b(sb))" direction="out"/>
+<arg name="result" type="(bs)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
@@ -65,13 +65,13 @@ SPECS = {
 </method>
 <method name="CreateFilesystems">
 <arg name="specs" type="as" direction="in"/>
-<arg name="results" type="(b(a(os)a(ss)))" direction="out"/>
+<arg name="results" type="(ba(os))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="DestroyFilesystems">
-<arg name="filesystems" type="as" direction="in"/>
-<arg name="results" type="(b((as)(as)))" direction="out"/>
+<arg name="filesystems" type="ao" direction="in"/>
+<arg name="results" type="(bas)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -34,13 +34,13 @@ SPECS = {
 <arg name="name" type="s" direction="in"/>
 <arg name="redundancy" type="(bq)" direction="in"/>
 <arg name="devices" type="as" direction="in"/>
-<arg name="result" type="(oao)" direction="out"/>
+<arg name="result" type="bb(oao)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="DestroyPool">
 <arg name="pool" type="o" direction="in"/>
-<arg name="action" type="b" direction="out"/>
+<arg name="result" type="bbs" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
@@ -65,7 +65,7 @@ SPECS = {
 </method>
 <method name="CreateFilesystems">
 <arg name="specs" type="as" direction="in"/>
-<arg name="filesystems" type="a(os)" direction="out"/>
+<arg name="filesystems" type="ba(os)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -34,13 +34,13 @@ SPECS = {
 <arg name="name" type="s" direction="in"/>
 <arg name="redundancy" type="(bq)" direction="in"/>
 <arg name="devices" type="as" direction="in"/>
-<arg name="result" type="bb(oao)" direction="out"/>
+<arg name="result" type="(s(b(oao)))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="DestroyPool">
 <arg name="pool" type="o" direction="in"/>
-<arg name="result" type="bbs" direction="out"/>
+<arg name="result" type="(b(sb))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
@@ -65,19 +65,19 @@ SPECS = {
 </method>
 <method name="CreateFilesystems">
 <arg name="specs" type="as" direction="in"/>
-<arg name="filesystems" type="ba(os)" direction="out"/>
+<arg name="results" type="(b(a(os)a(ss)))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="DestroyFilesystems">
-<arg name="filesystems" type="ao" direction="in"/>
-<arg name="results" type="as" direction="out"/>
+<arg name="filesystems" type="as" direction="in"/>
+<arg name="results" type="(b((as)(as)))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="SetName">
 <arg name="name" type="s" direction="in"/>
-<arg name="action" type="b" direction="out"/>
+<arg name="result" type="(bbs)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>

--- a/tests/client-dbus/tests/dbus/manager/test_create.py
+++ b/tests/client-dbus/tests/dbus/manager/test_create.py
@@ -52,7 +52,7 @@ class Create2TestCase(SimTestCase):
         If rc is OK, then pool must exist.
         """
         devs = _DEVICE_STRATEGY()
-        ((poolpath, devnodes), rc, _) = Manager.Methods.CreatePool(
+        ((_, _, (poolpath, devnodes)), rc, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": devs},
         )

--- a/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
@@ -44,7 +44,7 @@ class AddCacheDevsTestCase1(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (_, (poolpath, _))), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": []},
         )
@@ -121,7 +121,7 @@ class AddCacheDevsTestCase2(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((poolpath, devpaths), _, _) = Manager.Methods.CreatePool(
+        ((_, (_, (poolpath, devpaths))), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,

--- a/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
@@ -44,7 +44,7 @@ class AddDataDevsTestCase(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (_, (poolpath, _))), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": []},
         )

--- a/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
@@ -44,7 +44,7 @@ class AddDataDevsTestCase(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((_, (_, (poolpath, _))), _, _) = Manager.Methods.CreatePool(
+        ((_, ((poolpath, _), _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": []},
         )

--- a/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
@@ -150,7 +150,8 @@ class CreateFSTestCase1(SimTestCase):
         )
 
         self.assertEqual(rc, StratisdErrors.OK)
-        assert(use_result, "CreateFilesystems reported that results should not be used when they are valid")
+        assert use_result,
+               "CreateFilesystems reported that results should not be used when they are valid"
         self.assertEqual(len(changed_result), 1)
         self.assertEqual(len(unchanged_result), 0)
 
@@ -192,7 +193,8 @@ class CreateFSTestCase1(SimTestCase):
         )
 
         self.assertEqual(rc, StratisdErrors.ERROR)
-        assert(not use_result, "DBus did not indicate that there was an error using multiple filesystems")
+        assert not use_result,
+               "DBus did not indicate that there was an error using multiple filesystems"
         self.assertEqual(len(changed_result), 0)
         self.assertEqual(len(unchanged_result), 0)
 

--- a/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_create_filesystem.py
@@ -150,7 +150,7 @@ class CreateFSTestCase1(SimTestCase):
         )
 
         self.assertEqual(rc, StratisdErrors.OK)
-        assert use_result,
+        assert use_result, \
                "CreateFilesystems reported that results should not be used when they are valid"
         self.assertEqual(len(changed_result), 1)
         self.assertEqual(len(unchanged_result), 0)
@@ -193,7 +193,7 @@ class CreateFSTestCase1(SimTestCase):
         )
 
         self.assertEqual(rc, StratisdErrors.ERROR)
-        assert not use_result,
+        assert not use_result, \
                "DBus did not indicate that there was an error using multiple filesystems"
         self.assertEqual(len(changed_result), 0)
         self.assertEqual(len(unchanged_result), 0)

--- a/tests/client-dbus/tests/dbus/pool/test_create_snapshot.py
+++ b/tests/client-dbus/tests/dbus/pool/test_create_snapshot.py
@@ -46,7 +46,7 @@ class CreateSnapshotTestCase(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((_, (_, (poolpath, _))), _, _) = Manager.Methods.CreatePool(
+        ((_, ((poolpath, _), _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )

--- a/tests/client-dbus/tests/dbus/pool/test_create_snapshot.py
+++ b/tests/client-dbus/tests/dbus/pool/test_create_snapshot.py
@@ -53,13 +53,13 @@ class CreateSnapshotTestCase(SimTestCase):
         self._pool_object = get_object(poolpath)
         Manager.Methods.ConfigureSimulator(self._proxy, {"denominator": 8})
 
-        ((_, (fs_objects_changed, fs_objects_unchanged)), rc, _) = Pool.Methods.CreateFilesystems(
+        ((_, fs_objects), rc, _) = Pool.Methods.CreateFilesystems(
             self._pool_object, {"specs": [self._VOLNAME]}
         )
 
         self.assertEqual(rc, StratisdErrors.OK)
 
-        fs_object_path = fs_objects_changed[0][0]
+        fs_object_path = fs_objects[0][0]
         self.assertNotEqual(fs_object_path, "/")
 
         self._fs_object_path = fs_object_path

--- a/tests/client-dbus/tests/dbus/pool/test_create_snapshot.py
+++ b/tests/client-dbus/tests/dbus/pool/test_create_snapshot.py
@@ -46,20 +46,20 @@ class CreateSnapshotTestCase(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (_, (poolpath, _))), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )
         self._pool_object = get_object(poolpath)
         Manager.Methods.ConfigureSimulator(self._proxy, {"denominator": 8})
 
-        (fs_objects, rc, _) = Pool.Methods.CreateFilesystems(
+        ((_, (fs_objects_changed, fs_objects_unchanged)), rc, _) = Pool.Methods.CreateFilesystems(
             self._pool_object, {"specs": [self._VOLNAME]}
         )
 
         self.assertEqual(rc, StratisdErrors.OK)
 
-        fs_object_path = fs_objects[0][0]
+        fs_object_path = fs_objects_changed[0][0]
         self.assertNotEqual(fs_object_path, "/")
 
         self._fs_object_path = fs_object_path

--- a/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
@@ -44,7 +44,7 @@ class DestroyFSTestCase(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (_, (poolpath, _))), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )
@@ -57,11 +57,12 @@ class DestroyFSTestCase(SimTestCase):
         list should always succeed, and it should not decrease the
         number of volumes.
         """
-        (result, rc, _) = Pool.Methods.DestroyFilesystems(
+        ((_, (result_changed, result_unchanged)), rc, _) = Pool.Methods.DestroyFilesystems(
             self._pool_object, {"filesystems": []}
         )
 
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result_changed), 0)
+        self.assertEqual(len(result_unchanged), 0)
         self.assertEqual(rc, StratisdErrors.OK)
 
         result = filesystems().search(
@@ -74,11 +75,12 @@ class DestroyFSTestCase(SimTestCase):
         Test calling with a non-existant object path. This should succeed,
         because at the end the filesystem is not there.
         """
-        (result, rc, _) = Pool.Methods.DestroyFilesystems(
+        ((_, (result_changed, result_unchanged)), rc, _) = Pool.Methods.DestroyFilesystems(
             self._pool_object, {"filesystems": ["/"]}
         )
+        self.assertEqual(len(result_changed), 0)
+        self.assertEqual(len(result_unchanged), 1)
         self.assertEqual(rc, StratisdErrors.OK)
-        self.assertEqual(len(result), 0)
 
         result = filesystems().search(
             ObjectManager.Methods.GetManagedObjects(self._proxy, {})
@@ -101,7 +103,7 @@ class DestroyFSTestCase1(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((self._poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (_, (self._poolpath, _))), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )

--- a/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
@@ -44,7 +44,7 @@ class DestroyFSTestCase(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((_, (_, (poolpath, _))), _, _) = Manager.Methods.CreatePool(
+        ((_, ((poolpath, _), _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )
@@ -57,12 +57,13 @@ class DestroyFSTestCase(SimTestCase):
         list should always succeed, and it should not decrease the
         number of volumes.
         """
-        ((_, (result_changed, result_unchanged)), rc, _) = Pool.Methods.DestroyFilesystems(
-            self._pool_object, {"filesystems": []}
-        )
+        (
+            (_, result_changed),
+            rc,
+            _,
+        ) = Pool.Methods.DestroyFilesystems(self._pool_object, {"filesystems": []})
 
         self.assertEqual(len(result_changed), 0)
-        self.assertEqual(len(result_unchanged), 0)
         self.assertEqual(rc, StratisdErrors.OK)
 
         result = filesystems().search(
@@ -75,9 +76,11 @@ class DestroyFSTestCase(SimTestCase):
         Test calling with a non-existant object path. This should succeed,
         because at the end the filesystem is not there.
         """
-        ((_, (result_changed, result_unchanged)), rc, _) = Pool.Methods.DestroyFilesystems(
-            self._pool_object, {"filesystems": ["/"]}
-        )
+        (
+            (_, (result_changed, result_unchanged)),
+            rc,
+            _,
+        ) = Pool.Methods.DestroyFilesystems(self._pool_object, {"filesystems": ["/"]})
         self.assertEqual(len(result_changed), 0)
         self.assertEqual(len(result_unchanged), 1)
         self.assertEqual(rc, StratisdErrors.OK)
@@ -103,7 +106,7 @@ class DestroyFSTestCase1(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((_, (_, (self._poolpath, _))), _, _) = Manager.Methods.CreatePool(
+        ((_, ((self._poolpath, _), _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )

--- a/tests/client-dbus/tests/dbus/pool/test_rename.py
+++ b/tests/client-dbus/tests/dbus/pool/test_rename.py
@@ -43,7 +43,7 @@ class SetNameTestCase(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
+        ((_, _, (self._pool_object_path, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,


### PR DESCRIPTION
This PR is meant to change the engine API to be fully idempotent when creating, deleting, and renaming resources in stratisd. Ultimately the changes should meet the following requirements similar to the existing `RenameAction` enum that already existed:
* Contain information about what resources were operated on
* Pass back whether an action was performed or not
* Standardize across all calls that perform a create, delete, or rename to return this information for consumption by the caller