### PR TITLE
Add macro uuid_to_string

### DIFF
--- a/src/dbus_api/macros.rs
+++ b/src/dbus_api/macros.rs
@@ -42,3 +42,10 @@ macro_rules! get_mut_pool {
         }
     };
 }
+
+// Macro for formatting a Uuid object for transport on the D-Bus as a string
+macro_rules! uuid_to_string {
+    ($uuid:expr) => {
+        $uuid.to_simple_ref().to_string()
+    };
+}

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -138,10 +138,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                 dbus_context.actions.borrow_mut().push_remove(op, m.tree);
             }
 
-            let return_value: Vec<String> = uuids
-                .iter()
-                .map(|n| n.to_simple_ref().to_string())
-                .collect();
+            let return_value: Vec<String> = uuids.iter().map(|n| uuid_to_string!(n)).collect();
             return_message.append3(return_value, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -104,7 +104,7 @@ pub fn get_uuid(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Result<
         .as_ref()
         .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
 
-    i.append(data.uuid.to_simple_ref().to_string());
+    i.append(uuid_to_string!(data.uuid));
     Ok(())
 }
 


### PR DESCRIPTION
#1597 is going to use a new macro, `uuid_to_string!()`. Per requested changes in that PR, I've broken out this macro definition and the use of it where `.to_simple_ref().to_string()` was used previously into a separate PR to be merged before #1597.