### PR TITLE
Changes to DBus and engine APIs for idempotence

### DIFF
--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -26,7 +26,7 @@ use crate::{
             engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok, tuple_to_option,
         },
     },
-    engine::{Engine, Pool, PoolUuid},
+    engine::{CreateAction, DeleteAction, Engine, Pool, PoolUuid},
     stratis::VERSION,
 };
 
@@ -47,28 +47,30 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let return_message = message.method_return();
 
-    let default_return: (dbus::Path, Vec<dbus::Path>) = (dbus::Path::default(), Vec::new());
+    let default_return: (bool, (dbus::Path<'static>, Vec<dbus::Path<'static>>)) =
+        (false, (dbus::Path::default(), Vec::new()));
 
     let msg = match result {
-        Ok(pool_uuid) => {
-            let (_, pool) = get_mut_pool!(engine; pool_uuid; default_return; return_message);
+        Ok(pool_uuid_action) => {
+            let results = match pool_uuid_action {
+                CreateAction::Created(uuid) => {
+                    let (_, pool) = get_mut_pool!(engine; uuid; default_return; return_message);
 
-            let pool_object_path: dbus::Path =
-                create_dbus_pool(dbus_context, object_path.clone(), pool_uuid, pool);
+                    let pool_object_path: dbus::Path =
+                        create_dbus_pool(dbus_context, object_path.clone(), uuid, pool);
 
-            let bd_object_paths = pool
-                .blockdevs_mut()
-                .into_iter()
-                .map(|(uuid, bd)| {
-                    create_dbus_blockdev(dbus_context, pool_object_path.clone(), uuid, bd)
-                })
-                .collect::<Vec<_>>();
-
-            return_message.append3(
-                (pool_object_path, bd_object_paths),
-                msg_code_ok(),
-                msg_string_ok(),
-            )
+                    let bd_paths = pool
+                        .blockdevs_mut()
+                        .into_iter()
+                        .map(|(uuid, bd)| {
+                            create_dbus_blockdev(dbus_context, pool_object_path.clone(), uuid, bd)
+                        })
+                        .collect::<Vec<_>>();
+                    (true, (pool_object_path, bd_paths))
+                }
+                CreateAction::Identity => default_return,
+            };
+            return_message.append3(results, msg_code_ok(), msg_string_ok())
         }
         Err(x) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&x);
@@ -82,15 +84,20 @@ fn destroy_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let object_path: dbus::Path<'static> = get_next_arg(&mut iter, 0)?;
+    let pool_path: dbus::Path<'static> = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
 
-    let default_return = false;
+    let default_return = (false, uuid_to_string!(PoolUuid::nil()));
     let return_message = message.method_return();
 
-    let pool_uuid = match m.tree.get(&object_path) {
-        Some(pool_path) => get_data!(pool_path; default_return; return_message).uuid,
+    let pool_uuid = match m
+        .tree
+        .get(&pool_path)
+        .and_then(|op| op.get_data().as_ref())
+        .map(|d| d.uuid)
+    {
+        Some(uuid) => uuid,
         None => {
             return Ok(vec![return_message.append3(
                 default_return,
@@ -101,12 +108,19 @@ fn destroy_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     };
 
     let msg = match dbus_context.engine.borrow_mut().destroy_pool(pool_uuid) {
-        Ok(action) => {
+        Ok(DeleteAction::Deleted(uuid)) => {
             dbus_context
                 .actions
                 .borrow_mut()
-                .push_remove(&object_path, m.tree);
-            return_message.append3(action, msg_code_ok(), msg_string_ok())
+                .push_remove(&pool_path, m.tree);
+            return_message.append3(
+                (true, uuid_to_string!(uuid)),
+                msg_code_ok(),
+                msg_string_ok(),
+            )
+        }
+        Ok(DeleteAction::Identity) => {
+            return_message.append3(default_return, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -155,14 +169,25 @@ fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>, db
         .in_arg(("name", "s"))
         .in_arg(("redundancy", "(bq)"))
         .in_arg(("devices", "as"))
-        .out_arg(("result", "(oao)"))
+        // In order from left to right:
+        // b: true if a pool was created and object paths were returned
+        // o: Object path for Pool
+        // a(o): Array of object paths for block devices
+        //
+        // Rust representation: (bool, (dbus::Path, Vec<dbus::Path>))
+        .out_arg(("result", "(b(oao))"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
     let destroy_pool_method = f
         .method("DestroyPool", (), destroy_pool)
         .in_arg(("pool", "o"))
-        .out_arg(("action", "b"))
+        // In order from left to right:
+        // b: true if a valid UUID is returned - otherwise no action was performed
+        // s: String representation of pool UUID that was destroyed
+        //
+        // Rust representation: (bool, String)
+        .out_arg(("result", "(bs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -13,8 +13,6 @@ use dbus::{
     Message,
 };
 
-use uuid::Uuid;
-
 use devicemapper::Sectors;
 
 use crate::{
@@ -28,7 +26,10 @@ use crate::{
             msg_string_ok,
         },
     },
-    engine::{BlockDevTier, MaybeDbusPath, Name, Pool, RenameAction},
+    engine::{
+        BlockDevTier, CreateAction, EngineAction, FilesystemUuid, MaybeDbusPath, Name, Pool,
+        PoolUuid, RenameAction,
+    },
 };
 
 fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -40,7 +41,7 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return: Vec<(dbus::Path, &str)> = Vec::new();
+    let default_return: (bool, Vec<(dbus::Path, &str)>) = (false, Vec::new());
 
     if filesystems.count() > 1 {
         let error_message = "only 1 filesystem per request allowed";
@@ -65,15 +66,23 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
             .collect::<Vec<(&str, Option<Sectors>)>>(),
     );
 
-    let msg = match result {
-        Ok(ref infos) => {
-            let return_value = infos
+    let infos = match result {
+        Ok(created_set) => created_set.changed(),
+        Err(err) => {
+            let (rc, rs) = engine_to_dbus_err_tuple(&err);
+            return Ok(vec![return_message.append3(default_return, rc, rs)]);
+        }
+    };
+
+    let return_value = match infos {
+        Some(ref newly_created_filesystems) => {
+            let v = newly_created_filesystems
                 .iter()
                 .map(|&(name, uuid)| {
+                    // FIXME: To avoid this expect, modify create_filesystem
+                    // so that it returns a mutable reference to the
+                    // filesystem created.
                     (
-                        // FIXME: To avoid this expect, modify create_filesystem
-                        // so that it returns a mutable reference to the
-                        // filesystem created.
                         create_dbus_filesystem(
                             dbus_context,
                             object_path.clone(),
@@ -86,15 +95,16 @@ fn create_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                     )
                 })
                 .collect::<Vec<_>>();
-
-            return_message.append3(return_value, msg_code_ok(), msg_string_ok())
+            (true, v)
         }
-        Err(err) => {
-            let (rc, rs) = engine_to_dbus_err_tuple(&err);
-            return_message.append3(default_return, rc, rs)
-        }
+        None => default_return,
     };
-    Ok(vec![msg])
+
+    Ok(vec![return_message.append3(
+        return_value,
+        msg_code_ok(),
+        msg_string_ok(),
+    )])
 }
 
 fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -106,7 +116,7 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return: Vec<&str> = Vec::new();
+    let default_return: (bool, Vec<String>) = (false, Vec::new());
 
     let pool_path = m
         .tree
@@ -117,29 +127,39 @@ fn destroy_filesystems(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut engine = dbus_context.engine.borrow_mut();
     let (pool_name, pool) = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
-    let mut filesystem_map: HashMap<Uuid, dbus::Path<'static>> = HashMap::new();
-    for op in filesystems {
-        if let Some(filesystem_path) = m.tree.get(&op) {
-            let filesystem_uuid = get_data!(filesystem_path; default_return; return_message).uuid;
-            filesystem_map.insert(filesystem_uuid, op);
-        }
-    }
+    let filesystem_map: HashMap<FilesystemUuid, dbus::Path<'static>> = filesystems
+        .filter_map(|path| {
+            m.tree.get(&path).and_then(|op| {
+                op.get_data()
+                    .as_ref()
+                    .map(|d| (d.uuid, op.get_name().clone()))
+            })
+        })
+        .collect();
 
     let result = pool.destroy_filesystems(
         &pool_name,
-        &filesystem_map.keys().cloned().collect::<Vec<Uuid>>(),
+        &filesystem_map.keys().cloned().collect::<Vec<_>>(),
     );
     let msg = match result {
-        Ok(ref uuids) => {
-            for uuid in uuids {
-                let op = filesystem_map
-                    .get(uuid)
-                    .expect("'uuids' is a subset of filesystem_map.keys()");
-                dbus_context.actions.borrow_mut().push_remove(op, m.tree);
-            }
-
-            let return_value: Vec<String> = uuids.iter().map(|n| uuid_to_string!(n)).collect();
-            return_message.append3(return_value, msg_code_ok(), msg_string_ok())
+        Ok(uuids) => {
+            // Only get changed values here as non-existant filesystems will have been filtered out
+            // before calling destroy_filesystems
+            let uuid_vec: Vec<String> = if let Some(ref changed_uuids) = uuids.changed() {
+                for uuid in changed_uuids {
+                    let op = filesystem_map
+                        .get(uuid)
+                        .expect("'uuids' is a subset of filesystem_map.keys()");
+                    dbus_context.actions.borrow_mut().push_remove(op, m.tree);
+                }
+                changed_uuids
+                    .iter()
+                    .map(|uuid| uuid_to_string!(uuid))
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            return_message.append3((true, uuid_vec), msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -159,7 +179,7 @@ fn snapshot_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return = dbus::Path::default();
+    let default_return = (false, dbus::Path::default());
 
     let pool_path = m
         .tree
@@ -180,10 +200,13 @@ fn snapshot_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let (pool_name, pool) = get_mut_pool!(engine; pool_uuid; default_return; return_message);
 
     let msg = match pool.snapshot_filesystem(pool_uuid, &pool_name, fs_uuid, snapshot_name) {
-        Ok((uuid, fs)) => {
+        Ok(CreateAction::Created((uuid, fs))) => {
             let fs_object_path: dbus::Path =
                 create_dbus_filesystem(dbus_context, object_path.clone(), uuid, fs);
-            return_message.append3(fs_object_path, msg_code_ok(), msg_string_ok())
+            return_message.append3((true, fs_object_path), msg_code_ok(), msg_string_ok())
+        }
+        Ok(CreateAction::Identity) => {
+            return_message.append3(default_return, msg_code_ok(), msg_string_ok())
         }
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
@@ -203,7 +226,7 @@ fn add_blockdevs(m: &MethodInfo<MTFn<TData>, TData>, tier: BlockDevTier) -> Meth
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return: Vec<dbus::Path> = Vec::new();
+    let default_return: (bool, Vec<dbus::Path>) = (false, Vec::new());
 
     let pool_path = m
         .tree
@@ -217,8 +240,8 @@ fn add_blockdevs(m: &MethodInfo<MTFn<TData>, TData>, tier: BlockDevTier) -> Meth
     let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
 
     let result = pool.add_blockdevs(pool_uuid, &*pool_name, &blockdevs, tier);
-    let msg = match result {
-        Ok(uuids) => {
+    let msg = match result.map(|bds| bds.changed()) {
+        Ok(Some(uuids)) => {
             let return_value = uuids
                 .iter()
                 .map(|uuid| {
@@ -236,8 +259,9 @@ fn add_blockdevs(m: &MethodInfo<MTFn<TData>, TData>, tier: BlockDevTier) -> Meth
                 })
                 .collect::<Vec<_>>();
 
-            return_message.append3(return_value, msg_code_ok(), msg_string_ok())
+            return_message.append3((true, return_value), msg_code_ok(), msg_string_ok())
         }
+        Ok(None) => return_message.append3(default_return, msg_code_ok(), msg_string_ok()),
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
@@ -264,7 +288,7 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
     let return_message = message.method_return();
-    let default_return = false;
+    let default_return = (false, uuid_to_string!(PoolUuid::nil()));
 
     let pool_path = m
         .tree
@@ -278,12 +302,18 @@ fn rename_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         .rename_pool(pool_uuid, new_name)
     {
         Ok(RenameAction::NoSource) => {
-            let error_message = format!("engine doesn't know about pool {}", &pool_uuid);
+            let error_message = format!("engine doesn't know about pool {}", pool_uuid);
             let (rc, rs) = (DbusErrorEnum::INTERNAL_ERROR as u16, error_message);
             return_message.append3(default_return, rc, rs)
         }
-        Ok(RenameAction::Identity) => return_message.append3(false, msg_code_ok(), msg_string_ok()),
-        Ok(RenameAction::Renamed) => return_message.append3(true, msg_code_ok(), msg_string_ok()),
+        Ok(RenameAction::Identity) => {
+            return_message.append3(default_return, msg_code_ok(), msg_string_ok())
+        }
+        Ok(RenameAction::Renamed(uuid)) => return_message.append3(
+            (true, uuid_to_string!(uuid)),
+            msg_code_ok(),
+            msg_string_ok(),
+        ),
         Err(err) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&err);
             return_message.append3(default_return, rc, rs)
@@ -301,7 +331,7 @@ fn get_pool_property<F, R>(
     getter: F,
 ) -> Result<(), MethodErr>
 where
-    F: Fn((Name, Uuid, &dyn Pool)) -> Result<R, MethodErr>,
+    F: Fn((Name, PoolUuid, &dyn Pool)) -> Result<R, MethodErr>,
     R: dbus::arg::Append,
 {
     let dbus_context = p.tree.get_data();
@@ -334,7 +364,7 @@ fn get_pool_total_physical_used(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,
 ) -> Result<(), MethodErr> {
-    fn get_used((_, uuid, pool): (Name, Uuid, &dyn Pool)) -> Result<String, MethodErr> {
+    fn get_used((_, uuid, pool): (Name, PoolUuid, &dyn Pool)) -> Result<String, MethodErr> {
         let err_func = |_| {
             MethodErr::failed(&format!(
                 "no total physical size computed for pool with uuid {}",
@@ -377,7 +407,7 @@ fn get_space_state(i: &mut IterAppend, p: &PropInfo<MTFn<TData>, TData>) -> Resu
 pub fn create_dbus_pool<'a>(
     dbus_context: &DbusContext,
     parent: dbus::Path<'static>,
-    uuid: Uuid,
+    uuid: PoolUuid,
     pool: &mut dyn Pool,
 ) -> dbus::Path<'a> {
     let f = Factory::new_fn();
@@ -385,35 +415,55 @@ pub fn create_dbus_pool<'a>(
     let create_filesystems_method = f
         .method("CreateFilesystems", (), create_filesystems)
         .in_arg(("specs", "as"))
-        .out_arg(("filesystems", "a(os)"))
+        // b: true if filesystems were created
+        // a(os): Array of tuples with object paths and names
+        //
+        // Rust representation: (bool, Vec<(dbus::Path, String)>)
+        .out_arg(("results", "(ba(os))"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
     let destroy_filesystems_method = f
         .method("DestroyFilesystems", (), destroy_filesystems)
         .in_arg(("filesystems", "ao"))
-        .out_arg(("results", "as"))
+        // b: true if filesystems were destroyed
+        // as: Array of UUIDs of destroyed filesystems
+        //
+        // Rust representation: (bool, Vec<String>)
+        .out_arg(("results", "(bas)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
     let add_blockdevs_method = f
         .method("AddDataDevs", (), add_datadevs)
         .in_arg(("devices", "as"))
-        .out_arg(("results", "ao"))
+        // b: Indicates if any data devices were added
+        // ao: Array of object paths of created data devices
+        //
+        // Rust representation: (bool, Vec<dbus::path>)
+        .out_arg(("results", "(bao)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
     let add_cachedevs_method = f
         .method("AddCacheDevs", (), add_cachedevs)
         .in_arg(("devices", "as"))
-        .out_arg(("results", "ao"))
+        // b: Indicates if any cache devices were added
+        // ao: Array of object paths of created cache devices
+        //
+        // Rust representation: (bool, Vec<dbus::path>)
+        .out_arg(("results", "(bao)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
     let rename_method = f
         .method("SetName", (), rename_pool)
         .in_arg(("name", "s"))
-        .out_arg(("action", "b"))
+        // b: false if no pool was renamed
+        // s: UUID of renamed pool
+        //
+        // Rust representation: (bool, String)
+        .out_arg(("result", "(bs)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 
@@ -421,7 +471,11 @@ pub fn create_dbus_pool<'a>(
         .method("SnapshotFilesystem", (), snapshot_filesystem)
         .in_arg(("origin", "o"))
         .in_arg(("snapshot_name", "s"))
-        .out_arg(("result", "o"))
+        // b: false if no new snapshot was created
+        // s: Object path of new snapshot
+        //
+        // Rust representation: (bool, String)
+        .out_arg(("result", "(bo)"))
         .out_arg(("return_code", "q"))
         .out_arg(("return_string", "s"));
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -15,8 +15,9 @@ use devicemapper::{Bytes, Device, Sectors};
 
 use crate::{
     engine::types::{
-        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
-        PoolExtendState, PoolState, PoolUuid, RenameAction,
+        BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid,
+        FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState, PoolUuid, RenameAction,
+        SetCreateAction, SetDeleteAction,
     },
     stratis::StratisResult,
 };
@@ -78,7 +79,7 @@ pub trait Pool: Debug {
         pool_uuid: PoolUuid,
         pool_name: &str,
         specs: &[(&'b str, Option<Sectors>)],
-    ) -> StratisResult<Vec<(&'b str, FilesystemUuid)>>;
+    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>>;
 
     /// Adds blockdevs specified by paths to pool.
     /// Returns a list of uuids corresponding to devices actually added.
@@ -90,7 +91,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         paths: &[&Path],
         tier: BlockDevTier,
-    ) -> StratisResult<Vec<DevUuid>>;
+    ) -> StratisResult<SetCreateAction<DevUuid>>;
 
     /// Destroy the pool.
     /// Precondition: All filesystems belonging to this pool must be
@@ -105,7 +106,7 @@ pub trait Pool: Debug {
         &'a mut self,
         pool_name: &str,
         fs_uuids: &[FilesystemUuid],
-    ) -> StratisResult<Vec<FilesystemUuid>>;
+    ) -> StratisResult<SetDeleteAction<FilesystemUuid>>;
 
     /// Rename filesystem
     /// Rename pool with uuid to new_name.
@@ -117,7 +118,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         uuid: FilesystemUuid,
         new_name: &str,
-    ) -> StratisResult<RenameAction>;
+    ) -> StratisResult<RenameAction<FilesystemUuid>>;
 
     /// Snapshot filesystem
     /// Create a CoW snapshot of the origin
@@ -127,7 +128,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<(FilesystemUuid, &mut dyn Filesystem)>;
+    ) -> StratisResult<CreateAction<(FilesystemUuid, &mut dyn Filesystem)>>;
 
     /// The total number of Sectors belonging to this pool.
     /// There are no exclusions, so this number includes overhead sectors
@@ -174,7 +175,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         uuid: DevUuid,
         user_info: Option<&str>,
-    ) -> StratisResult<bool>;
+    ) -> StratisResult<RenameAction<DevUuid>>;
 
     /// The current state of the Pool.
     fn state(&self) -> PoolState;
@@ -202,7 +203,7 @@ pub trait Engine: Debug {
         name: &str,
         blockdev_paths: &[&Path],
         redundancy: Option<u16>,
-    ) -> StratisResult<PoolUuid>;
+    ) -> StratisResult<CreateAction<PoolUuid>>;
 
     /// Evaluate a device node & devicemapper::Device to see if it's a valid
     /// stratis device.  If all the devices are present in the pool and the pool isn't already
@@ -216,13 +217,17 @@ pub trait Engine: Debug {
     /// Destroy a pool.
     /// Ensures that the pool of the given UUID is absent on completion.
     /// Returns true if some action was necessary, otherwise false.
-    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<bool>;
+    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<DeleteAction<PoolUuid>>;
 
     /// Rename pool with uuid to new_name.
     /// Raises an error if the mapping can't be applied because
     /// new_name is already in use.
     /// Returns true if it was necessary to perform an action, false if not.
-    fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> StratisResult<RenameAction>;
+    fn rename_pool(
+        &mut self,
+        uuid: PoolUuid,
+        new_name: &str,
+    ) -> StratisResult<RenameAction<PoolUuid>>;
 
     /// Find the pool designated by uuid.
     fn get_pool(&self, uuid: PoolUuid) -> Option<(Name, &dyn Pool)>;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -9,8 +9,9 @@ pub use self::{
     sim_engine::SimEngine,
     strat_engine::StratEngine,
     types::{
-        BlockDevState, BlockDevTier, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
-        Redundancy, RenameAction,
+        BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, EngineAction,
+        FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction, SetCreateAction,
+        SetDeleteAction,
     },
 };
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -21,8 +21,9 @@ use crate::{
         sim_engine::{blockdev::SimDev, filesystem::SimFilesystem, randomization::Randomizer},
         structures::Table,
         types::{
-            BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
-            PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction,
+            BlockDevTier, CreateAction, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath,
+            Name, PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction, SetCreateAction,
+            SetDeleteAction,
         },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
@@ -89,27 +90,20 @@ impl Pool for SimPool {
         _pool_uuid: PoolUuid,
         _pool_name: &str,
         specs: &[(&'b str, Option<Sectors>)],
-    ) -> StratisResult<Vec<(&'b str, FilesystemUuid)>> {
+    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>> {
         let names: HashMap<_, _> = HashMap::from_iter(specs.iter().map(|&tup| (tup.0, tup.1)));
+        let mut result = Vec::new();
         for name in names.keys() {
-            if self.filesystems.contains_name(name) {
-                return Err(StratisError::Engine(
-                    ErrorEnum::AlreadyExists,
-                    name.to_string(),
-                ));
+            if !self.filesystems.contains_name(name) {
+                let uuid = Uuid::new_v4();
+                let new_filesystem = SimFilesystem::new();
+                self.filesystems
+                    .insert(Name::new((&**name).to_owned()), uuid, new_filesystem);
+                result.push((*name, uuid));
             }
         }
 
-        let mut result = Vec::new();
-        for name in names.keys() {
-            let uuid = Uuid::new_v4();
-            let new_filesystem = SimFilesystem::new();
-            self.filesystems
-                .insert(Name::new((&**name).to_owned()), uuid, new_filesystem);
-            result.push((*name, uuid));
-        }
-
-        Ok(result)
+        Ok(SetCreateAction::new(result))
     }
 
     fn add_blockdevs(
@@ -118,21 +112,31 @@ impl Pool for SimPool {
         _pool_name: &str,
         paths: &[&Path],
         tier: BlockDevTier,
-    ) -> StratisResult<Vec<DevUuid>> {
+    ) -> StratisResult<SetCreateAction<DevUuid>> {
         let devices: HashSet<_, RandomState> = HashSet::from_iter(paths);
+
         let device_pairs: Vec<_> = devices
             .iter()
             .map(|p| SimDev::new(Rc::clone(&self.rdm), p))
             .collect();
-        let ret_uuids = device_pairs.iter().map(|&(uuid, _)| uuid).collect();
 
         let the_vec = match tier {
             BlockDevTier::Cache => &mut self.cache_devs,
             BlockDevTier::Data => &mut self.block_devs,
         };
 
-        the_vec.extend(device_pairs);
-        Ok(ret_uuids)
+        let filter: Vec<_> = the_vec.values().map(|d| d.devnode()).collect();
+        let filtered_device_pairs: Vec<_> = device_pairs
+            .into_iter()
+            .filter(|(_, sd)| !filter.contains(&sd.devnode()))
+            .collect();
+
+        let ret_uuids = filtered_device_pairs
+            .iter()
+            .map(|&(uuid, _)| uuid)
+            .collect();
+        the_vec.extend(filtered_device_pairs);
+        Ok(SetCreateAction::new(ret_uuids))
     }
 
     fn destroy(&mut self) -> StratisResult<()> {
@@ -144,14 +148,14 @@ impl Pool for SimPool {
         &'a mut self,
         _pool_name: &str,
         fs_uuids: &[FilesystemUuid],
-    ) -> StratisResult<Vec<FilesystemUuid>> {
+    ) -> StratisResult<SetDeleteAction<FilesystemUuid>> {
         let mut removed = Vec::new();
         for &uuid in fs_uuids {
             if self.filesystems.remove_by_uuid(uuid).is_some() {
                 removed.push(uuid);
             }
         }
-        Ok(removed)
+        Ok(SetDeleteAction::new(removed))
     }
 
     fn rename_filesystem(
@@ -159,7 +163,7 @@ impl Pool for SimPool {
         _pool_name: &str,
         uuid: FilesystemUuid,
         new_name: &str,
-    ) -> StratisResult<RenameAction> {
+    ) -> StratisResult<RenameAction<FilesystemUuid>> {
         rename_filesystem_pre!(self; uuid; new_name);
 
         let (_, filesystem) = self
@@ -170,7 +174,7 @@ impl Pool for SimPool {
         self.filesystems
             .insert(Name::new(new_name.to_owned()), uuid, filesystem);
 
-        Ok(RenameAction::Renamed)
+        Ok(RenameAction::Renamed(uuid))
     }
 
     fn snapshot_filesystem(
@@ -179,12 +183,9 @@ impl Pool for SimPool {
         _pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<(FilesystemUuid, &mut dyn Filesystem)> {
+    ) -> StratisResult<CreateAction<(FilesystemUuid, &mut dyn Filesystem)>> {
         if self.filesystems.contains_name(snapshot_name) {
-            return Err(StratisError::Engine(
-                ErrorEnum::AlreadyExists,
-                snapshot_name.to_string(),
-            ));
+            return Ok(CreateAction::Identity);
         }
 
         let uuid = Uuid::new_v4();
@@ -199,13 +200,13 @@ impl Pool for SimPool {
         };
         self.filesystems
             .insert(Name::new(snapshot_name.to_owned()), uuid, snapshot);
-        Ok((
+        Ok(CreateAction::Created((
             uuid,
             self.filesystems
                 .get_mut_by_uuid(uuid)
                 .expect("just inserted")
                 .1,
-        ))
+        )))
     }
 
     fn total_physical_size(&self) -> Sectors {
@@ -281,16 +282,17 @@ impl Pool for SimPool {
         _pool_name: &str,
         uuid: DevUuid,
         user_info: Option<&str>,
-    ) -> StratisResult<bool> {
-        self.get_mut_blockdev_internal(uuid).map_or_else(
-            || {
-                Err(StratisError::Engine(
-                    ErrorEnum::NotFound,
-                    format!("No blockdev for uuid {} found", uuid),
-                ))
+    ) -> StratisResult<RenameAction<DevUuid>> {
+        Ok(self.get_mut_blockdev_internal(uuid).map_or_else(
+            || RenameAction::NoSource,
+            |(_, b)| {
+                if b.set_user_info(user_info) {
+                    RenameAction::Renamed(uuid)
+                } else {
+                    RenameAction::Identity
+                }
             },
-            |(_, b)| Ok(b.set_user_info(user_info)),
-        )
+        ))
     }
 
     fn state(&self) -> PoolState {
@@ -325,6 +327,8 @@ mod tests {
 
     use crate::engine::sim_engine::SimEngine;
 
+    use crate::engine::types::EngineAction;
+
     use super::*;
 
     #[test]
@@ -332,7 +336,11 @@ mod tests {
     fn rename_empty() {
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         assert!(
             match pool.rename_filesystem(pool_name, Uuid::new_v4(), "new_name") {
@@ -347,16 +355,21 @@ mod tests {
     fn rename_happens() {
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         let infos = pool
             .create_filesystems(uuid, pool_name, &[("old_name", None)])
+            .unwrap()
+            .changed()
             .unwrap();
-        assert!(
-            match pool.rename_filesystem(pool_name, infos[0].1, "new_name") {
-                Ok(RenameAction::Renamed) => true,
-                _ => false,
-            }
+        assert_matches!(
+            pool.rename_filesystem(pool_name, infos[0].1, "new_name")
+                .unwrap(),
+            RenameAction::Renamed(_)
         );
     }
 
@@ -367,10 +380,16 @@ mod tests {
         let new_name = "new_name";
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         let results = pool
             .create_filesystems(uuid, pool_name, &[(old_name, None), (new_name, None)])
+            .unwrap()
+            .changed()
             .unwrap();
         let old_uuid = results.iter().find(|x| x.0 == old_name).unwrap().1;
         assert!(
@@ -387,7 +406,11 @@ mod tests {
         let new_name = "new_name";
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         assert!(
             match pool.rename_filesystem(pool_name, Uuid::new_v4(), new_name) {
@@ -402,10 +425,14 @@ mod tests {
     fn destroy_fs_empty() {
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         assert!(match pool.destroy_filesystems(pool_name, &[]) {
-            Ok(names) => names.is_empty(),
+            Ok(uuids) => !uuids.is_changed(),
             _ => false,
         });
     }
@@ -415,7 +442,11 @@ mod tests {
     fn destroy_fs_some() {
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         assert_matches!(
             pool.destroy_filesystems(pool_name, &[Uuid::new_v4()]),
@@ -428,18 +459,22 @@ mod tests {
     fn destroy_fs_any() {
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         let fs_results = pool
             .create_filesystems(uuid, pool_name, &[("fs_name", None)])
+            .unwrap()
+            .changed()
             .unwrap();
         let fs_uuid = fs_results[0].1;
-        assert!(
-            match pool.destroy_filesystems(pool_name, &[fs_uuid, Uuid::new_v4()]) {
-                Ok(filesystems) => filesystems == vec![fs_uuid],
-                _ => false,
-            }
-        );
+        assert!(match pool.destroy_filesystems(pool_name, &[fs_uuid]) {
+            Ok(filesystems) => filesystems == SetDeleteAction::new(vec![fs_uuid]),
+            _ => false,
+        });
     }
 
     #[test]
@@ -447,12 +482,14 @@ mod tests {
     fn create_fs_none() {
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
-        assert!(match pool.create_filesystems(uuid, pool_name, &[]) {
-            Ok(names) => names.is_empty(),
-            _ => false,
-        });
+        let fs = pool.create_filesystems(uuid, pool_name, &[]).unwrap();
+        assert!(!fs.is_changed())
     }
 
     #[test]
@@ -460,14 +497,20 @@ mod tests {
     fn create_fs_some() {
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
-        assert!(
-            match pool.create_filesystems(uuid, pool_name, &[("name", None)]) {
-                Ok(names) => (names.len() == 1) & (names[0].0 == "name"),
-                _ => false,
-            }
-        );
+        assert!(match pool
+            .create_filesystems(uuid, pool_name, &[("name", None)])
+            .ok()
+            .and_then(|fs| fs.changed())
+        {
+            Some(names) => (names.len() == 1) & (names[0].0 == "name"),
+            _ => false,
+        });
     }
 
     #[test]
@@ -476,16 +519,18 @@ mod tests {
         let fs_name = "fs_name";
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
         pool.create_filesystems(uuid, pool_name, &[(fs_name, None)])
             .unwrap();
-        assert!(
-            match pool.create_filesystems(uuid, pool_name, &[(fs_name, None)]) {
-                Err(StratisError::Engine(ErrorEnum::AlreadyExists, _)) => true,
-                _ => false,
-            }
-        );
+        let set_create_action = pool
+            .create_filesystems(uuid, pool_name, &[(fs_name, None)])
+            .unwrap();
+        assert!(!set_create_action.is_changed());
     }
 
     #[test]
@@ -494,28 +539,40 @@ mod tests {
         let fs_name = "fs_name";
         let mut engine = SimEngine::default();
         let pool_name = "pool_name";
-        let uuid = engine.create_pool(pool_name, &[], None).unwrap();
+        let uuid = engine
+            .create_pool(pool_name, &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let pool = engine.get_mut_pool(uuid).unwrap().1;
-        assert!(
-            match pool.create_filesystems(uuid, pool_name, &[(fs_name, None), (fs_name, None)]) {
-                Ok(names) => (names.len() == 1) & (names[0].0 == fs_name),
-                _ => false,
-            }
-        );
+        assert!(match pool
+            .create_filesystems(uuid, pool_name, &[(fs_name, None), (fs_name, None)])
+            .ok()
+            .and_then(|fs| fs.changed())
+        {
+            Some(names) => (names.len() == 1) & (names[0].0 == fs_name),
+            _ => false,
+        });
     }
 
     #[test]
     /// Adding a list of devices to an empty pool should yield list.
     fn add_device_empty() {
         let mut engine = SimEngine::default();
-        let uuid = engine.create_pool("pool_name", &[], None).unwrap();
+        let uuid = engine
+            .create_pool("pool_name", &[], None)
+            .unwrap()
+            .changed()
+            .unwrap();
         let (pool_name, pool) = engine.get_mut_pool(uuid).unwrap();
         let devices = [Path::new("/s/a"), Path::new("/s/b")];
-        assert!(
-            match pool.add_blockdevs(uuid, &*pool_name, &devices, BlockDevTier::Data) {
-                Ok(devs) => devs.len() == devices.len(),
-                _ => false,
-            }
-        );
+        assert!(match pool
+            .add_blockdevs(uuid, &*pool_name, &devices, BlockDevTier::Data)
+            .ok()
+            .and_then(|c| c.changed())
+        {
+            Some(devs) => devs.len() == devices.len(),
+            _ => false,
+        });
     }
 }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -26,7 +26,8 @@ use crate::{
             pool::{check_metadata, StratPool},
         },
         structures::Table,
-        Engine, EngineEvent, Name, Pool, PoolUuid, Redundancy, RenameAction,
+        types::{CreateAction, DeleteAction, RenameAction},
+        Engine, EngineEvent, Name, Pool, PoolUuid, Redundancy,
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
@@ -174,21 +175,22 @@ impl Engine for StratEngine {
         name: &str,
         blockdev_paths: &[&Path],
         redundancy: Option<u16>,
-    ) -> StratisResult<PoolUuid> {
+    ) -> StratisResult<CreateAction<PoolUuid>> {
         let redundancy = calculate_redundancy!(redundancy);
 
         validate_name(name)?;
 
-        if self.pools.contains_name(name) {
-            return Err(StratisError::Engine(ErrorEnum::AlreadyExists, name.into()));
+        match self.pools.get_by_name(name) {
+            None => {
+                let (uuid, pool) = StratPool::initialize(name, blockdev_paths, redundancy)?;
+
+                let name = Name::new(name.to_owned());
+                devlinks::pool_added(&name);
+                self.pools.insert(name, uuid, pool);
+                Ok(CreateAction::Created(uuid))
+            }
+            Some(_) => Ok(CreateAction::Identity),
         }
-
-        let (uuid, pool) = StratPool::initialize(name, blockdev_paths, redundancy)?;
-
-        let name = Name::new(name.to_owned());
-        devlinks::pool_added(&name);
-        self.pools.insert(name, uuid, pool);
-        Ok(uuid)
     }
 
     /// Evaluate a device node & devicemapper::Device to see if it's a valid
@@ -266,7 +268,7 @@ impl Engine for StratEngine {
         Ok(pool_uuid)
     }
 
-    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<bool> {
+    fn destroy_pool(&mut self, uuid: PoolUuid) -> StratisResult<DeleteAction<PoolUuid>> {
         if let Some((_, pool)) = self.pools.get_by_uuid(uuid) {
             if pool.has_filesystems() {
                 return Err(StratisError::Engine(
@@ -275,7 +277,7 @@ impl Engine for StratEngine {
                 ));
             };
         } else {
-            return Ok(false);
+            return Ok(DeleteAction::Identity);
         }
 
         let (pool_name, mut pool) = self
@@ -288,11 +290,15 @@ impl Engine for StratEngine {
             Err(err)
         } else {
             devlinks::pool_removed(&pool_name);
-            Ok(true)
+            Ok(DeleteAction::Deleted(uuid))
         }
     }
 
-    fn rename_pool(&mut self, uuid: PoolUuid, new_name: &str) -> StratisResult<RenameAction> {
+    fn rename_pool(
+        &mut self,
+        uuid: PoolUuid,
+        new_name: &str,
+    ) -> StratisResult<RenameAction<PoolUuid>> {
         validate_name(new_name)?;
         let old_name = rename_pool_pre!(self; uuid; new_name);
 
@@ -314,7 +320,7 @@ impl Engine for StratEngine {
 
             self.pools.insert(new_name.clone(), uuid, pool);
             devlinks::pool_renamed(&old_name, &new_name);
-            Ok(RenameAction::Renamed)
+            Ok(RenameAction::Renamed(uuid))
         }
     }
 
@@ -382,6 +388,8 @@ mod test {
 
     use crate::engine::strat_engine::tests::{loopbacked, real};
 
+    use crate::engine::types::EngineAction;
+
     use super::*;
 
     /// Verify that a pool rename causes the pool metadata to get the new name.
@@ -389,12 +397,16 @@ mod test {
         let mut engine = StratEngine::initialize().unwrap();
 
         let name1 = "name1";
-        let uuid1 = engine.create_pool(&name1, paths, None).unwrap();
+        let uuid1 = engine
+            .create_pool(&name1, paths, None)
+            .unwrap()
+            .changed()
+            .unwrap();
 
         let name2 = "name2";
         let action = engine.rename_pool(uuid1, name2).unwrap();
 
-        assert_eq!(action, RenameAction::Renamed);
+        assert_eq!(action, RenameAction::Renamed(uuid1));
         engine.teardown().unwrap();
 
         let engine = StratEngine::initialize().unwrap();
@@ -435,10 +447,18 @@ mod test {
         let mut engine = StratEngine::initialize().unwrap();
 
         let name1 = "name1";
-        let uuid1 = engine.create_pool(&name1, paths1, None).unwrap();
+        let uuid1 = engine
+            .create_pool(&name1, paths1, None)
+            .unwrap()
+            .changed()
+            .unwrap();
 
         let name2 = "name2";
-        let uuid2 = engine.create_pool(&name2, paths2, None).unwrap();
+        let uuid2 = engine
+            .create_pool(&name2, paths2, None)
+            .unwrap()
+            .changed()
+            .unwrap();
 
         assert!(engine.get_pool(uuid1).is_some());
         assert!(engine.get_pool(uuid2).is_some());

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -25,8 +25,9 @@ use crate::{
             thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE},
         },
         types::{
-            BlockDevTier, DevUuid, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name,
-            PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction,
+            BlockDevTier, CreateAction, DevUuid, EngineAction, FilesystemUuid, FreeSpaceState,
+            MaybeDbusPath, Name, PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction,
+            SetCreateAction, SetDeleteAction,
         },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
@@ -283,28 +284,25 @@ impl Pool for StratPool {
         pool_uuid: PoolUuid,
         pool_name: &str,
         specs: &[(&'b str, Option<Sectors>)],
-    ) -> StratisResult<Vec<(&'b str, FilesystemUuid)>> {
+    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>> {
         let names: HashMap<_, _> = HashMap::from_iter(specs.iter().map(|&tup| (tup.0, tup.1)));
-        for name in names.keys() {
-            validate_name(name)?;
-            if self.thin_pool.get_mut_filesystem_by_name(*name).is_some() {
-                return Err(StratisError::Engine(
-                    ErrorEnum::AlreadyExists,
-                    name.to_string(),
-                ));
-            }
-        }
+
+        names.iter().fold(Ok(()), |res, (name, _)| {
+            res.and_then(|()| validate_name(name))
+        })?;
 
         // TODO: Roll back on filesystem initialization failure.
         let mut result = Vec::new();
         for (name, size) in names {
-            let fs_uuid = self
-                .thin_pool
-                .create_filesystem(pool_uuid, pool_name, name, size)?;
-            result.push((name, fs_uuid));
+            if self.thin_pool.get_mut_filesystem_by_name(name).is_none() {
+                let fs_uuid = self
+                    .thin_pool
+                    .create_filesystem(pool_uuid, pool_name, name, size)?;
+                result.push((name, fs_uuid));
+            }
         }
 
-        Ok(result)
+        Ok(SetCreateAction::new(result))
     }
 
     fn add_blockdevs(
@@ -313,7 +311,7 @@ impl Pool for StratPool {
         pool_name: &str,
         paths: &[&Path],
         tier: BlockDevTier,
-    ) -> StratisResult<Vec<DevUuid>> {
+    ) -> StratisResult<SetCreateAction<DevUuid>> {
         let bdev_info = if tier == BlockDevTier::Cache {
             // If adding cache devices, must suspend the pool, since the cache
             // must be augmeneted with the new devices.
@@ -321,7 +319,7 @@ impl Pool for StratPool {
             let bdev_info = self.backstore.add_cachedevs(pool_uuid, paths)?;
             self.thin_pool.set_device(self.backstore.device().expect("Since thin pool exists, space must have been allocated from the backstore, so backstore must have a cap device"))?;
             self.thin_pool.resume()?;
-            Ok(bdev_info)
+            Ok(SetCreateAction::new(bdev_info))
         } else {
             // If just adding data devices, no need to suspend the pool.
             // No action will be taken on the DM devices.
@@ -334,7 +332,7 @@ impl Pool for StratPool {
             // so that it can satisfy the allocation request where
             // previously it could not. Run check() in case that is true.
             self.thin_pool.check(pool_uuid, &mut self.backstore)?;
-            Ok(bdev_info)
+            Ok(SetCreateAction::new(bdev_info))
         };
         self.write_metadata(pool_name)?;
         bdev_info
@@ -350,14 +348,16 @@ impl Pool for StratPool {
         &'a mut self,
         pool_name: &str,
         fs_uuids: &[FilesystemUuid],
-    ) -> StratisResult<Vec<FilesystemUuid>> {
+    ) -> StratisResult<SetDeleteAction<FilesystemUuid>> {
         let mut removed = Vec::new();
         for &uuid in fs_uuids {
-            self.thin_pool.destroy_filesystem(pool_name, uuid)?;
-            removed.push(uuid);
+            let changed = self.thin_pool.destroy_filesystem(pool_name, uuid)?;
+            if changed.is_changed() {
+                removed.push(uuid);
+            }
         }
 
-        Ok(removed)
+        Ok(SetDeleteAction::new(removed))
     }
 
     fn rename_filesystem(
@@ -365,7 +365,7 @@ impl Pool for StratPool {
         pool_name: &str,
         uuid: FilesystemUuid,
         new_name: &str,
-    ) -> StratisResult<RenameAction> {
+    ) -> StratisResult<RenameAction<FilesystemUuid>> {
         validate_name(new_name)?;
         self.thin_pool.rename_filesystem(pool_name, uuid, new_name)
     }
@@ -376,7 +376,7 @@ impl Pool for StratPool {
         pool_name: &str,
         origin_uuid: FilesystemUuid,
         snapshot_name: &str,
-    ) -> StratisResult<(FilesystemUuid, &mut dyn Filesystem)> {
+    ) -> StratisResult<CreateAction<(FilesystemUuid, &mut dyn Filesystem)>> {
         validate_name(snapshot_name)?;
 
         if self
@@ -384,14 +384,12 @@ impl Pool for StratPool {
             .get_filesystem_by_name(snapshot_name)
             .is_some()
         {
-            return Err(StratisError::Engine(
-                ErrorEnum::AlreadyExists,
-                snapshot_name.to_string(),
-            ));
+            return Ok(CreateAction::Identity);
         }
 
         self.thin_pool
             .snapshot_filesystem(pool_uuid, pool_name, origin_uuid, snapshot_name)
+            .map(CreateAction::Created)
     }
 
     fn total_physical_size(&self) -> Sectors {
@@ -456,13 +454,12 @@ impl Pool for StratPool {
         pool_name: &str,
         uuid: DevUuid,
         user_info: Option<&str>,
-    ) -> StratisResult<bool> {
-        if self.backstore.set_blockdev_user_info(uuid, user_info)? {
+    ) -> StratisResult<RenameAction<DevUuid>> {
+        let result = self.backstore.set_blockdev_user_info(uuid, user_info);
+        if let RenameAction::Renamed(_) = result {
             self.write_metadata(pool_name)?;
-            Ok(true)
-        } else {
-            Ok(false)
         }
+        Ok(result)
     }
 
     fn state(&self) -> PoolState {
@@ -506,7 +503,7 @@ mod tests {
             cmd,
             tests::{loopbacked, real},
         },
-        types::Redundancy,
+        types::{EngineAction, Redundancy},
     };
 
     use super::*;
@@ -620,7 +617,8 @@ mod tests {
         let (_, fs_uuid) = pool
             .create_filesystems(uuid, &name, &[("stratis-filesystem", None)])
             .unwrap()
-            .pop()
+            .changed()
+            .and_then(|mut fs| fs.pop())
             .unwrap();
         invariant(&pool, &name);
 
@@ -735,7 +733,8 @@ mod tests {
         let (_, fs_uuid) = pool
             .create_filesystems(pool_uuid, &name, &[(&fs_name, None)])
             .unwrap()
-            .pop()
+            .changed()
+            .and_then(|mut fs| fs.pop())
             .expect("just created one");
 
         let devnode = pool.get_filesystem(fs_uuid).unwrap().1.devnode();

--- a/src/engine/types/actions.rs
+++ b/src/engine/types/actions.rs
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Contains types which encode the results of actions requested on an engine,
+//! pool, filesystem, or blockdev. Each action type is designed to support
+//! idempotency. In every case, the action type is used to indicate the
+//! effect of the action at the time the action is requested. The action was
+//! completed succesfully; this type indicates what changes had to be made.
+
+/// A trait for a generic kind of action. Defines the type of the thing to
+/// be changed, and also a method to indicate what changed.
+pub trait EngineAction {
+    type Return;
+
+    /// Returns whether or not the action changed state.
+    fn is_changed(&self) -> bool;
+
+    /// Returns the thing or things changed.
+    fn changed(self) -> Option<Self::Return>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// A single create action.
+pub enum CreateAction<T> {
+    /// The thing already existed.
+    Identity,
+    /// The thing did not already exist.
+    Created(T),
+}
+
+impl<T> EngineAction for CreateAction<T> {
+    type Return = T;
+
+    fn is_changed(&self) -> bool {
+        match *self {
+            CreateAction::Identity => false,
+            _ => true,
+        }
+    }
+
+    fn changed(self) -> Option<T> {
+        match self {
+            CreateAction::Created(t) => Some(t),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// An action which may create multiple things.
+pub struct SetCreateAction<T> {
+    changed: Vec<T>,
+}
+
+impl<T> SetCreateAction<T> {
+    pub fn new(changed: Vec<T>) -> Self {
+        SetCreateAction { changed }
+    }
+}
+
+impl<T> EngineAction for SetCreateAction<T> {
+    type Return = Vec<T>;
+
+    fn is_changed(&self) -> bool {
+        !self.changed.is_empty()
+    }
+
+    fn changed(self) -> Option<Vec<T>> {
+        if self.changed.is_empty() {
+            None
+        } else {
+            Some(self.changed)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// An action which may rename a single thing.
+pub enum RenameAction<T> {
+    /// The thing already had the given name.
+    Identity,
+    /// The thing did not have the given name and was renamed.
+    Renamed(T),
+    /// The thing did not exist, so could not be renamed.
+    NoSource,
+}
+
+impl<T> EngineAction for RenameAction<T> {
+    type Return = T;
+
+    fn is_changed(&self) -> bool {
+        match *self {
+            RenameAction::Renamed(_) => true,
+            _ => false,
+        }
+    }
+
+    fn changed(self) -> Option<T> {
+        match self {
+            RenameAction::Renamed(t) => Some(t),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// A single delete action.
+pub enum DeleteAction<T> {
+    /// The thing was already gone.
+    Identity,
+    /// The thing existed and was removed.
+    Deleted(T),
+}
+
+impl<T> EngineAction for DeleteAction<T> {
+    type Return = T;
+
+    fn is_changed(&self) -> bool {
+        match *self {
+            DeleteAction::Deleted(_) => true,
+            _ => false,
+        }
+    }
+
+    fn changed(self) -> Option<T> {
+        match self {
+            DeleteAction::Deleted(t) => Some(t),
+            _ => None,
+        }
+    }
+}
+
+/// An action which may delete multiple things.
+pub type SetDeleteAction<T> = SetCreateAction<T>;

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -4,6 +4,11 @@
 
 use std::{borrow::Borrow, fmt, ops::Deref, rc::Rc};
 
+mod actions;
+pub use crate::engine::types::actions::{
+    CreateAction, DeleteAction, EngineAction, RenameAction, SetCreateAction, SetDeleteAction,
+};
+
 #[cfg(feature = "dbus_enabled")]
 use dbus;
 use uuid::Uuid;
@@ -11,13 +16,6 @@ use uuid::Uuid;
 pub type DevUuid = Uuid;
 pub type FilesystemUuid = Uuid;
 pub type PoolUuid = Uuid;
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum RenameAction {
-    Identity,
-    NoSource,
-    Renamed,
-}
 
 /// A DM pool operates in 4 modes.  See drivers/md/dm-thin.c (enum pool_mode).
 /// The 4 modes map to Running, OutOfDataSpace, ReadOnly and Failed - in degrading

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -34,13 +34,13 @@ SPECS = {
 <arg name="name" type="s" direction="in"/>
 <arg name="redundancy" type="(bq)" direction="in"/>
 <arg name="devices" type="as" direction="in"/>
-<arg name="result" type="(oao)" direction="out"/>
+<arg name="result" type="(b(oao))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="DestroyPool">
 <arg name="pool" type="o" direction="in"/>
-<arg name="action" type="b" direction="out"/>
+<arg name="result" type="(bs)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
@@ -53,38 +53,38 @@ SPECS = {
 <interface name="org.storage.stratis1.pool">
 <method name="AddCacheDevs">
 <arg name="devices" type="as" direction="in"/>
-<arg name="results" type="ao" direction="out"/>
+<arg name="results" type="(bao)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="AddDataDevs">
 <arg name="devices" type="as" direction="in"/>
-<arg name="results" type="ao" direction="out"/>
+<arg name="results" type="(bao)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="CreateFilesystems">
 <arg name="specs" type="as" direction="in"/>
-<arg name="filesystems" type="a(os)" direction="out"/>
+<arg name="results" type="(ba(os))" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="DestroyFilesystems">
 <arg name="filesystems" type="ao" direction="in"/>
-<arg name="results" type="as" direction="out"/>
+<arg name="results" type="(bas)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="SetName">
 <arg name="name" type="s" direction="in"/>
-<arg name="action" type="b" direction="out"/>
+<arg name="result" type="(bbs)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="SnapshotFilesystem">
 <arg name="origin" type="o" direction="in"/>
 <arg name="snapshot_name" type="s" direction="in"/>
-<arg name="result" type="o" direction="out"/>
+<arg name="result" type="(bo)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>

--- a/tests/client-dbus/tests/dbus/filesystem/test_properties.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_properties.py
@@ -42,7 +42,7 @@ class SetNameTestCase(SimTestCase):
         super().setUp()
         self._fs_name = "fs"
         self._proxy = get_object(TOP_OBJECT)
-        ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (self._pool_object_path, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,
@@ -51,7 +51,7 @@ class SetNameTestCase(SimTestCase):
             },
         )
         self._pool_object = get_object(self._pool_object_path)
-        (created, _, _) = Pool.Methods.CreateFilesystems(
+        ((_, created), _, _) = Pool.Methods.CreateFilesystems(
             self._pool_object, {"specs": [self._fs_name]}
         )
         self._filesystem_object_path = created[0][0]

--- a/tests/client-dbus/tests/dbus/filesystem/test_rename.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_rename.py
@@ -45,7 +45,7 @@ class SetNameTestCase(SimTestCase):
         super().setUp()
         self._fs_name = "fs"
         self._proxy = get_object(TOP_OBJECT)
-        ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (self._pool_object_path, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,
@@ -54,7 +54,7 @@ class SetNameTestCase(SimTestCase):
             },
         )
         self._pool_object = get_object(self._pool_object_path)
-        (created, _, _) = Pool.Methods.CreateFilesystems(
+        ((_, created), _, _) = Pool.Methods.CreateFilesystems(
             self._pool_object, {"specs": [self._fs_name]}
         )
         self._filesystem_object_path = created[0][0]
@@ -65,12 +65,13 @@ class SetNameTestCase(SimTestCase):
         Test rename to same name.
         """
         filesystem = get_object(self._filesystem_object_path)
-        (result, rc, _) = Filesystem.Methods.SetName(
+        ((is_some, result), rc, _) = Filesystem.Methods.SetName(
             filesystem, {"name": self._fs_name}
         )
 
         self.assertEqual(rc, StratisdErrors.OK)
-        self.assertFalse(result)
+        self.assertFalse(is_some)
+        self.assertEqual(result, "0" * 32)
 
     def testNewName(self):
         """

--- a/tests/client-dbus/tests/dbus/manager/test_create.py
+++ b/tests/client-dbus/tests/dbus/manager/test_create.py
@@ -52,7 +52,7 @@ class Create2TestCase(SimTestCase):
         If rc is OK, then pool must exist.
         """
         devs = _DEVICE_STRATEGY()
-        ((poolpath, devnodes), rc, _) = Manager.Methods.CreatePool(
+        ((_, (poolpath, devnodes)), rc, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": devs},
         )
@@ -121,7 +121,7 @@ class Create3TestCase(SimTestCase):
             ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         )
 
-        (_, rc, _) = Manager.Methods.CreatePool(
+        ((is_some, _), rc, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,
@@ -129,8 +129,8 @@ class Create3TestCase(SimTestCase):
                 "devices": _DEVICE_STRATEGY(),
             },
         )
-        expected_rc = StratisdErrors.ALREADY_EXISTS
-        self.assertEqual(rc, expected_rc)
+        self.assertEqual(rc, StratisdErrors.OK)
+        self.assertFalse(is_some)
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         pools2 = list(pools().search(managed_objects))

--- a/tests/client-dbus/tests/dbus/manager/test_destroy.py
+++ b/tests/client-dbus/tests/dbus/manager/test_destroy.py
@@ -127,7 +127,7 @@ class Destroy3TestCase(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (poolpath, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,
@@ -145,9 +145,9 @@ class Destroy3TestCase(SimTestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         (pool, _) = next(pools(props={"Name": self._POOLNAME}).search(managed_objects))
 
-        (result, rc, _) = Manager.Methods.DestroyPool(self._proxy, {"pool": pool})
+        ((is_some, _), rc, _) = Manager.Methods.DestroyPool(self._proxy, {"pool": pool})
         self.assertEqual(rc, StratisdErrors.BUSY)
-        self.assertEqual(result, False)
+        self.assertFalse(is_some)
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         (pool1, _) = next(pools(props={"Name": self._POOLNAME}).search(managed_objects))
@@ -181,10 +181,10 @@ class Destroy4TestCase(SimTestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         (pool, _) = next(pools(props={"Name": self._POOLNAME}).search(managed_objects))
 
-        (result, rc, _) = Manager.Methods.DestroyPool(self._proxy, {"pool": pool})
+        ((is_some, _), rc, _) = Manager.Methods.DestroyPool(self._proxy, {"pool": pool})
 
         self.assertEqual(rc, StratisdErrors.OK)
-        self.assertEqual(result, True)
+        self.assertTrue(is_some)
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         self.assertIsNone(

--- a/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_cache_devs.py
@@ -44,7 +44,7 @@ class AddCacheDevsTestCase1(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (poolpath, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": []},
         )
@@ -58,8 +58,11 @@ class AddCacheDevsTestCase1(SimTestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         (pool, _) = next(pools(props={"Name": self._POOLNAME}).search(managed_objects))
 
-        (result, rc, _) = Pool.Methods.AddCacheDevs(self._pool_object, {"devices": []})
+        ((is_some, result), rc, _) = Pool.Methods.AddCacheDevs(
+            self._pool_object, {"devices": []}
+        )
 
+        self.assertFalse(is_some)
         self.assertEqual(len(result), 0)
         self.assertEqual(rc, StratisdErrors.OK)
 
@@ -77,7 +80,7 @@ class AddCacheDevsTestCase1(SimTestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         (pool, _) = next(pools(props={"Name": self._POOLNAME}).search(managed_objects))
 
-        (result, rc, _) = Pool.Methods.AddCacheDevs(
+        ((is_some, result), rc, _) = Pool.Methods.AddCacheDevs(
             self._pool_object, {"devices": _DEVICE_STRATEGY()}
         )
 
@@ -85,16 +88,18 @@ class AddCacheDevsTestCase1(SimTestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
 
         if rc == StratisdErrors.OK:
+            self.assertTrue(is_some)
             self.assertGreater(num_devices_added, 0)
         else:
+            self.assertFalse(is_some)
             self.assertEqual(num_devices_added, 0)
 
-        blockdev_object_paths = frozenset(result)
+        blockdev_paths = frozenset(result)
 
         # blockdevs exported on the D-Bus are exactly those added
         blockdevs2 = list(blockdevs(props={"Pool": pool}).search(managed_objects))
-        blockdevs2_object_paths = frozenset([op for (op, _) in blockdevs2])
-        self.assertEqual(blockdevs2_object_paths, blockdev_object_paths)
+        blockdevs2_paths = frozenset([op for (op, _) in blockdevs2])
+        self.assertEqual(blockdevs2_paths, blockdev_paths)
 
         # no duplicates in the object paths
         self.assertEqual(len(blockdevs2), num_devices_added)
@@ -121,7 +126,7 @@ class AddCacheDevsTestCase2(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((poolpath, devpaths), _, _) = Manager.Methods.CreatePool(
+        ((_, (poolpath, devpaths)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,
@@ -145,8 +150,11 @@ class AddCacheDevsTestCase2(SimTestCase):
         blockdevs2 = blockdevs(props={"Pool": pool, "Tier": 1}).search(managed_objects)
         self.assertEqual(list(blockdevs2), [])
 
-        (result, rc, _) = Pool.Methods.AddCacheDevs(self._pool_object, {"devices": []})
+        ((is_some, result), rc, _) = Pool.Methods.AddCacheDevs(
+            self._pool_object, {"devices": []}
+        )
 
+        self.assertFalse(is_some)
         self.assertEqual(len(result), 0)
         self.assertEqual(rc, StratisdErrors.OK)
 
@@ -163,7 +171,7 @@ class AddCacheDevsTestCase2(SimTestCase):
 
         blockdevs1 = blockdevs(props={"Pool": pool, "Tier": 0}).search(managed_objects)
         self.assertEqual(self._devpaths, frozenset(op for (op, _) in blockdevs1))
-        (result, rc, _) = Pool.Methods.AddCacheDevs(
+        ((is_some, result), rc, _) = Pool.Methods.AddCacheDevs(
             self._pool_object, {"devices": _DEVICE_STRATEGY()}
         )
 
@@ -171,8 +179,10 @@ class AddCacheDevsTestCase2(SimTestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
 
         if rc == StratisdErrors.OK:
+            self.assertTrue(is_some)
             self.assertGreater(num_devices_added, 0)
         else:
+            self.assertFalse(is_some)
             self.assertEqual(num_devices_added, 0)
 
         blockdev_object_paths = frozenset(result)

--- a/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
+++ b/tests/client-dbus/tests/dbus/pool/test_add_data_devs.py
@@ -44,7 +44,7 @@ class AddDataDevsTestCase(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (poolpath, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": []},
         )
@@ -61,8 +61,11 @@ class AddDataDevsTestCase(SimTestCase):
         blockdevs1 = blockdevs(props={"Pool": pool}).search(managed_objects)
         self.assertEqual(list(blockdevs1), [])
 
-        (result, rc, _) = Pool.Methods.AddDataDevs(self._pool_object, {"devices": []})
+        ((is_some, result), rc, _) = Pool.Methods.AddDataDevs(
+            self._pool_object, {"devices": []}
+        )
 
+        self.assertFalse(is_some)
         self.assertEqual(result, [])
         self.assertEqual(rc, StratisdErrors.OK)
 
@@ -84,7 +87,7 @@ class AddDataDevsTestCase(SimTestCase):
         blockdevs1 = blockdevs(props={"Pool": pool}).search(managed_objects)
         self.assertEqual(list(blockdevs1), [])
 
-        (result, rc, _) = Pool.Methods.AddDataDevs(
+        ((is_some, result), rc, _) = Pool.Methods.AddDataDevs(
             self._pool_object, {"devices": _DEVICE_STRATEGY()}
         )
 
@@ -92,8 +95,10 @@ class AddDataDevsTestCase(SimTestCase):
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
 
         if rc == StratisdErrors.OK:
+            self.assertTrue(is_some)
             self.assertGreater(num_devices_added, 0)
         else:
+            self.assertFalse(is_some)
             self.assertEqual(num_devices_added, 0)
 
         blockdev_object_paths = frozenset(result)

--- a/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
+++ b/tests/client-dbus/tests/dbus/pool/test_destroy_filesystem.py
@@ -44,7 +44,7 @@ class DestroyFSTestCase(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (poolpath, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )
@@ -57,11 +57,11 @@ class DestroyFSTestCase(SimTestCase):
         list should always succeed, and it should not decrease the
         number of volumes.
         """
-        (result, rc, _) = Pool.Methods.DestroyFilesystems(
+        ((_, result_changed), rc, _) = Pool.Methods.DestroyFilesystems(
             self._pool_object, {"filesystems": []}
         )
 
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result_changed), 0)
         self.assertEqual(rc, StratisdErrors.OK)
 
         result = filesystems().search(
@@ -74,11 +74,11 @@ class DestroyFSTestCase(SimTestCase):
         Test calling with a non-existant object path. This should succeed,
         because at the end the filesystem is not there.
         """
-        (result, rc, _) = Pool.Methods.DestroyFilesystems(
+        ((_, result), rc, _) = Pool.Methods.DestroyFilesystems(
             self._pool_object, {"filesystems": ["/"]}
         )
-        self.assertEqual(rc, StratisdErrors.OK)
         self.assertEqual(len(result), 0)
+        self.assertEqual(rc, StratisdErrors.OK)
 
         result = filesystems().search(
             ObjectManager.Methods.GetManagedObjects(self._proxy, {})
@@ -101,12 +101,12 @@ class DestroyFSTestCase1(SimTestCase):
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
         self._devs = _DEVICE_STRATEGY()
-        ((self._poolpath, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (self._poolpath, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {"name": self._POOLNAME, "redundancy": (True, 0), "devices": self._devs},
         )
         self._pool_object = get_object(self._poolpath)
-        (self._filesystems, _, _) = Pool.Methods.CreateFilesystems(
+        ((_, self._filesystems), _, _) = Pool.Methods.CreateFilesystems(
             self._pool_object, {"specs": [(self._VOLNAME, "", None)]}
         )
         Manager.Methods.ConfigureSimulator(self._proxy, {"denominator": 8})
@@ -117,10 +117,11 @@ class DestroyFSTestCase1(SimTestCase):
         should always succeed.
         """
         fs_object_path = self._filesystems[0][0]
-        (result, rc, _) = Pool.Methods.DestroyFilesystems(
+        ((is_some, result), rc, _) = Pool.Methods.DestroyFilesystems(
             self._pool_object, {"filesystems": [fs_object_path]}
         )
 
+        self.assertTrue(is_some)
         self.assertEqual(len(result), 1)
         self.assertEqual(rc, StratisdErrors.OK)
 
@@ -136,10 +137,11 @@ class DestroyFSTestCase1(SimTestCase):
         returned.
         """
         fs_object_path = self._filesystems[0][0]
-        (result, rc, _) = Pool.Methods.DestroyFilesystems(
+        ((is_some, result), rc, _) = Pool.Methods.DestroyFilesystems(
             self._pool_object, {"filesystems": [fs_object_path, "/"]}
         )
 
+        self.assertTrue(is_some)
         self.assertEqual(len(result), 1)
         self.assertEqual(rc, StratisdErrors.OK)
 

--- a/tests/client-dbus/tests/dbus/pool/test_rename.py
+++ b/tests/client-dbus/tests/dbus/pool/test_rename.py
@@ -43,7 +43,7 @@ class SetNameTestCase(SimTestCase):
         """
         super().setUp()
         self._proxy = get_object(TOP_OBJECT)
-        ((self._pool_object_path, _), _, _) = Manager.Methods.CreatePool(
+        ((_, (self._pool_object_path, _)), _, _) = Manager.Methods.CreatePool(
             self._proxy,
             {
                 "name": self._POOLNAME,
@@ -58,12 +58,12 @@ class SetNameTestCase(SimTestCase):
         """
         Test rename to same name.
         """
-        (result, rc, _) = Pool.Methods.SetName(
+        ((is_some, _), rc, _) = Pool.Methods.SetName(
             self._pool_object, {"name": self._POOLNAME}
         )
 
         self.assertEqual(rc, StratisdErrors.OK)
-        self.assertFalse(result)
+        self.assertFalse(is_some)
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})
         result = next(
@@ -79,9 +79,11 @@ class SetNameTestCase(SimTestCase):
         """
         new_name = "new"
 
-        (result, rc, _) = Pool.Methods.SetName(self._pool_object, {"name": new_name})
+        ((is_some, _), rc, _) = Pool.Methods.SetName(
+            self._pool_object, {"name": new_name}
+        )
 
-        self.assertTrue(result)
+        self.assertTrue(is_some)
         self.assertEqual(rc, StratisdErrors.OK)
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(self._proxy, {})

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -69,7 +69,11 @@ class UdevAdd(unittest.TestCase):
         # actually exist, retry on error.
         error_reasons = ""
         for _ in range(3):
-            ((pool_object_path, _), exit_code, error_str) = Manager.Methods.CreatePool(
+            (
+                (_, (pool_object_path, _)),
+                exit_code,
+                error_str,
+            ) = Manager.Methods.CreatePool(
                 get_object(TOP_OBJECT),
                 {"name": name, "redundancy": (True, 0), "devices": devices},
             )


### PR DESCRIPTION
This PR is a continuation of #1597 which was closed as Github was not updating the branch and kicking off CI for new commits.

The current state of this PR is:
* non-rust tests still need to be fixed
* Engine API is idempotent and returns changed resources or set of changed resources, filtering out no-ops in the return value
* DBus API uses object paths for identifying resources that exist in DBus and resolves them to UUIDs or names for the engine calls - it is also idempotent and follows the same convention of returning only changed resources
* There is a new set of types and a trait `EngineActions` to provide the return types of the idempotent engine API