### PR TITLE
Increase lowest supported rust toolchain to 1.36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ matrix:
 
         # MANDATORY TESTING USING LOWEST SUPPORTED COMPILER
         # tests
-        - rust: 1.35.0
+        - rust: 1.36.0
           env: TASK=test
         # release
-        - rust: 1.35.0
+        - rust: 1.36.0
           env: TASK=release
 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ versions of the compiler may disagree with the CI tasks on some points,
 so should be avoided.
 
 #### Building
-Stratisd requires Rust 1.35+ and Cargo to build. These may be available via
+Stratisd requires Rust 1.36+ and Cargo to build. These may be available via
 your distribution's package manager. If not, [Rustup](https://www.rustup.rs/)
 is available to install and update the Rust toolchain.
 Once toolchain and other dependencies are in place, run `make build` to build, and then run the


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/73.