### PR TITLE
Fix deprecated ONCE_INIT usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -277,7 +277,7 @@ dependencies = [
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "libmount 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "libudev 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -394,7 +394,7 @@ dependencies = [
  "bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -757,7 +757,7 @@ dependencies = [
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
 "checksum libdbus-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "18cb88963258d00f4962205dbb5933d82780d9962c8c8a064b651d2ad7189210"
 "checksum libmount 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "fb5543ddc79983a086a52c23a857bd7d9965be2c25a779e0dbc0739b0871e0c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ env_logger="0.5"
 libc = "0.2.47"
 libmount = "0.1.13"
 libudev = "0.2.0"
-lazy_static = "1.0.0"
+lazy_static = "1.4.0"
 timerfd = "1.0.0"
 
 [dependencies.uuid]

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -2,16 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{
-    fmt::Debug,
-    sync::{Once, ONCE_INIT},
-};
+use std::{fmt::Debug, sync::Once};
 
 use crate::engine::types::{
     BlockDevState, FreeSpaceState, MaybeDbusPath, PoolExtendState, PoolState,
 };
 
-static INIT: Once = ONCE_INIT;
+static INIT: Once = Once::new();
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;
 
 #[derive(Debug, Clone)]

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -74,11 +74,11 @@ impl SimPool {
         let cache_devs = &mut self.cache_devs;
         self.block_devs
             .get_mut(&uuid)
-            .and_then(|bd| Some((BlockDevTier::Data, bd)))
+            .map(|bd| (BlockDevTier::Data, bd))
             .or_else(move || {
                 cache_devs
                     .get_mut(&uuid)
-                    .and_then(|bd| Some((BlockDevTier::Cache, bd)))
+                    .map(|bd| (BlockDevTier::Cache, bd))
             })
     }
 }
@@ -263,11 +263,11 @@ impl Pool for SimPool {
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &dyn BlockDev)> {
         self.block_devs
             .get(&uuid)
-            .and_then(|bd| Some((BlockDevTier::Data, bd as &dyn BlockDev)))
+            .map(|bd| (BlockDevTier::Data, bd as &dyn BlockDev))
             .or_else(move || {
                 self.cache_devs
                     .get(&uuid)
-                    .and_then(|bd| Some((BlockDevTier::Cache, bd as &dyn BlockDev)))
+                    .map(|bd| (BlockDevTier::Cache, bd as &dyn BlockDev))
             })
     }
 

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -200,7 +200,7 @@ impl CacheTier {
     pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<(BlockDevTier, &StratBlockDev)> {
         self.block_mgr
             .get_blockdev_by_uuid(uuid)
-            .and_then(|bd| Some((BlockDevTier::Cache, bd)))
+            .map(|bd| (BlockDevTier::Cache, bd))
     }
 
     /// Lookup a mutable blockdev by its Stratis UUID.
@@ -210,7 +210,7 @@ impl CacheTier {
     ) -> Option<(BlockDevTier, &mut StratBlockDev)> {
         self.block_mgr
             .get_mut_blockdev_by_uuid(uuid)
-            .and_then(|bd| Some((BlockDevTier::Cache, bd)))
+            .map(|bd| (BlockDevTier::Cache, bd))
     }
 }
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -130,7 +130,7 @@ impl DataTier {
     pub fn get_blockdev_by_uuid(&self, uuid: DevUuid) -> Option<(BlockDevTier, &StratBlockDev)> {
         self.block_mgr
             .get_blockdev_by_uuid(uuid)
-            .and_then(|bd| Some((BlockDevTier::Data, bd)))
+            .map(|bd| (BlockDevTier::Data, bd))
     }
 
     /// Lookup a mutable blockdev by its Stratis UUID.
@@ -140,7 +140,7 @@ impl DataTier {
     ) -> Option<(BlockDevTier, &mut StratBlockDev)> {
         self.block_mgr
             .get_mut_blockdev_by_uuid(uuid)
-            .and_then(|bd| Some((BlockDevTier::Data, bd)))
+            .map(|bd| (BlockDevTier::Data, bd))
     }
 
     /// Get the blockdevs belonging to this tier

--- a/src/engine/strat_engine/backstore/util.rs
+++ b/src/engine/strat_engine/backstore/util.rs
@@ -42,14 +42,14 @@ pub fn get_udev_block_device(
         .scan_devices()?
         .filter(|dev| dev.is_initialized())
         .find(|x| x.devnode().map_or(false, |d| canonical == d))
-        .and_then(|dev| Some(device_as_map(&dev)));
+        .map(|dev| device_as_map(&dev));
     Ok(result)
 }
 
 /// Lookup the WWN from the udev db using the device node eg. /dev/sda
 pub fn hw_lookup(dev_node_search: &Path) -> StratisResult<Option<String>> {
     let dev = get_udev_block_device(dev_node_search)?;
-    Ok(dev.and_then(|dev| dev.get("ID_WWN").and_then(|i| Some(i.clone()))))
+    Ok(dev.and_then(|dev| dev.get("ID_WWN").cloned()))
 }
 
 /// Collect paths for all the block devices which are not individual multipath paths and which

--- a/src/engine/strat_engine/dm.rs
+++ b/src/engine/strat_engine/dm.rs
@@ -6,7 +6,7 @@
 
 use std::{
     os::unix::io::{AsRawFd, RawFd},
-    sync::{Once, ONCE_INIT},
+    sync::Once,
 };
 
 use devicemapper::{DmResult, DM};
@@ -16,7 +16,7 @@ use crate::{
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
 
-static INIT: Once = ONCE_INIT;
+static INIT: Once = Once::new();
 static mut DM_CONTEXT: Option<DmResult<DM>> = None;
 
 pub fn get_dm_init() -> StratisResult<&'static DM> {

--- a/src/engine/strat_engine/tests/logger.rs
+++ b/src/engine/strat_engine/tests/logger.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
-static LOGGER_INIT: Once = ONCE_INIT;
+static LOGGER_INIT: Once = Once::new();
 
 /// Initialize the logger once.  More than one init() attempt returns
 /// errors.


### PR DESCRIPTION
This PR is a little more complicated than the one in `devicemapper-rs` for stratis-storage/project#75. It has a few components.

1. Fix explicit `ONCE_INIT` usage.
2. Fix usage of `ONCE_INIT` in `lazy_static` crate that I tracked down to this issue: rust-lang-nursery/lazy-static.rs#151. It requires updating our version of `lazy_static` to include the deprecation allow that was added.
3. Clippy is throwing errors with `.and_then(Some)` usage as opposed to `.map()` so I've updated the code with all of the requested changes to avoid clippy failures in the future.