### PR TITLE
Change pid file path and improve failure error message

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -11,7 +11,7 @@ use std::{
     cell::RefCell,
     env,
     fs::{File, OpenOptions},
-    io::{ErrorKind, Read, Write},
+    io::{Read, Write},
     os::unix::io::{AsRawFd, RawFd},
     path::PathBuf,
     process::exit,
@@ -113,13 +113,8 @@ fn trylock_pid_file() -> StratisResult<File> {
     {
         Ok(f) => f,
         Err(e) => {
-            if e.kind() == ErrorKind::PermissionDenied {
-                return Err(StratisError::Error(
-                    "Must be running as root in order to start daemon.".to_string(),
-                ));
-            }
             return Err(StratisError::Error(format!(
-                "Failed to create the stratisd PID file at {}: {}",
+                "Failed to create or open the stratisd PID file at {}: {}",
                 STRATISD_PID_PATH, e
             )));
         }

--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -47,7 +47,7 @@ use libstratis::{
     stratis::{buff_log, StratisError, StratisResult, VERSION},
 };
 
-const STRATISD_PID_PATH: &str = "/var/run/stratisd.pid";
+const STRATISD_PID_PATH: &str = "/run/stratisd.pid";
 
 /// Interval at which to have stratisd dump its state
 const DEFAULT_STATE_DUMP_MINUTES: i64 = 10;
@@ -118,7 +118,10 @@ fn trylock_pid_file() -> StratisResult<File> {
                     "Must be running as root in order to start daemon.".to_string(),
                 ));
             }
-            return Err(e.into());
+            return Err(StratisError::Error(format!(
+                "Failed to create the stratisd PID file at {}: {}",
+                STRATISD_PID_PATH, e
+            )));
         }
     };
     match flock(f.as_raw_fd(), FlockArg::LockExclusiveNonblock) {


### PR DESCRIPTION
Closes #1630.

This commit resolves two problems:
1. stratisd uses the legacy symlink `/var/run` for the location of its pid file. This PR moves the pid file path to `/run` which should always be there. This should resolve issues where `/var` is not yet mounted when stratisd starts and similar problems.
2. The error message on failure to create the pid file is more informative and makes it clear why stratisd is failing and where PID file creation was attempted.