### PR TITLE
Fix for unnecessary clone as checked by clippy

### DIFF
--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -181,7 +181,7 @@ fn make_linear_test_dev(devnode: &Path, start: Sectors, length: Sectors) -> Line
         get_dm(),
         DmName::new(&format!("stratis_test_{}", Uuid::new_v4())).expect("valid format"),
         None,
-        table.clone(),
+        table,
     )
     .unwrap()
 }


### PR DESCRIPTION
This will begin to fail soon as nightly already caught this.