### PR TITLE
Fetch some DBus properties through DBus method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +295,7 @@ dependencies = [
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "libmount 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -867,6 +876,7 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ libmount = "0.1.13"
 libudev = "0.2.0"
 lazy_static = "1.4.0"
 timerfd = "1.0.0"
+itertools = "0.8.0"
 
 [dependencies.uuid]
 version = "0.7"

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -2,15 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::collections::HashMap;
+
 use dbus::{
     self,
-    arg::IterAppend,
+    arg::{Array, IterAppend, RefArg, Variant},
     tree::{
         Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+        Tree,
     },
-    Message,
+    Message, Path,
 };
-
+use itertools::Itertools;
 use uuid::Uuid;
 
 use crate::{
@@ -68,18 +71,6 @@ pub fn create_dbus_blockdev<'a>(
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_blockdev_initialization_time);
 
-    let total_physical_size_property = f
-        .property::<&str, _>("TotalPhysicalSize", ())
-        .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
-        .on_get(get_blockdev_physical_size);
-
-    let state_property = f
-        .property::<u16, _>(consts::BLOCKDEV_STATE_PROP, ())
-        .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::True)
-        .on_get(get_blockdev_state);
-
     let pool_property = f
         .property::<&dbus::Path, _>("Pool", ())
         .access(Access::Read)
@@ -98,6 +89,25 @@ pub fn create_dbus_blockdev<'a>(
         .emits_changed(EmitsChangedSignal::False)
         .on_get(get_blockdev_tier);
 
+    let get_all_properties_method = f
+        .method("GetAllProperties", (), get_all_properties)
+        // a{s(bv)}: Dictionary of property names to tuples
+        // In the tuple:
+        // b: Indicates whether the property value fetched was successful
+        // v: If b is true, represents the value for the given property
+        //    If b is false, represents the error returned when fetching the property
+        .out_arg(("results", "a{s(bv)}"));
+
+    let get_properties_method = f
+        .method("GetProperties", (), get_properties)
+        .in_arg(("properties", "as"))
+        // a{s(bv)}: Dictionary of property names to tuples
+        // In the tuple:
+        // b: Indicates whether the property value fetched was successful
+        // v: If b is true, represents the value for the given property
+        //    If b is false, represents the error returned when fetching the property
+        .out_arg(("results", "a{s(bv)}"));
+
     let object_name = make_object_path(dbus_context);
 
     let object_path = f
@@ -109,12 +119,15 @@ pub fn create_dbus_blockdev<'a>(
                 .add_p(devnode_property)
                 .add_p(hardware_info_property)
                 .add_p(initialization_time_property)
-                .add_p(total_physical_size_property)
                 .add_p(pool_property)
-                .add_p(state_property)
                 .add_p(tier_property)
                 .add_p(user_info_property)
                 .add_p(uuid_property),
+        )
+        .add(
+            f.interface(consts::PROPERTY_FETCH_INTERFACE_NAME, ())
+                .add_m(get_all_properties_method)
+                .add_m(get_properties_method),
         );
 
     let path = object_path.get_name().to_owned();
@@ -177,6 +190,91 @@ fn set_user_info(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     Ok(vec![msg])
 }
 
+fn get_properties_shared(
+    m: &MethodInfo<MTFn<TData>, TData>,
+    properties: &mut dyn Iterator<Item = String>,
+) -> MethodResult {
+    let message: &Message = m.msg;
+    let object_path = &m.path;
+
+    let return_message = message.method_return();
+
+    let return_value: HashMap<String, (bool, Variant<Box<dyn RefArg>>)> = properties
+        .unique()
+        .filter_map(|prop| match prop.as_str() {
+            "TotalPhysicalSize" => {
+                let bd_size_result =
+                    blockdev_operation(m.tree, object_path.get_name(), |_, bd| Ok(*bd.size()));
+                let (bd_size_success, bd_size_prop) = match bd_size_result {
+                    Ok(bd_size) => (true, Variant(Box::new(bd_size) as Box<dyn RefArg>)),
+                    Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
+                };
+
+                Some((prop, (bd_size_success, bd_size_prop)))
+            }
+            _ => None,
+        })
+        .collect();
+
+    Ok(vec![return_message.append1(return_value)])
+}
+
+fn get_all_properties(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+    get_properties_shared(
+        m,
+        &mut vec!["TotalPhysicalSize"].into_iter().map(|s| s.to_string()),
+    )
+}
+
+fn get_properties(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+    let message: &Message = m.msg;
+    let mut iter = message.iter_init();
+    let mut properties: Array<String, _> = get_next_arg(&mut iter, 0)?;
+    get_properties_shared(m, &mut properties)
+}
+
+/// Perform an operation on a `BlockDev` object for a given
+/// DBus implicit argument that is a block device
+fn blockdev_operation<F, R>(
+    tree: &Tree<MTFn<TData>, TData>,
+    object_path: &Path<'static>,
+    closure: F,
+) -> Result<R, String>
+where
+    F: Fn(BlockDevTier, &dyn BlockDev) -> Result<R, String>,
+    R: dbus::arg::Append,
+{
+    let dbus_context = tree.get_data();
+
+    let blockdev_path = tree
+        .get(object_path)
+        .expect("tree must contain implicit argument");
+
+    let blockdev_data = blockdev_path
+        .get_data()
+        .as_ref()
+        .ok_or_else(|| format!("no data for object path {}", object_path))?;
+
+    let pool_path = tree
+        .get(&blockdev_data.parent)
+        .ok_or_else(|| format!("no path for parent object path {}", &blockdev_data.parent))?;
+
+    let pool_uuid = pool_path
+        .get_data()
+        .as_ref()
+        .ok_or_else(|| format!("no data for object path {}", object_path))?
+        .uuid;
+
+    let engine = dbus_context.engine.borrow();
+    let (_, pool) = engine
+        .get_pool(pool_uuid)
+        .ok_or_else(|| format!("no pool corresponding to uuid {}", &pool_uuid))?;
+    let (tier, blockdev) = pool
+        .get_blockdev(blockdev_data.uuid)
+        .ok_or_else(|| format!("no blockdev with uuid {}", blockdev_data.uuid))?;
+    closure(tier, blockdev)
+}
+
 /// Get a blockdev property and place it on the D-Bus. The property is
 /// found by means of the getter method which takes a reference to a
 /// blockdev and obtains the property from the blockdev.
@@ -186,43 +284,13 @@ fn get_blockdev_property<F, R>(
     getter: F,
 ) -> Result<(), MethodErr>
 where
-    F: Fn(BlockDevTier, &dyn BlockDev) -> Result<R, MethodErr>,
+    F: Fn(BlockDevTier, &dyn BlockDev) -> Result<R, String>,
     R: dbus::arg::Append,
 {
-    let dbus_context = p.tree.get_data();
-    let object_path = p.path.get_name();
-
-    let blockdev_path = p
-        .tree
-        .get(object_path)
-        .expect("tree must contain implicit argument");
-
-    let blockdev_data = blockdev_path
-        .get_data()
-        .as_ref()
-        .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
-
-    let pool_path = p.tree.get(&blockdev_data.parent).ok_or_else(|| {
-        MethodErr::failed(&format!(
-            "no path for parent object path {}",
-            &blockdev_data.parent
-        ))
-    })?;
-
-    let pool_uuid = pool_path
-        .get_data()
-        .as_ref()
-        .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?
-        .uuid;
-
-    let engine = dbus_context.engine.borrow();
-    let (_, pool) = engine.get_pool(pool_uuid).ok_or_else(|| {
-        MethodErr::failed(&format!("no pool corresponding to uuid {}", &pool_uuid))
-    })?;
-    let (tier, blockdev) = pool.get_blockdev(blockdev_data.uuid).ok_or_else(|| {
-        MethodErr::failed(&format!("no blockdev with uuid {}", blockdev_data.uuid))
-    })?;
-    i.append(getter(tier, blockdev)?);
+    i.append(
+        blockdev_operation(p.tree, p.path.get_name(), getter)
+            .map_err(|ref e| MethodErr::failed(e))?,
+    );
     Ok(())
 }
 
@@ -253,20 +321,6 @@ fn get_blockdev_initialization_time(
     p: &PropInfo<MTFn<TData>, TData>,
 ) -> Result<(), MethodErr> {
     get_blockdev_property(i, p, |_, p| Ok(p.initialization_time().timestamp() as u64))
-}
-
-fn get_blockdev_physical_size(
-    i: &mut IterAppend,
-    p: &PropInfo<MTFn<TData>, TData>,
-) -> Result<(), MethodErr> {
-    get_blockdev_property(i, p, |_, p| Ok(format!("{}", *p.size())))
-}
-
-fn get_blockdev_state(
-    i: &mut IterAppend,
-    p: &PropInfo<MTFn<TData>, TData>,
-) -> Result<(), MethodErr> {
-    get_blockdev_property(i, p, |_, p| Ok(p.state() as u16))
 }
 
 fn get_blockdev_tier(

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -7,15 +7,14 @@ pub const STRATIS_BASE_SERVICE: &str = "org.storage.stratis1";
 
 pub const MANAGER_INTERFACE_NAME: &str = "org.storage.stratis1.Manager";
 
+pub const PROPERTY_FETCH_INTERFACE_NAME: &str = "org.storage.stratis1.FetchProperties";
+
 pub const POOL_INTERFACE_NAME: &str = "org.storage.stratis1.pool";
 pub const POOL_NAME_PROP: &str = "Name";
-pub const POOL_STATE_PROP: &str = "State";
-pub const POOL_EXTEND_STATE_PROP: &str = "ExtendState";
-pub const POOL_SPACE_STATE_PROP: &str = "SpaceState";
+pub const POOL_TOTAL_SIZE_PROP: &str = "TotalPhysicalSize";
 
 pub const FILESYSTEM_INTERFACE_NAME: &str = "org.storage.stratis1.filesystem";
 pub const FILESYSTEM_NAME_PROP: &str = "Name";
 pub const FILESYSTEM_USED_PROP: &str = "Used";
 
 pub const BLOCKDEV_INTERFACE_NAME: &str = "org.storage.stratis1.blockdev";
-pub const BLOCKDEV_STATE_PROP: &str = "State";

--- a/src/dbus_api/event_handler.rs
+++ b/src/dbus_api/event_handler.rs
@@ -25,23 +25,6 @@ impl EventHandler {
 impl EngineListener for EventHandler {
     fn notify(&self, event: &EngineEvent) {
         match *event {
-            EngineEvent::BlockdevStateChanged { dbus_path, state } => {
-                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
-                    prop_changed_dispatch(
-                        &self.dbus_conn.borrow(),
-                        consts::BLOCKDEV_STATE_PROP,
-                        state as u16,
-                        dbus_path,
-                        consts::BLOCKDEV_INTERFACE_NAME,
-                    )
-                    .unwrap_or_else(|()| {
-                        warn!(
-                            "BlockdevStateChanged: {} state: {} failed to send dbus update.",
-                            dbus_path, state as u16,
-                        );
-                    });
-                }
-            }
             EngineEvent::FilesystemRenamed {
                 dbus_path,
                 from,
@@ -63,23 +46,6 @@ impl EngineListener for EventHandler {
                     });
                 }
             }
-            EngineEvent::PoolExtendStateChanged { dbus_path, state } => {
-                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
-                    prop_changed_dispatch(
-                        &self.dbus_conn.borrow(),
-                        consts::POOL_EXTEND_STATE_PROP,
-                        state as u16,
-                        dbus_path,
-                        consts::POOL_INTERFACE_NAME,
-                    )
-                    .unwrap_or_else(|()| {
-                        warn!(
-                            "PoolExtendStateChanged: {} state: {} failed to send dbus update.",
-                            dbus_path, state as u16,
-                        );
-                    });
-                }
-            }
             EngineEvent::PoolRenamed {
                 dbus_path,
                 from,
@@ -97,40 +63,6 @@ impl EngineListener for EventHandler {
                         warn!(
                             "PoolRenamed: {} from: {} to: {} failed to send dbus update.",
                             dbus_path, from, to,
-                        );
-                    });
-                }
-            }
-            EngineEvent::PoolSpaceStateChanged { dbus_path, state } => {
-                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
-                    prop_changed_dispatch(
-                        &self.dbus_conn.borrow(),
-                        consts::POOL_SPACE_STATE_PROP,
-                        state as u16,
-                        dbus_path,
-                        consts::POOL_INTERFACE_NAME,
-                    )
-                    .unwrap_or_else(|()| {
-                        warn!(
-                            "PoolSpaceStateChanged: {} state: {} failed to send dbus update.",
-                            dbus_path, state as u16,
-                        );
-                    });
-                }
-            }
-            EngineEvent::PoolStateChanged { dbus_path, state } => {
-                if let MaybeDbusPath(Some(ref dbus_path)) = *dbus_path {
-                    prop_changed_dispatch(
-                        &self.dbus_conn.borrow(),
-                        consts::POOL_STATE_PROP,
-                        state as u16,
-                        dbus_path,
-                        consts::POOL_INTERFACE_NAME,
-                    )
-                    .unwrap_or_else(|()| {
-                        warn!(
-                            "PoolStateChanged: {} state: {} failed to send dbus update.",
-                            dbus_path, state as u16,
                         );
                     });
                 }

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -2,15 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::collections::HashMap;
+
 use chrono::SecondsFormat;
 use dbus::{
     self,
-    arg::IterAppend,
+    arg::{Array, IterAppend, RefArg, Variant},
     tree::{
         Access, EmitsChangedSignal, Factory, MTFn, MethodErr, MethodInfo, MethodResult, PropInfo,
+        Tree,
     },
-    Message,
+    Message, Path,
 };
+use itertools::Itertools;
 
 use crate::{
     dbus_api::{
@@ -25,6 +29,55 @@ use crate::{
         filesystem_mount_path, Filesystem, FilesystemUuid, MaybeDbusPath, Name, RenameAction,
     },
 };
+
+fn get_properties_shared(
+    m: &MethodInfo<MTFn<TData>, TData>,
+    properties: &mut dyn Iterator<Item = String>,
+) -> MethodResult {
+    let message: &Message = m.msg;
+    let object_path = &m.path;
+
+    let return_message = message.method_return();
+
+    let return_value: HashMap<String, (bool, Variant<Box<dyn RefArg>>)> = properties
+        .unique()
+        .filter_map(|prop| match prop.as_str() {
+            consts::FILESYSTEM_USED_PROP => {
+                let fs_used_result =
+                    filesystem_operation(m.tree, object_path.get_name(), |(_, _, fs)| {
+                        fs.used()
+                            .map(|u| (*u).to_string())
+                            .map_err(|e| e.to_string())
+                    });
+                let (fs_used_success, fs_used_prop) = match fs_used_result {
+                    Ok(fs_used) => (true, Variant(Box::new(fs_used) as Box<dyn RefArg>)),
+                    Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
+                };
+
+                Some((prop, (fs_used_success, fs_used_prop)))
+            }
+            _ => None,
+        })
+        .collect();
+
+    Ok(vec![return_message.append1(return_value)])
+}
+
+fn get_all_properties(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+    get_properties_shared(
+        m,
+        &mut vec![consts::FILESYSTEM_USED_PROP]
+            .into_iter()
+            .map(|s| s.to_string()),
+    )
+}
+
+fn get_properties(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+    let message: &Message = m.msg;
+    let mut iter = message.iter_init();
+    let mut properties: Array<String, _> = get_next_arg(&mut iter, 0)?;
+    get_properties_shared(m, &mut properties)
+}
 
 pub fn create_dbus_filesystem<'a>(
     dbus_context: &DbusContext,
@@ -75,11 +128,24 @@ pub fn create_dbus_filesystem<'a>(
         .emits_changed(EmitsChangedSignal::Const)
         .on_get(get_filesystem_created);
 
-    let used_property = f
-        .property::<&str, _>(consts::FILESYSTEM_USED_PROP, ())
-        .access(Access::Read)
-        .emits_changed(EmitsChangedSignal::False)
-        .on_get(get_filesystem_used);
+    let get_all_properties_method = f
+        .method("GetAllProperties", (), get_all_properties)
+        // a{s(bv)}: Dictionary of property names to tuples
+        // In the tuple:
+        // b: Indicates whether the property value fetched was successful
+        // v: If b is true, represents the value for the given property
+        //    If b is false, represents the error returned when fetching the property
+        .out_arg(("results", "a{s(bv)}"));
+
+    let get_properties_method = f
+        .method("GetProperties", (), get_properties)
+        .in_arg(("properties", "as"))
+        // a{s(bv)}: Dictionary of property names to tuples
+        // In the tuple:
+        // b: Indicates whether the property value fetched was successful
+        // v: If b is true, represents the value for the given property
+        //    If b is false, represents the error returned when fetching the property
+        .out_arg(("results", "a{s(bv)}"));
 
     let object_name = make_object_path(dbus_context);
 
@@ -93,8 +159,12 @@ pub fn create_dbus_filesystem<'a>(
                 .add_p(name_property)
                 .add_p(pool_property)
                 .add_p(uuid_property)
-                .add_p(created_property)
-                .add_p(used_property),
+                .add_p(created_property),
+        )
+        .add(
+            f.interface(consts::PROPERTY_FETCH_INTERFACE_NAME, ())
+                .add_m(get_all_properties_method)
+                .add_m(get_properties_method),
         );
 
     let path = object_path.get_name().to_owned();
@@ -152,6 +222,49 @@ fn rename_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     Ok(vec![msg])
 }
 
+/// Get execute a given closure providing a filesystem object and return
+/// the calculated value
+fn filesystem_operation<F, R>(
+    tree: &Tree<MTFn<TData>, TData>,
+    object_path: &Path<'static>,
+    closure: F,
+) -> Result<R, String>
+where
+    F: Fn((Name, Name, &dyn Filesystem)) -> Result<R, String>,
+    R: dbus::arg::Append,
+{
+    let dbus_context = tree.get_data();
+
+    let filesystem_path = tree
+        .get(object_path)
+        .expect("tree must contain implicit argument");
+
+    let filesystem_data = filesystem_path
+        .get_data()
+        .as_ref()
+        .ok_or_else(|| format!("no data for object path {}", object_path))?;
+
+    let pool_path = tree
+        .get(&filesystem_data.parent)
+        .ok_or_else(|| format!("no path for parent object path {}", &filesystem_data.parent))?;
+
+    let pool_uuid = pool_path
+        .get_data()
+        .as_ref()
+        .ok_or_else(|| format!("no data for object path {}", object_path))?
+        .uuid;
+
+    let engine = dbus_context.engine.borrow();
+    let (pool_name, pool) = engine
+        .get_pool(pool_uuid)
+        .ok_or_else(|| format!("no pool corresponding to uuid {}", &pool_uuid))?;
+    let filesystem_uuid = filesystem_data.uuid;
+    let (fs_name, fs) = pool
+        .get_filesystem(filesystem_uuid)
+        .ok_or_else(|| format!("no name for filesystem with uuid {}", &filesystem_uuid))?;
+    closure((pool_name, fs_name, fs))
+}
+
 /// Get a filesystem property and place it on the D-Bus. The property is
 /// found by means of the getter method which takes a reference to a
 /// Filesystem and obtains the property from the filesystem.
@@ -161,47 +274,13 @@ fn get_filesystem_property<F, R>(
     getter: F,
 ) -> Result<(), MethodErr>
 where
-    F: Fn((Name, Name, &dyn Filesystem)) -> Result<R, MethodErr>,
+    F: Fn((Name, Name, &dyn Filesystem)) -> Result<R, String>,
     R: dbus::arg::Append,
 {
-    let dbus_context = p.tree.get_data();
-    let object_path = p.path.get_name();
-
-    let filesystem_path = p
-        .tree
-        .get(object_path)
-        .expect("tree must contain implicit argument");
-
-    let filesystem_data = filesystem_path
-        .get_data()
-        .as_ref()
-        .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?;
-
-    let pool_path = p.tree.get(&filesystem_data.parent).ok_or_else(|| {
-        MethodErr::failed(&format!(
-            "no path for parent object path {}",
-            &filesystem_data.parent
-        ))
-    })?;
-
-    let pool_uuid = pool_path
-        .get_data()
-        .as_ref()
-        .ok_or_else(|| MethodErr::failed(&format!("no data for object path {}", object_path)))?
-        .uuid;
-
-    let engine = dbus_context.engine.borrow();
-    let (pool_name, pool) = engine.get_pool(pool_uuid).ok_or_else(|| {
-        MethodErr::failed(&format!("no pool corresponding to uuid {}", &pool_uuid))
-    })?;
-    let filesystem_uuid = filesystem_data.uuid;
-    let (fs_name, fs) = pool.get_filesystem(filesystem_uuid).ok_or_else(|| {
-        MethodErr::failed(&format!(
-            "no name for filesystem with uuid {}",
-            &filesystem_uuid
-        ))
-    })?;
-    i.append(getter((pool_name, fs_name, fs))?);
+    i.append(
+        filesystem_operation(p.tree, p.path.get_name(), getter)
+            .map_err(|ref e| MethodErr::failed(e))?,
+    );
     Ok(())
 }
 
@@ -232,17 +311,5 @@ fn get_filesystem_created(
 ) -> Result<(), MethodErr> {
     get_filesystem_property(i, p, |(_, _, fs)| {
         Ok(fs.created().to_rfc3339_opts(SecondsFormat::Secs, true))
-    })
-}
-
-/// Get the number of bytes used for any purpose on the filesystem
-fn get_filesystem_used(
-    i: &mut IterAppend,
-    p: &PropInfo<MTFn<TData>, TData>,
-) -> Result<(), MethodErr> {
-    get_filesystem_property(i, p, |(_, _, fs)| {
-        fs.used()
-            .map(|v| (*v).to_string())
-            .map_err(|_| MethodErr::failed(&"fs used() engine call failed".to_owned()))
     })
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -15,9 +15,8 @@ use devicemapper::{Bytes, Device, Sectors};
 
 use crate::{
     engine::types::{
-        BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid,
-        FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState, PoolUuid, RenameAction,
-        SetCreateAction, SetDeleteAction,
+        BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid, MaybeDbusPath, Name,
+        PoolUuid, RenameAction, SetCreateAction, SetDeleteAction,
     },
     stratis::StratisResult,
 };
@@ -57,9 +56,6 @@ pub trait BlockDev: Debug {
 
     /// The total size of the device, including space not usable for data.
     fn size(&self) -> Sectors;
-
-    /// The current state of the blockdev.
-    fn state(&self) -> BlockDevState;
 
     /// Set dbus path associated with the BlockDev.
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();
@@ -138,11 +134,6 @@ pub trait Pool: Debug {
     /// associated with a pool.
     fn total_physical_size(&self) -> Sectors;
 
-    /// The number of Sectors in this pool that are currently in use by the
-    /// pool for some purpose, be it to store metadata, to store user data,
-    /// or to reserve for some other purpose.
-    fn total_physical_used(&self) -> StratisResult<Sectors>;
-
     /// Get all the filesystems belonging to this pool.
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)>;
 
@@ -176,15 +167,6 @@ pub trait Pool: Debug {
         uuid: DevUuid,
         user_info: Option<&str>,
     ) -> StratisResult<RenameAction<DevUuid>>;
-
-    /// The current state of the Pool.
-    fn state(&self) -> PoolState;
-
-    /// The current extend state of the Pool.
-    fn extend_state(&self) -> PoolExtendState;
-
-    /// The current space state of the Pool.
-    fn free_space_state(&self) -> FreeSpaceState;
 
     /// Set dbus path associated with the Pool.
     fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();

--- a/src/engine/event.rs
+++ b/src/engine/event.rs
@@ -4,40 +4,22 @@
 
 use std::{fmt::Debug, sync::Once};
 
-use crate::engine::types::{
-    BlockDevState, FreeSpaceState, MaybeDbusPath, PoolExtendState, PoolState,
-};
+use crate::engine::types::MaybeDbusPath;
 
 static INIT: Once = Once::new();
 static mut ENGINE_LISTENER_LIST: Option<EngineListenerList> = None;
 
 #[derive(Debug, Clone)]
 pub enum EngineEvent<'a> {
-    BlockdevStateChanged {
-        dbus_path: &'a MaybeDbusPath,
-        state: BlockDevState,
-    },
     FilesystemRenamed {
         dbus_path: &'a MaybeDbusPath,
         from: &'a str,
         to: &'a str,
     },
-    PoolExtendStateChanged {
-        dbus_path: &'a MaybeDbusPath,
-        state: PoolExtendState,
-    },
     PoolRenamed {
         dbus_path: &'a MaybeDbusPath,
         from: &'a str,
         to: &'a str,
-    },
-    PoolSpaceStateChanged {
-        dbus_path: &'a MaybeDbusPath,
-        state: FreeSpaceState,
-    },
-    PoolStateChanged {
-        dbus_path: &'a MaybeDbusPath,
-        state: PoolState,
     },
 }
 

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -14,9 +14,7 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Sectors, IEC};
 
 use crate::engine::{
-    engine::BlockDev,
-    sim_engine::randomization::Randomizer,
-    types::{BlockDevState, MaybeDbusPath},
+    engine::BlockDev, sim_engine::randomization::Randomizer, types::MaybeDbusPath,
 };
 
 #[derive(Debug)]
@@ -49,10 +47,6 @@ impl BlockDev for SimDev {
 
     fn size(&self) -> Sectors {
         Bytes(IEC::Gi).sectors()
-    }
-
-    fn state(&self) -> BlockDevState {
-        BlockDevState::InUse
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -215,10 +215,6 @@ impl Pool for SimPool {
         Sectors(IEC::Ei)
     }
 
-    fn total_physical_used(&self) -> StratisResult<Sectors> {
-        Ok(Sectors(0))
-    }
-
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.filesystems
             .iter()
@@ -293,18 +289,6 @@ impl Pool for SimPool {
                 }
             },
         ))
-    }
-
-    fn state(&self) -> PoolState {
-        self.pool_state
-    }
-
-    fn extend_state(&self) -> PoolExtendState {
-        self.pool_extend_state
-    }
-
-    fn free_space_state(&self) -> FreeSpaceState {
-        self.free_space_state
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -540,12 +540,6 @@ impl Backstore {
             })
     }
 
-    /// The number of sectors in the backstore given up to Stratis
-    /// metadata on devices in the data tier.
-    pub fn datatier_metadata_size(&self) -> Sectors {
-        self.data_tier.metadata_size()
-    }
-
     /// Write the given data to the data tier's devices.
     pub fn save_state(&mut self, metadata: &[u8]) -> StratisResult<()> {
         self.data_tier.save_state(metadata)

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -25,9 +25,8 @@ use crate::{
             thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE},
         },
         types::{
-            BlockDevTier, CreateAction, DevUuid, EngineAction, FilesystemUuid, FreeSpaceState,
-            MaybeDbusPath, Name, PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction,
-            SetCreateAction, SetDeleteAction,
+            BlockDevTier, CreateAction, DevUuid, EngineAction, FilesystemUuid, MaybeDbusPath, Name,
+            PoolUuid, Redundancy, RenameAction, SetCreateAction, SetDeleteAction,
         },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
@@ -396,12 +395,6 @@ impl Pool for StratPool {
         self.backstore.datatier_size()
     }
 
-    fn total_physical_used(&self) -> StratisResult<Sectors> {
-        self.thin_pool
-            .total_physical_used()
-            .and_then(|v| Ok(v + self.backstore.datatier_metadata_size()))
-    }
-
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.thin_pool.filesystems()
     }
@@ -462,18 +455,6 @@ impl Pool for StratPool {
         Ok(result)
     }
 
-    fn state(&self) -> PoolState {
-        self.thin_pool.state()
-    }
-
-    fn extend_state(&self) -> PoolExtendState {
-        self.thin_pool.extend_state()
-    }
-
-    fn free_space_state(&self) -> FreeSpaceState {
-        self.thin_pool.free_space_state()
-    }
-
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {
         self.thin_pool.set_dbus_path(path.clone());
         self.dbus_path = path
@@ -503,7 +484,7 @@ mod tests {
             cmd,
             tests::{loopbacked, real},
         },
-        types::{EngineAction, Redundancy},
+        types::{EngineAction, PoolExtendState, PoolState, Redundancy},
     };
 
     use super::*;

--- a/tests/client-dbus/src/stratisd_client_dbus/__init__.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/__init__.py
@@ -17,6 +17,7 @@ Top-level classes and methods.
 
 from ._connection import get_object
 
+from ._implementation import FetchProperties
 from ._implementation import Filesystem
 from ._implementation import Manager
 from ._implementation import ObjectManager

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -23,6 +23,17 @@ SPECS = {
 </method>
 </interface>
 """,
+    "org.storage.stratis1.FetchProperties": """
+<interface name="org.storage.stratis1.FetchProperties">
+<method name="GetAllProperties">
+<arg name="property_hash" type="a{s(bv)}" direction="out"/>
+</method>
+<method name="GetProperties">
+<arg name="properties" type="as" direction="in"/>
+<arg name="property_hash" type="a{s(bv)}" direction="out"/>
+</method>
+</interface>
+""",
     "org.storage.stratis1.Manager": """
 <interface name="org.storage.stratis1.Manager">
 <method name="ConfigureSimulator">
@@ -91,23 +102,8 @@ SPECS = {
 <property name="Name" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
 </property>
-<property name="TotalPhysicalSize" type="s" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-</property>
-<property name="TotalPhysicalUsed" type="s" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-</property>
 <property name="Uuid" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
-</property>
-<property name="State" type="q" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-</property>
-<property name="ExtendState" type="q" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-</property>
-<property name="SpaceState" type="q" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
 </property>
 </interface>
 """,
@@ -130,9 +126,6 @@ SPECS = {
 </property>
 <property name="Pool" type="o" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
-</property>
-<property name="Used" type="s" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="Uuid" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
@@ -159,13 +152,7 @@ SPECS = {
 <property name="Pool" type="o" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
 </property>
-<property name="State" type="q" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-</property>
 <property name="Tier" type="q" access="read">
-<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-</property>
-<property name="TotalPhysicalSize" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="UserInfo" type="s" access="read">

--- a/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
@@ -45,5 +45,10 @@ ObjectManager = make_class(
 Manager = make_class(
     "Manager", ET.fromstring(SPECS["org.storage.stratis1.Manager"]), TIME_OUT
 )
+FetchProperties = make_class(
+    "FetchProperties",
+    ET.fromstring(SPECS["org.storage.stratis1.FetchProperties"]),
+    TIME_OUT,
+)
 Filesystem = make_class("Filesystem", _FILESYSTEM_SPEC, TIME_OUT)
 Pool = make_class("Pool", _POOL_SPEC, TIME_OUT)

--- a/tests/client-dbus/tests/dbus/filesystem/test_properties.py
+++ b/tests/client-dbus/tests/dbus/filesystem/test_properties.py
@@ -15,6 +15,7 @@
 Test accessing properties of a filesystem.
 """
 
+from stratisd_client_dbus import FetchProperties
 from stratisd_client_dbus import Filesystem
 from stratisd_client_dbus import Manager
 from stratisd_client_dbus import Pool
@@ -78,8 +79,11 @@ class SetNameTestCase(SimTestCase):
         # I think this is also always true
         self.assertEqual(len(created), 20)
 
-        used = Filesystem.Properties.Used.Get(filesystem)
+        (used_success, used) = FetchProperties.Methods.GetProperties(
+            filesystem, {"properties": ["Used"]}
+        )["Used"]
 
+        self.assertEqual(used_success, True)
         self.assertEqual(used, "12345678")
 
         devnode = Filesystem.Properties.Devnode.Get(filesystem)

--- a/tests/client-dbus/tests/dbus/manager/test_create.py
+++ b/tests/client-dbus/tests/dbus/manager/test_create.py
@@ -15,7 +15,6 @@
 Test 'CreatePool'.
 """
 
-from stratisd_client_dbus import MOPool
 from stratisd_client_dbus import Manager
 from stratisd_client_dbus import StratisdErrors
 from stratisd_client_dbus import ObjectManager
@@ -65,15 +64,10 @@ class Create2TestCase(SimTestCase):
 
         if rc == StratisdErrors.OK:
             self.assertIsNotNone(result)
-            (pool, table) = result
+            (pool, _) = result
             self.assertEqual(pool, poolpath)
             self.assertEqual(len(all_pools), 1)
             self.assertLessEqual(len(devnodes), len(devs))
-
-            pool_info = MOPool(table)
-            self.assertLessEqual(
-                int(pool_info.TotalPhysicalUsed()), int(pool_info.TotalPhysicalSize())
-            )
         else:
             self.assertIsNone(result)
             self.assertEqual(len(all_pools), 0)


### PR DESCRIPTION
Some DBus properties can fail or take longer to compute. This PR removes properties that are not useful from the DBus interface and changes access to the properties that can fail or take longer to compute to be fetched through the FetchProperties interface.

Supersedes #1662 
Related to stratis-storage/project#52