### PR TITLE
Convert from sectors to bytes manually in stratisd

### DIFF
--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -204,9 +204,13 @@ fn get_properties_shared(
         .filter_map(|prop| match prop.as_str() {
             "TotalPhysicalSize" => {
                 let bd_size_result =
-                    blockdev_operation(m.tree, object_path.get_name(), |_, bd| Ok(*bd.size()));
+                    blockdev_operation(m.tree, object_path.get_name(), |_, bd| Ok(*bd.size()))
+                        .map(|size| u128::from(size) * devicemapper::SECTOR_SIZE as u128);
                 let (bd_size_success, bd_size_prop) = match bd_size_result {
-                    Ok(bd_size) => (true, Variant(Box::new(bd_size) as Box<dyn RefArg>)),
+                    Ok(bd_size) => (
+                        true,
+                        Variant(Box::new(bd_size.to_string()) as Box<dyn RefArg>),
+                    ),
                     Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
                 };
 

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -45,12 +45,13 @@ fn get_properties_shared(
             consts::FILESYSTEM_USED_PROP => {
                 let fs_used_result =
                     filesystem_operation(m.tree, object_path.get_name(), |(_, _, fs)| {
-                        fs.used()
-                            .map(|u| (*u).to_string())
-                            .map_err(|e| e.to_string())
+                        fs.used().map(|u| *u).map_err(|e| e.to_string())
                     });
                 let (fs_used_success, fs_used_prop) = match fs_used_result {
-                    Ok(fs_used) => (true, Variant(Box::new(fs_used) as Box<dyn RefArg>)),
+                    Ok(fs_used) => (
+                        true,
+                        Variant(Box::new(fs_used.to_string()) as Box<dyn RefArg>),
+                    ),
                     Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
                 };
 

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -390,10 +390,11 @@ fn get_properties_shared(
             consts::POOL_TOTAL_SIZE_PROP => {
                 let total_size_result =
                     pool_operation(m.tree, object_path.get_name(), |(_, _, pool)| {
-                        Ok((*pool.total_physical_size()).to_string())
-                    });
+                        Ok(*pool.total_physical_size())
+                    })
+                    .map(|size| u128::from(size) * devicemapper::SECTOR_SIZE as u128);
                 let (total_size_success, total_size_prop) = match total_size_result {
-                    Ok(size) => (true, Variant(Box::new(size) as Box<dyn RefArg>)),
+                    Ok(size) => (true, Variant(Box::new(size.to_string()) as Box<dyn RefArg>)),
                     Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
                 };
                 Some((prop, (total_size_success, total_size_prop)))


### PR DESCRIPTION
Closes #1243 

This will prevent overflow on multiplication from sectors into number of bytes until we can examine devicemapper more thoroughly to see if we want to change the internal representation of `Bytes` to a `u128`.

Also contains a bug fix where blockdev size was not converted to a string before sending across the DBus.