### PR TITLE
Restore TotalPhysicalUsed property on the D-Bus

### DIFF
--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -201,14 +201,11 @@ fn get_properties_shared(
         .unique()
         .filter_map(|prop| match prop.as_str() {
             "TotalPhysicalSize" => {
-                let bd_size_result =
-                    blockdev_operation(m.tree, object_path.get_name(), |_, bd| Ok(*bd.size()))
-                        .map(|size| u128::from(size) * devicemapper::SECTOR_SIZE as u128);
+                let bd_size_result = blockdev_operation(m.tree, object_path.get_name(), |_, bd| {
+                    Ok((u128::from(*bd.size()) * devicemapper::SECTOR_SIZE as u128).to_string())
+                });
                 let (bd_size_success, bd_size_prop) = match bd_size_result {
-                    Ok(bd_size) => (
-                        true,
-                        Variant(Box::new(bd_size.to_string()) as Box<dyn RefArg>),
-                    ),
+                    Ok(bd_size) => (true, Variant(Box::new(bd_size) as Box<dyn RefArg>)),
                     Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
                 };
 

--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -200,7 +200,7 @@ fn get_properties_shared(
     let return_value: HashMap<String, (bool, Variant<Box<dyn RefArg>>)> = properties
         .unique()
         .filter_map(|prop| match prop.as_str() {
-            "TotalPhysicalSize" => {
+            consts::BLOCKDEV_TOTAL_SIZE_PROP => {
                 let bd_size_result = blockdev_operation(m.tree, object_path.get_name(), |_, bd| {
                     Ok((u128::from(*bd.size()) * devicemapper::SECTOR_SIZE as u128).to_string())
                 });
@@ -221,7 +221,9 @@ fn get_properties_shared(
 fn get_all_properties(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     get_properties_shared(
         m,
-        &mut vec!["TotalPhysicalSize"].into_iter().map(|s| s.to_string()),
+        &mut vec![consts::BLOCKDEV_TOTAL_SIZE_PROP]
+            .into_iter()
+            .map(|s| s.to_string()),
     )
 }
 

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -12,6 +12,7 @@ pub const PROPERTY_FETCH_INTERFACE_NAME: &str = "org.storage.stratis2.FetchPrope
 pub const POOL_INTERFACE_NAME: &str = "org.storage.stratis2.pool";
 pub const POOL_NAME_PROP: &str = "Name";
 pub const POOL_TOTAL_SIZE_PROP: &str = "TotalPhysicalSize";
+pub const POOL_TOTAL_USED_PROP: &str = "TotalPhysicalUsed";
 
 pub const FILESYSTEM_INTERFACE_NAME: &str = "org.storage.stratis2.filesystem";
 pub const FILESYSTEM_NAME_PROP: &str = "Name";

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -19,3 +19,4 @@ pub const FILESYSTEM_NAME_PROP: &str = "Name";
 pub const FILESYSTEM_USED_PROP: &str = "Used";
 
 pub const BLOCKDEV_INTERFACE_NAME: &str = "org.storage.stratis2.blockdev";
+pub const BLOCKDEV_TOTAL_SIZE_PROP: &str = "TotalPhysicalSize";

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -45,13 +45,12 @@ fn get_properties_shared(
             consts::FILESYSTEM_USED_PROP => {
                 let fs_used_result =
                     filesystem_operation(m.tree, object_path.get_name(), |(_, _, fs)| {
-                        fs.used().map(|u| *u).map_err(|e| e.to_string())
+                        fs.used()
+                            .map(|u| (*u).to_string())
+                            .map_err(|e| e.to_string())
                     });
                 let (fs_used_success, fs_used_prop) = match fs_used_result {
-                    Ok(fs_used) => (
-                        true,
-                        Variant(Box::new(fs_used.to_string()) as Box<dyn RefArg>),
-                    ),
+                    Ok(fs_used) => (true, Variant(Box::new(fs_used) as Box<dyn RefArg>)),
                     Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
                 };
 

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -390,11 +390,12 @@ fn get_properties_shared(
             consts::POOL_TOTAL_SIZE_PROP => {
                 let total_size_result =
                     pool_operation(m.tree, object_path.get_name(), |(_, _, pool)| {
-                        Ok(*pool.total_physical_size())
-                    })
-                    .map(|size| u128::from(size) * devicemapper::SECTOR_SIZE as u128);
+                        Ok((u128::from(*pool.total_physical_size())
+                            * devicemapper::SECTOR_SIZE as u128)
+                            .to_string())
+                    });
                 let (total_size_success, total_size_prop) = match total_size_result {
-                    Ok(size) => (true, Variant(Box::new(size.to_string()) as Box<dyn RefArg>)),
+                    Ok(size) => (true, Variant(Box::new(size) as Box<dyn RefArg>)),
                     Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
                 };
                 Some((prop, (total_size_success, total_size_prop)))
@@ -404,11 +405,12 @@ fn get_properties_shared(
                     pool_operation(m.tree, object_path.get_name(), |(_, _, pool)| {
                         pool.total_physical_used()
                             .map_err(|e| e.to_string())
-                            .map(|size| *size)
-                    })
-                    .map(|size| u128::from(size) * devicemapper::SECTOR_SIZE as u128);
+                            .map(|size| {
+                                (u128::from(*size) * devicemapper::SECTOR_SIZE as u128).to_string()
+                            })
+                    });
                 let (total_used_success, total_used_prop) = match total_used_result {
-                    Ok(size) => (true, Variant(Box::new(size.to_string()) as Box<dyn RefArg>)),
+                    Ok(size) => (true, Variant(Box::new(size) as Box<dyn RefArg>)),
                     Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
                 };
                 Some((prop, (total_used_success, total_used_prop)))

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -134,6 +134,12 @@ pub trait Pool: Debug {
     /// associated with a pool.
     fn total_physical_size(&self) -> Sectors;
 
+    /// The number of Sectors in this pool that are currently in use by the
+    /// pool for some purpose, and therefore not available for future use,
+    /// by any subcomponent of Stratis, either for internal managment or to
+    /// store user data.
+    fn total_physical_used(&self) -> StratisResult<Sectors>;
+
     /// Get all the filesystems belonging to this pool.
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)>;
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -215,6 +215,10 @@ impl Pool for SimPool {
         Sectors(IEC::Ei)
     }
 
+    fn total_physical_used(&self) -> StratisResult<Sectors> {
+        Ok(Sectors(0))
+    }
+
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.filesystems
             .iter()

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -540,6 +540,12 @@ impl Backstore {
             })
     }
 
+    /// The number of sectors in the backstore given up to Stratis metadata
+    /// on devices in the data tier.
+    pub fn datatier_metadata_size(&self) -> Sectors {
+        self.data_tier.metadata_size()
+    }
+
     /// Write the given data to the data tier's devices.
     pub fn save_state(&mut self, metadata: &[u8]) -> StratisResult<()> {
         self.data_tier.save_state(metadata)

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -395,6 +395,12 @@ impl Pool for StratPool {
         self.backstore.datatier_size()
     }
 
+    fn total_physical_used(&self) -> StratisResult<Sectors> {
+        self.thin_pool
+            .total_physical_used()
+            .map(|v| v + self.backstore.datatier_metadata_size())
+    }
+
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.thin_pool.filesystems()
     }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -396,6 +396,12 @@ impl Pool for StratPool {
     }
 
     fn total_physical_used(&self) -> StratisResult<Sectors> {
+        // TODO: note that with the addition of another layer, the
+        // calculation of the amount of physical spaced used by means
+        // of adding the amount used by Stratis metadata to the amount used
+        // by the pool abstraction will be invalid. In the event of, e.g.,
+        // software RAID, the amount will be far too low to be useful, in the
+        // event of, e.g, VDO, the amount will be far too large to be useful.
         self.thin_pool
             .total_physical_used()
             .map(|v| v + self.backstore.datatier_metadata_size())

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -807,6 +807,37 @@ impl ThinPool {
         result
     }
 
+    /// The number of physical sectors in use, that is, unavailable for storage
+    /// of additional user data, by this pool.
+    // This includes all the sectors being held as spares for the meta device,
+    // all the sectors allocated to the meta data device, and all the sectors
+    // in use on the data device.
+    pub fn total_physical_used(&self) -> StratisResult<Sectors> {
+        let data_dev_used = match self.thin_pool.status(get_dm())? {
+            ThinPoolStatus::Working(ref status) => datablocks_to_sectors(status.usage.used_data),
+            ThinPoolStatus::Error => {
+                let err_msg = format!(
+                    "Devicemapper could not obtain status for devicemapper thin
+ pool device {}",
+                    self.thin_pool.device(),
+                );
+                return Err(StratisError::Engine(ErrorEnum::Invalid, err_msg));
+            }
+            ThinPoolStatus::Fail => {
+                let err_msg = "thin pool failed, could not obtain usage";
+                return Err(StratisError::Engine(ErrorEnum::Invalid, err_msg.into()));
+            }
+        };
+
+        let spare_total = self.segments.meta_spare_segments.iter().map(|s| s.1).sum();
+
+        let meta_dev_total = self.thin_pool.meta_dev().size();
+
+        let mdv_total = self.segments.mdv_segments.iter().map(|s| s.1).sum();
+
+        Ok(data_dev_used + spare_total + meta_dev_total + mdv_total)
+    }
+
     pub fn get_filesystem_by_uuid(&self, uuid: FilesystemUuid) -> Option<(Name, &StratFilesystem)> {
         self.filesystems.get_by_uuid(uuid)
     }


### PR DESCRIPTION
This PR does the following:

* Restores the TotalPhysicalUsed property for a pool via the new FetchProperties interface.
* Slightly modifies how total physical used is calculated for a ThinPool abstraction.
* Smooths out some actions in the D-Bus layer in the FetchProperties implementation so that actions
are more uniform. There is a bit more of this available, to remove duplicate code, I think, but I'm leaving that until later.
* Adds a TODO as a reminder about the brittleness of this approach of calculating total physical size.