### PR TITLE
Tidy up get_properties_shared methods

### DIFF
--- a/src/dbus_api/blockdev.rs
+++ b/src/dbus_api/blockdev.rs
@@ -22,7 +22,7 @@ use crate::{
         types::{DbusContext, DbusErrorEnum, OPContext, TData},
         util::{
             engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path,
-            msg_code_ok, msg_string_ok, tuple_to_option,
+            msg_code_ok, msg_string_ok, result_to_tuple, tuple_to_option,
         },
     },
     engine::{BlockDev, BlockDevTier, DevUuid, MaybeDbusPath, RenameAction},
@@ -208,13 +208,7 @@ fn get_properties_shared(
             )),
             _ => None,
         })
-        .map(|(key, result)| {
-            let (success, value) = match result {
-                Ok(value) => (true, Variant(Box::new(value) as Box<dyn RefArg>)),
-                Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
-            };
-            (key, (success, value))
-        })
+        .map(|(key, result)| result_to_tuple(key, result))
         .collect();
 
     Ok(vec![return_message.append1(return_value)])

--- a/src/dbus_api/filesystem.rs
+++ b/src/dbus_api/filesystem.rs
@@ -22,7 +22,7 @@ use crate::{
         types::{DbusContext, DbusErrorEnum, OPContext, TData},
         util::{
             engine_to_dbus_err_tuple, get_next_arg, get_parent, get_uuid, make_object_path,
-            msg_code_ok, msg_string_ok,
+            msg_code_ok, msg_string_ok, result_to_tuple,
         },
     },
     engine::{
@@ -52,13 +52,7 @@ fn get_properties_shared(
             )),
             _ => None,
         })
-        .map(|(key, result)| {
-            let (success, value) = match result {
-                Ok(value) => (true, Variant(Box::new(value) as Box<dyn RefArg>)),
-                Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
-            };
-            (key, (success, value))
-        })
+        .map(|(key, result)| result_to_tuple(key, result))
         .collect();
 
     Ok(vec![return_message.append1(return_value)])

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -25,7 +25,7 @@ use crate::{
         types::{DbusContext, DbusErrorEnum, OPContext, TData},
         util::{
             engine_to_dbus_err_tuple, get_next_arg, get_uuid, make_object_path, msg_code_ok,
-            msg_string_ok,
+            msg_string_ok, result_to_tuple,
         },
     },
     engine::{
@@ -407,13 +407,7 @@ fn get_properties_shared(
             )),
             _ => None,
         })
-        .map(|(key, result)| {
-            let (success, value) = match result {
-                Ok(value) => (true, Variant(Box::new(value) as Box<dyn RefArg>)),
-                Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
-            };
-            (key, (success, value))
-        })
+        .map(|(key, result)| result_to_tuple(key, result))
         .collect();
 
     Ok(vec![return_message.append1(return_value)])

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -387,35 +387,32 @@ fn get_properties_shared(
     let return_value: HashMap<String, (bool, Variant<Box<dyn RefArg>>)> = properties
         .unique()
         .filter_map(|prop| match prop.as_str() {
-            consts::POOL_TOTAL_SIZE_PROP => {
-                let total_size_result =
-                    pool_operation(m.tree, object_path.get_name(), |(_, _, pool)| {
-                        Ok((u128::from(*pool.total_physical_size())
-                            * devicemapper::SECTOR_SIZE as u128)
-                            .to_string())
-                    });
-                let (total_size_success, total_size_prop) = match total_size_result {
-                    Ok(size) => (true, Variant(Box::new(size) as Box<dyn RefArg>)),
-                    Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
-                };
-                Some((prop, (total_size_success, total_size_prop)))
-            }
-            consts::POOL_TOTAL_USED_PROP => {
-                let total_used_result =
-                    pool_operation(m.tree, object_path.get_name(), |(_, _, pool)| {
-                        pool.total_physical_used()
-                            .map_err(|e| e.to_string())
-                            .map(|size| {
-                                (u128::from(*size) * devicemapper::SECTOR_SIZE as u128).to_string()
-                            })
-                    });
-                let (total_used_success, total_used_prop) = match total_used_result {
-                    Ok(size) => (true, Variant(Box::new(size) as Box<dyn RefArg>)),
-                    Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
-                };
-                Some((prop, (total_used_success, total_used_prop)))
-            }
+            consts::POOL_TOTAL_SIZE_PROP => Some((
+                prop,
+                pool_operation(m.tree, object_path.get_name(), |(_, _, pool)| {
+                    Ok((u128::from(*pool.total_physical_size())
+                        * devicemapper::SECTOR_SIZE as u128)
+                        .to_string())
+                }),
+            )),
+            consts::POOL_TOTAL_USED_PROP => Some((
+                prop,
+                pool_operation(m.tree, object_path.get_name(), |(_, _, pool)| {
+                    pool.total_physical_used()
+                        .map_err(|e| e.to_string())
+                        .map(|size| {
+                            (u128::from(*size) * devicemapper::SECTOR_SIZE as u128).to_string()
+                        })
+                }),
+            )),
             _ => None,
+        })
+        .map(|(key, result)| {
+            let (success, value) = match result {
+                Ok(value) => (true, Variant(Box::new(value) as Box<dyn RefArg>)),
+                Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
+            };
+            (key, (success, value))
         })
         .collect();
 

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -31,6 +31,26 @@ pub fn tuple_to_option<T>(value: (bool, T)) -> Option<T> {
     }
 }
 
+/// Map a result obtained for the FetchProperties interface to a pair of
+/// a key and a value. The key is the property key, and therefore the key
+/// of the item returned. The value is a tuple. An error in the result
+/// argument yields a false in the return value, indicating that the value
+/// returned is a string representation of the error encountered in
+/// obtaining the value, and not the value requested.
+pub fn result_to_tuple<T>(
+    key: String,
+    result: Result<T, String>,
+) -> (String, (bool, Variant<Box<dyn RefArg>>))
+where
+    T: RefArg + 'static,
+{
+    let (success, value) = match result {
+        Ok(value) => (true, Variant(Box::new(value) as Box<dyn RefArg>)),
+        Err(e) => (false, Variant(Box::new(e) as Box<dyn RefArg>)),
+    };
+    (key, (success, value))
+}
+
 /// Get the next argument off the bus
 pub fn get_next_arg<'a, T>(iter: &mut Iter<'a>, loc: u16) -> Result<T, MethodErr>
 where


### PR DESCRIPTION
This tidies up the private get_properties_shared methods in the definitions of the FetchProperties interface for pools, blockdevs, and filesystems.

This makes the code a bit longer now, because in all cases only 1 or 2 properties are returned via this interface. The benefits will be realized as more properties are added, which will certainly happen quite soon.