### PR TITLE
Move idempotent return type to pool level

### DIFF
--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -30,18 +30,18 @@ macro_rules! get_mut_pool {
     };
 }
 
-macro_rules! rename_filesystem_pre {
-    ($s:ident; $uuid:ident; $new_name:ident) => {{
-        let old_name = match $s.filesystems.get_by_uuid($uuid) {
+macro_rules! rename_pre {
+    ($s:expr; $uuid:ident; $new_name:ident; $not_found:expr; $same:expr) => {{
+        let old_name = match $s.get_by_uuid($uuid) {
             Some((name, _)) => name,
-            None => return Ok(RenameAction::NoSource),
+            None => return $not_found,
         };
 
         if &*old_name == $new_name {
-            return Ok(RenameAction::Identity);
+            return $same;
         }
 
-        if $s.filesystems.contains_name($new_name) {
+        if $s.contains_name($new_name) {
             return Err(StratisError::Engine(
                 ErrorEnum::AlreadyExists,
                 $new_name.into(),
@@ -51,25 +51,43 @@ macro_rules! rename_filesystem_pre {
     }};
 }
 
-macro_rules! rename_pool_pre {
+macro_rules! rename_filesystem_pre {
     ($s:ident; $uuid:ident; $new_name:ident) => {{
-        let old_name = match $s.pools.get_by_uuid($uuid) {
-            Some((name, _)) => name,
-            None => return Ok(RenameAction::NoSource),
-        };
-
-        if &*old_name == $new_name {
-            return Ok(RenameAction::Identity);
-        }
-
-        if $s.pools.contains_name($new_name) {
-            return Err(StratisError::Engine(
-                ErrorEnum::AlreadyExists,
-                $new_name.into(),
+        rename_pre!(
+            $s.filesystems;
+            $uuid;
+            $new_name;
+            Err(StratisError::Engine(
+                ErrorEnum::NotFound,
+                format!("Filesystem not found with UUID of {}", $uuid),
             ));
-        }
-        old_name
-    }};
+            Ok(None)
+        )
+    }}
+}
+
+macro_rules! rename_filesystem_pre_idem {
+    ($s:ident; $uuid:ident; $new_name:ident) => {{
+        rename_pre!(
+            $s.filesystems;
+            $uuid;
+            $new_name;
+            Ok(RenameAction::NoSource);
+            Ok(RenameAction::Identity)
+        )
+    }}
+}
+
+macro_rules! rename_pool_pre_idem {
+    ($s:ident; $uuid:ident; $new_name:ident) => {{
+        rename_pre!(
+            $s.pools;
+            $uuid;
+            $new_name;
+            Ok(RenameAction::NoSource);
+            Ok(RenameAction::Identity)
+        )
+    }}
 }
 
 macro_rules! set_blockdev_user_info {

--- a/src/engine/macros.rs
+++ b/src/engine/macros.rs
@@ -66,10 +66,10 @@ macro_rules! rename_filesystem_pre {
     }}
 }
 
-macro_rules! rename_filesystem_pre_idem {
-    ($s:ident; $uuid:ident; $new_name:ident) => {{
+macro_rules! rename_pre_idem {
+    ($s:expr; $uuid:ident; $new_name:ident) => {{
         rename_pre!(
-            $s.filesystems;
+            $s;
             $uuid;
             $new_name;
             Ok(RenameAction::NoSource);
@@ -78,14 +78,22 @@ macro_rules! rename_filesystem_pre_idem {
     }}
 }
 
+macro_rules! rename_filesystem_pre_idem {
+    ($s:ident; $uuid:ident; $new_name:ident) => {{
+        rename_pre_idem!(
+            $s.filesystems;
+            $uuid;
+            $new_name
+        )
+    }}
+}
+
 macro_rules! rename_pool_pre_idem {
     ($s:ident; $uuid:ident; $new_name:ident) => {{
-        rename_pre!(
+        rename_pre_idem!(
             $s.pools;
             $uuid;
-            $new_name;
-            Ok(RenameAction::NoSource);
-            Ok(RenameAction::Identity)
+            $new_name
         )
     }}
 }

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -94,7 +94,7 @@ impl Engine for SimEngine {
         uuid: PoolUuid,
         new_name: &str,
     ) -> StratisResult<RenameAction<PoolUuid>> {
-        rename_pool_pre!(self; uuid; new_name);
+        rename_pool_pre_idem!(self; uuid; new_name);
 
         let (_, pool) = self
             .pools

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -164,7 +164,7 @@ impl Pool for SimPool {
         uuid: FilesystemUuid,
         new_name: &str,
     ) -> StratisResult<RenameAction<FilesystemUuid>> {
-        rename_filesystem_pre!(self; uuid; new_name);
+        rename_filesystem_pre_idem!(self; uuid; new_name);
 
         let (_, filesystem) = self
             .filesystems

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -552,6 +552,11 @@ impl Backstore {
 
     /// Set user info field on the specified blockdev.
     /// May return an error if there is no blockdev for the given UUID.
+    ///
+    /// * Ok(Some(uuid)) provides the uuid of the changed blockdev
+    /// * Ok(None) is returned if the blockdev was unchanged
+    /// * Err(StratisError::Engine(ErrorEnum::NotFound, _)) is returned if the UUID
+    /// does not correspond to a blockdev
     pub fn set_blockdev_user_info(
         &mut self,
         uuid: DevUuid,
@@ -561,7 +566,7 @@ impl Backstore {
             || {
                 Err(StratisError::Engine(
                     ErrorEnum::NotFound,
-                    "Blockdev not found".to_string(),
+                    format!("Blockdev with a UUID of {} was not found", uuid),
                 ))
             },
             |(_, b)| {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -316,7 +316,7 @@ impl Engine for StratEngine {
         new_name: &str,
     ) -> StratisResult<RenameAction<PoolUuid>> {
         validate_name(new_name)?;
-        let old_name = rename_pool_pre!(self; uuid; new_name);
+        let old_name = rename_pool_pre_idem!(self; uuid; new_name);
 
         let (_, mut pool) = self
             .pools

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -471,10 +471,14 @@ impl Pool for StratPool {
         user_info: Option<&str>,
     ) -> StratisResult<RenameAction<DevUuid>> {
         let result = self.backstore.set_blockdev_user_info(uuid, user_info);
-        if let RenameAction::Renamed(_) = result {
-            self.write_metadata(pool_name)?;
+        match result {
+            Ok(Some(uuid)) => {
+                self.write_metadata(pool_name)?;
+                Ok(RenameAction::Renamed(uuid))
+            }
+            Ok(None) => Ok(RenameAction::Identity),
+            Err(_) => Ok(RenameAction::NoSource),
         }
-        Ok(result)
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -25,8 +25,8 @@ use crate::{
             thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE},
         },
         types::{
-            BlockDevTier, CreateAction, DevUuid, EngineAction, FilesystemUuid, MaybeDbusPath, Name,
-            PoolUuid, Redundancy, RenameAction, SetCreateAction, SetDeleteAction,
+            BlockDevTier, CreateAction, DevUuid, FilesystemUuid, MaybeDbusPath, Name, PoolUuid,
+            Redundancy, RenameAction, SetCreateAction, SetDeleteAction,
         },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
@@ -360,8 +360,7 @@ impl Pool for StratPool {
     ) -> StratisResult<SetDeleteAction<FilesystemUuid>> {
         let mut removed = Vec::new();
         for &uuid in fs_uuids {
-            let changed = self.thin_pool.destroy_filesystem(pool_name, uuid)?;
-            if changed.is_changed() {
+            if let Some(uuid) = self.thin_pool.destroy_filesystem(pool_name, uuid)? {
                 removed.push(uuid);
             }
         }
@@ -376,7 +375,17 @@ impl Pool for StratPool {
         new_name: &str,
     ) -> StratisResult<RenameAction<FilesystemUuid>> {
         validate_name(new_name)?;
-        self.thin_pool.rename_filesystem(pool_name, uuid, new_name)
+        match self.thin_pool.rename_filesystem(pool_name, uuid, new_name) {
+            Ok(Some(uuid)) => Ok(RenameAction::Renamed(uuid)),
+            Ok(None) => Ok(RenameAction::Identity),
+            Err(e) => {
+                if let StratisError::Engine(ErrorEnum::NotFound, _) = e {
+                    Ok(RenameAction::NoSource)
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 
     fn snapshot_filesystem(

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -957,6 +957,10 @@ impl ThinPool {
     /// Destroy a filesystem within the thin pool. Destroy metadata and
     /// devlinks information associated with the thinpool. If there is a
     /// failure to destroy the filesystem, retain it, and return an error.
+    ///
+    /// * Ok(Some(uuid)) provides the uuid of the destroyed filesystem
+    /// * Ok(None) is returned if the filesystem did not exist
+    /// * Err(_) is returned if the filesystem could not be destroyed
     pub fn destroy_filesystem(
         &mut self,
         pool_name: &str,

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -42,8 +42,8 @@ use crate::{
         },
         structures::Table,
         types::{
-            DeleteAction, FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState,
-            PoolState, PoolUuid, RenameAction,
+            FilesystemUuid, FreeSpaceState, MaybeDbusPath, Name, PoolExtendState, PoolState,
+            PoolUuid,
         },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
@@ -961,7 +961,7 @@ impl ThinPool {
         &mut self,
         pool_name: &str,
         uuid: FilesystemUuid,
-    ) -> StratisResult<DeleteAction<FilesystemUuid>> {
+    ) -> StratisResult<Option<FilesystemUuid>> {
         match self.filesystems.remove_by_uuid(uuid) {
             Some((fs_name, mut fs)) => match fs.destroy(&self.thin_pool) {
                 Ok(_) => {
@@ -973,14 +973,14 @@ impl ThinPool {
                                err);
                     }
                     devlinks::filesystem_removed(pool_name, &fs_name);
-                    Ok(DeleteAction::Deleted(uuid))
+                    Ok(Some(uuid))
                 }
                 Err(err) => {
                     self.filesystems.insert(fs_name, uuid, fs);
                     Err(err)
                 }
             },
-            None => Ok(DeleteAction::Identity),
+            None => Ok(None),
         }
     }
 
@@ -995,12 +995,19 @@ impl ThinPool {
     }
 
     /// Rename a filesystem within the thin pool.
+    ///
+    /// * Ok(Some(uuid)) provides the uuid of the renamed filesystem
+    /// * Ok(None) is returned if the source and target filesystem names are the same
+    /// * Err(StratisError::Engine(ErrorEnum::NotFound, _)) is returned if the source
+    /// filesystem name does not exist
+    /// * Err(StratisError::Engine(ErrorEnum::AlreadyExists, _)) is returned if the target
+    /// filesystem name already exists
     pub fn rename_filesystem(
         &mut self,
         pool_name: &str,
         uuid: FilesystemUuid,
         new_name: &str,
-    ) -> StratisResult<RenameAction<Uuid>> {
+    ) -> StratisResult<Option<Uuid>> {
         let old_name = rename_filesystem_pre!(self; uuid; new_name);
         let new_name = Name::new(new_name.to_owned());
 
@@ -1021,7 +1028,7 @@ impl ThinPool {
             });
             self.filesystems.insert(new_name.clone(), uuid, filesystem);
             devlinks::filesystem_renamed(pool_name, &old_name, &new_name);
-            Ok(RenameAction::Renamed(uuid))
+            Ok(Some(uuid))
         }
     }
 
@@ -1536,7 +1543,7 @@ mod tests {
             .unwrap();
 
         let action = pool.rename_filesystem(pool_name, fs_uuid, name2).unwrap();
-        assert_matches!(action, RenameAction::Renamed(_));
+        assert_matches!(action, Some(_));
         let flexdevs: FlexDevsSave = pool.record();
         let thinpoolsave: ThinPoolDevSave = pool.record();
         pool.teardown().unwrap();


### PR DESCRIPTION
Everywhere else in the code, we return idempotent data types at the layer right below the D-Bus layer (such as Pool, Engine, etc.). This moves the idempotent data type for renaming actions up one level from the backstore to make it consistent with all of the other return types.

It does not change the Engine interface and is merely an internal change to make it clearer where idempotence is handled. It also makes the backstore API consistent.