### PR TITLE
Smarter error handling for thinpool suspend/resume

### DIFF
--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -315,9 +315,19 @@ impl Pool for StratPool {
             // If adding cache devices, must suspend the pool, since the cache
             // must be augmeneted with the new devices.
             self.thin_pool.suspend()?;
-            let bdev_info = self.backstore.add_cachedevs(pool_uuid, paths)?;
-            self.thin_pool.set_device(self.backstore.device().expect("Since thin pool exists, space must have been allocated from the backstore, so backstore must have a cap device"))?;
+            let bdev_info_res = self
+                .backstore
+                .add_cachedevs(pool_uuid, paths)
+                .and_then(|bdi| {
+                    self.thin_pool
+                        .set_device(self.backstore.device().expect(
+                            "Since thin pool exists, space must have been allocated \
+                             from the backstore, so backstore must have a cap device",
+                        ))
+                        .and(Ok(bdi))
+                });
             self.thin_pool.resume()?;
+            let bdev_info = bdev_info_res?;
             Ok(SetCreateAction::new(bdev_info))
         } else {
             // If just adding data devices, no need to suspend the pool.


### PR DESCRIPTION
Closes #1730 

This will allow resuming the thinpool if something between suspend and resume fails so that the thin pool is not left in an unusable state that requires manual intervention to resume it.