### PR TITLE
Tidy up udev-based discovery of existing Stratis devices a bit more

### DIFF
--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -547,7 +547,7 @@ mod tests {
         backstore::{find_all, get_metadata},
         cmd,
         tests::{loopbacked, real},
-        udev::{block_device_apply, decide_ownership},
+        udev::block_device_ownership,
     };
 
     use crate::engine::strat_engine::backstore::metadata::device_identifiers;
@@ -612,19 +612,19 @@ mod tests {
         for (i, path) in paths.iter().enumerate() {
             if i == index {
                 assert_matches!(
-                    block_device_apply(path, |d| decide_ownership(d)
-                        .and_then(|decision| DevOwnership::from_udev_ownership(&decision, path)))
-                    .unwrap()
-                    .unwrap()
+                    DevOwnership::from_udev_ownership(
+                        &block_device_ownership(path).unwrap().unwrap().unwrap(),
+                        path
+                    )
                     .unwrap(),
                     DevOwnership::Theirs(_)
                 );
             } else {
                 assert_matches!(
-                    block_device_apply(path, |d| decide_ownership(d)
-                        .and_then(|decision| DevOwnership::from_udev_ownership(&decision, path)))
-                    .unwrap()
-                    .unwrap()
+                    DevOwnership::from_udev_ownership(
+                        &block_device_ownership(path).unwrap().unwrap().unwrap(),
+                        path
+                    )
                     .unwrap(),
                     DevOwnership::Unowned
                 );

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -54,7 +54,12 @@ pub fn find_all() -> StratisResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> 
         for devnode in enumerator
             .scan_devices()?
             .filter(|dev| dev.is_initialized())
-            .filter(|dev| !is_multipath_member(dev).unwrap_or(true))
+            .filter(|dev| !is_multipath_member(dev)
+                    .map_err(|err| {
+                        warn!("Could not certainly determine whether a device was a multipath member because of an error processing udev information, discarded the device from the set of devices to process, for safety: {}",
+                              err);
+                    })
+                    .unwrap_or(true))
             .filter_map(|i| i.devnode().map(|d| d.to_path_buf()))
         {
             if let Some(devno) = devnode_to_devno(&devnode)? {
@@ -111,6 +116,10 @@ pub fn find_all() -> StratisResult<HashMap<PoolUuid, HashMap<Device, PathBuf>>> 
             .filter(|dev| dev.is_initialized())
             .filter(|dev| {
                 decide_ownership(dev)
+                    .map_err(|err| {
+                        warn!("Could not determine ownership of a udev block device because of an error processing udev information, discarded the device from the set of devices to process, for safety: {}",
+                              err);
+                    })
                     .map(|decision| match decision {
                         UdevOwnership::Stratis | UdevOwnership::Unowned => true,
                         _ => false,

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -25,7 +25,7 @@ use crate::{
             dm::{get_dm, get_dm_init},
             names::validate_name,
             pool::{check_metadata, StratPool},
-            udev::{block_device_apply, decide_ownership},
+            udev::block_device_ownership,
         },
         structures::Table,
         types::{CreateAction, DeleteAction, RenameAction},
@@ -207,20 +207,9 @@ impl Engine for StratEngine {
         device: Device,
         dev_node: PathBuf,
     ) -> StratisResult<Option<PoolUuid>> {
-        let stratis_identifiers = if let Some(ownership) = block_device_apply(&dev_node, |d| {
-            decide_ownership(d)
-                .and_then(|decision| DevOwnership::from_udev_ownership(&decision, &dev_node))
-        })? {
-            ownership?.stratis_identifiers()
-        } else {
-            return Err(StratisError::Engine(
-                ErrorEnum::NotFound,
-                format!(
-                    "Could not determine ownership of block device {} because it could not be found in the udev database",
-                    dev_node.display()
-                ),
-            ));
-        };
+        let stratis_identifiers =
+            DevOwnership::from_udev_ownership(&block_device_ownership(&dev_node)???, &dev_node)?
+                .stratis_identifiers();
         let pool_uuid = if let Some((pool_uuid, device_uuid)) = stratis_identifiers {
             if self.pools.contains_uuid(pool_uuid) {
                 // We can get udev events for devices that are already in the pool.  Lets check

--- a/src/engine/strat_engine/udev.rs
+++ b/src/engine/strat_engine/udev.rs
@@ -109,6 +109,44 @@ pub fn decide_ownership(device: &libudev::Device) -> StratisResult<UdevOwnership
     })
 }
 
+/// Locate a udev block device with the specified devnode and return
+/// the UdevOwnership decision.
+/// If there is a udev error in setting up the search returns a Stratis error.
+/// If the device being searched can not be found, returns Ok(Stratis error).
+/// If the device could be found, but there was an error in determining
+/// ownership, return Ok(Ok(Stratis error)).
+/// Otherwise, returns the UdevOwnership designation.
+/// Precondition: The block device is known in the udev database.
+pub fn block_device_ownership(
+    devnode: &Path,
+) -> StratisResult<StratisResult<StratisResult<UdevOwnership>>> {
+    block_device_apply(devnode, |d| decide_ownership(d))
+        .map_err(|err| {
+            StratisError::Error(format!(
+                "Could not determine ownership of block device {} because of a udev failure: {}",
+                devnode.display(),
+                err
+            ))
+        })
+    .map(|option_ownership| {
+        option_ownership.ok_or_else(|| {
+            StratisError::Error(format!(
+                "Could not determine ownership of block device {} because it could not be found in the udev database",
+                devnode.display(),
+            ))
+        })
+        .map(|error_ownership| {
+            error_ownership.map_err(|err| {
+                StratisError::Error(format!(
+                        "Could not determine ownership of block device {} because of an error processing udev information: {}",
+                        devnode.display(),
+                        err
+                ))
+            })
+        })
+    })
+}
+
 /// Locate a udev block device with the specified devnode and apply a function
 /// to that device, returning the result.
 /// This approach is necessitated by the libudev lifetimes, which do not allow


### PR DESCRIPTION
Regularizes device discovery in the find_all() and the block_evaluate() methods, both of which are used to retrieve block devices in order to build Stratis pools.

Leaves blockdevmgr::initialize() device discovery strictly alone, as it has a different purpose from the other methods.

Related: #1659.