### PR TITLE
Fix up broken indices in arguments to get_next_arg()

### DIFF
--- a/src/dbus_api/api.rs
+++ b/src/dbus_api/api.rs
@@ -36,7 +36,7 @@ fn create_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
 
     let name: &str = get_next_arg(&mut iter, 0)?;
     let redundancy: (bool, u16) = get_next_arg(&mut iter, 1)?;
-    let devs: Array<&str, _> = get_next_arg(&mut iter, 3)?;
+    let devs: Array<&str, _> = get_next_arg(&mut iter, 2)?;
 
     let blockdevs = devs.map(|x| Path::new(x)).collect::<Vec<&Path>>();
 

--- a/src/dbus_api/pool.rs
+++ b/src/dbus_api/pool.rs
@@ -176,7 +176,7 @@ fn snapshot_filesystem(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let mut iter = message.iter_init();
 
     let filesystem: dbus::Path<'static> = get_next_arg(&mut iter, 0)?;
-    let snapshot_name: &str = get_next_arg(&mut iter, 0)?;
+    let snapshot_name: &str = get_next_arg(&mut iter, 1)?;
 
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();
@@ -223,7 +223,7 @@ fn add_blockdevs(m: &MethodInfo<MTFn<TData>, TData>, tier: BlockDevTier) -> Meth
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let devs: Array<&str, _> = get_next_arg(&mut iter, 1)?;
+    let devs: Array<&str, _> = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
     let object_path = m.path.get_name();

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -51,7 +51,8 @@ where
     (key, (success, value))
 }
 
-/// Get the next argument off the bus
+/// Get the next argument off the bus. loc is the index of the location of
+/// the argument in the iterator, and is used solely for error-reporting.
 pub fn get_next_arg<'a, T>(iter: &mut Iter<'a>, loc: u16) -> Result<T, MethodErr>
 where
     T: dbus::arg::Get<'a> + dbus::arg::Arg,


### PR DESCRIPTION
Previously create_pool and add_blockdevs had a force argument. When the force argument went away, the indices went out of sync. The error for snapshot was there from the beginning. These only affect error reporting, where they would have indicated that the wrong index was invalid.