### PR TITLE
Make setup::get_metadata more robust and more appropriate for its actual use

### DIFF
--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -775,7 +775,7 @@ mod tests {
 
         assert!(pools
             .iter()
-            .map(|(uuid, devs)| get_metadata(*uuid, devs))
+            .map(|(_, devs)| get_metadata(devs))
             .all(|x| x.unwrap().is_none()));
     }
 

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -279,7 +279,9 @@ pub fn get_metadata(
 
     // Most recent time should never be None if this was a properly
     // created pool; this allows for the method to be called in other
-    // circumstances.
+    // circumstances. The other circumstances might consist of a sudden
+    // failure between the time the block devices are initialized and the
+    // time that the metadata is first written.
     let most_recent_time = {
         match bdas
             .iter()

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -61,7 +61,7 @@ fn setup_pool(
         format!("(pool UUID: {}, devnodes: {})", pool_uuid, dev_paths)
     };
 
-    let (timestamp, metadata) = get_metadata(pool_uuid, devices)?.ok_or_else(|| {
+    let (timestamp, metadata) = get_metadata(devices)?.ok_or_else(|| {
         let err_msg = format!("no metadata found for {}", info_string());
         StratisError::Engine(ErrorEnum::NotFound, err_msg)
     })?;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -556,8 +556,8 @@ mod tests {
         assert_eq!(pools.len(), 2);
         let devnodes1 = &pools[&uuid1];
         let devnodes2 = &pools[&uuid2];
-        let (_, pool_save1) = get_metadata(uuid1, devnodes1).unwrap().unwrap();
-        let (_, pool_save2) = get_metadata(uuid2, devnodes2).unwrap().unwrap();
+        let (_, pool_save1) = get_metadata(devnodes1).unwrap().unwrap();
+        let (_, pool_save2) = get_metadata(devnodes2).unwrap().unwrap();
         assert_eq!(pool_save1, metadata1);
         assert_eq!(pool_save2, metadata2);
 
@@ -569,8 +569,8 @@ mod tests {
         assert_eq!(pools.len(), 2);
         let devnodes1 = &pools[&uuid1];
         let devnodes2 = &pools[&uuid2];
-        let (_, pool_save1) = get_metadata(uuid1, devnodes1).unwrap().unwrap();
-        let (_, pool_save2) = get_metadata(uuid2, devnodes2).unwrap().unwrap();
+        let (_, pool_save1) = get_metadata(devnodes1).unwrap().unwrap();
+        let (_, pool_save2) = get_metadata(devnodes2).unwrap().unwrap();
         assert_eq!(pool_save1, metadata1);
         assert_eq!(pool_save2, metadata2);
     }
@@ -689,7 +689,7 @@ mod tests {
         assert_eq!(pools.len(), 1);
         let devices = &pools[&uuid];
 
-        let (timestamp, metadata) = get_metadata(uuid, devices).unwrap().unwrap();
+        let (timestamp, metadata) = get_metadata(devices).unwrap().unwrap();
         let (name, pool) = StratPool::setup(uuid, devices, timestamp, &metadata).unwrap();
         invariant(&pool, &name);
 


### PR DESCRIPTION
Makes get_metadata more robust by adding useful logging when something strange happens,
and generally improving error messages to be as complete as possible given their context.

Changes the specification of get_metadata so it doesn't just ignore devices that don't seem to belong (because they have the wrong pool UUID) but instead returns an error.