### PR TITLE
Do not make beta task an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ language: rust
 matrix:
     fast_finish: true
     allow_failures:
-        # Allow beta tasks to fail
-        - rust: beta
         # Allow audit task to fail
         - env: TASK=audit
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,12 +87,18 @@ matrix:
               - cd tests/client-dbus
           env: TASK=fmt-travis
 
-        # ALLOWED FAILURES
-        # Run clippy on rust beta, in order to be good Rustaceans
+
+        # INTERMITTENTLY ALLOWED FAILURES
+        # Allowed if a failure occurs after a new Rust release until the
+        # failure is addressed.
+        # Run clippy on rust beta, in order to be good Rustaceans.
         - rust: beta
           before_script:
               - rustup component add clippy
           env: TASK=clippy
+
+
+        # ALLOWED FAILURES
         # Run audit on Rust stable.  Make it an allowed failure, because:
         # * It takes 9 minutes, the longest of any task.
         # * It should be an advisory, and should not gate our development.

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,11 +100,6 @@ matrix:
         # * It should be an advisory, and should not gate our development.
         - rust: stable
           env: TASK=audit
-        # Run fmt on rust beta, to observe any upcoming formatting changes
-        - rust: beta
-          before_script:
-              - rustup component add rustfmt
-          env: TASK=fmt-travis
 
 branches:
     only: develop


### PR DESCRIPTION
This tidies up our Travis configuration a bit:

* Removes the rustfmt beta task. This seemed like a good idea because previously rustfmt had broken its stability guarantee in a small way, but it hasn't broken it since, and running this test for every PR seems like a tremendous waste of cycles. We can always change our minds again.
* Makes beta clippy task not an allowed failure.
The intention is that usually this task will be mandatory, except immediately after a new Rust release, if it breaks. Then it will be re-allowed until addressed. This way, our code can be brought up to beta expectations and then _kept_ there.