### PR TITLE
Unify pool setup on initial setup and udev-event driven paths

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -187,8 +187,7 @@ impl StratEngine {
                 let mut devices = self
                     .incomplete_pools
                     .remove(&pool_uuid)
-                    .or_else(|| Some(HashMap::new()))
-                    .expect("We just retrieved or created a HashMap");
+                    .unwrap_or_else(HashMap::new);
                 devices.insert(device, dev_node);
                 match setup_pool(pool_uuid, &devices, &self.pools) {
                     Ok((pool_name, pool)) => {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -37,60 +37,6 @@ use crate::{
 
 const REQUIRED_DM_MINOR_VERSION: u32 = 37;
 
-/// Setup a pool from constituent devices in the context of some already
-/// setup pools. Return an error on anything that prevents the pool
-/// being set up.
-/// Precondition: every device in devices has already been determined to belong
-/// to the pool with pool_uuid.
-fn setup_pool(
-    pool_uuid: PoolUuid,
-    devices: &HashMap<Device, PathBuf>,
-    pools: &Table<StratPool>,
-) -> StratisResult<(Name, StratPool)> {
-    // FIXME: In this method, various errors are assembled from various
-    // sources and combined into strings, so that they
-    // can be printed as log messages if necessary. Instead, some kind of
-    // error-chaining should be used here and if it is necessary
-    // to log the error, the log code should be able to reduce the error
-    // chain to something that can be sensibly logged.
-    let info_string = || {
-        let dev_paths = devices
-            .values()
-            .map(|p| p.to_str().expect("Unix is utf-8"))
-            .collect::<Vec<&str>>()
-            .join(" ,");
-        format!("(pool UUID: {}, devnodes: {})", pool_uuid, dev_paths)
-    };
-
-    let (timestamp, metadata) = get_metadata(pool_uuid, devices)?.ok_or_else(|| {
-        let err_msg = format!("no metadata found for {}", info_string());
-        StratisError::Engine(ErrorEnum::NotFound, err_msg)
-    })?;
-
-    if pools.contains_name(&metadata.name) {
-        let err_msg = format!(
-            "pool with name \"{}\" set up; metadata specifies same name for {}",
-            &metadata.name,
-            info_string()
-        );
-        return Err(StratisError::Engine(ErrorEnum::AlreadyExists, err_msg));
-    }
-
-    StratPool::setup(pool_uuid, devices, timestamp, &metadata)
-        .or_else(|e| {
-            let err_msg = format!(
-                "failed to set up pool for {}: reason: {:?}",
-                info_string(),
-                e
-            );
-            Err(StratisError::Engine(ErrorEnum::Error, err_msg))
-        })
-        .and_then(|(pool_name, pool)| {
-            devlinks::setup_pool_devlinks(&pool_name, &pool);
-            Ok((pool_name, pool))
-        })
-}
-
 #[derive(Debug)]
 pub struct StratEngine {
     pools: Table<StratPool>,
@@ -146,6 +92,60 @@ impl StratEngine {
     // Given a set of devices, try to set up a pool. If the setup fails,
     // insert the devices into incomplete_pools.
     fn try_setup_pool(&mut self, pool_uuid: PoolUuid, devices: HashMap<Device, PathBuf>) {
+        /// Setup a pool from constituent devices in the context of some already
+        /// setup pools. Return an error on anything that prevents the pool
+        /// being set up.
+        /// Precondition: every device in devices has already been determined to belong
+        /// to the pool with pool_uuid.
+        fn setup_pool(
+            pool_uuid: PoolUuid,
+            devices: &HashMap<Device, PathBuf>,
+            pools: &Table<StratPool>,
+        ) -> StratisResult<(Name, StratPool)> {
+            // FIXME: In this method, various errors are assembled from various
+            // sources and combined into strings, so that they
+            // can be printed as log messages if necessary. Instead, some kind of
+            // error-chaining should be used here and if it is necessary
+            // to log the error, the log code should be able to reduce the error
+            // chain to something that can be sensibly logged.
+            let info_string = || {
+                let dev_paths = devices
+                    .values()
+                    .map(|p| p.to_str().expect("Unix is utf-8"))
+                    .collect::<Vec<&str>>()
+                    .join(" ,");
+                format!("(pool UUID: {}, devnodes: {})", pool_uuid, dev_paths)
+            };
+
+            let (timestamp, metadata) = get_metadata(pool_uuid, devices)?.ok_or_else(|| {
+                let err_msg = format!("no metadata found for {}", info_string());
+                StratisError::Engine(ErrorEnum::NotFound, err_msg)
+            })?;
+
+            if pools.contains_name(&metadata.name) {
+                let err_msg = format!(
+                    "pool with name \"{}\" set up; metadata specifies same name for {}",
+                    &metadata.name,
+                    info_string()
+                );
+                return Err(StratisError::Engine(ErrorEnum::AlreadyExists, err_msg));
+            }
+
+            StratPool::setup(pool_uuid, devices, timestamp, &metadata)
+                .or_else(|e| {
+                    let err_msg = format!(
+                        "failed to set up pool for {}: reason: {:?}",
+                        info_string(),
+                        e
+                    );
+                    Err(StratisError::Engine(ErrorEnum::Error, err_msg))
+                })
+                .and_then(|(pool_name, pool)| {
+                    devlinks::setup_pool_devlinks(&pool_name, &pool);
+                    Ok((pool_name, pool))
+                })
+        }
+
         match setup_pool(pool_uuid, &devices, &self.pools) {
             Ok((pool_name, pool)) => {
                 self.pools.insert(pool_name, pool_uuid, pool);

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -180,7 +180,7 @@ impl StratEngine {
     /// Logs a warning if the block devices appears to be a Stratis block
     /// device and no pool is set up.
     fn block_evaluate(&mut self, device: &libudev::Device) -> Option<(PoolUuid, &mut dyn Pool)> {
-        if let Some((pool_uuid, _, device, dev_node)) = identify_block_device(device) {
+        identify_block_device(device).and_then(move |(pool_uuid, _, device, dev_node)| {
             if self.pools.contains_uuid(pool_uuid) {
                 None
             } else {
@@ -207,9 +207,7 @@ impl StratEngine {
                     }
                 }
             }
-        } else {
-            None
-        }
+        })
     }
 }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -26,7 +26,7 @@ use crate::{
             devlinks,
             dm::{get_dm, get_dm_init},
             names::validate_name,
-            pool::{check_metadata, StratPool},
+            pool::StratPool,
         },
         structures::Table,
         types::{CreateAction, DeleteAction, RenameAction},
@@ -76,24 +76,14 @@ fn setup_pool(
         return Err(StratisError::Engine(ErrorEnum::AlreadyExists, err_msg));
     }
 
-    check_metadata(&metadata)
+    StratPool::setup(pool_uuid, devices, timestamp, &metadata)
         .or_else(|e| {
             let err_msg = format!(
-                "inconsistent metadata for {}: reason: {:?}",
+                "failed to set up pool for {}: reason: {:?}",
                 info_string(),
                 e
             );
             Err(StratisError::Engine(ErrorEnum::Error, err_msg))
-        })
-        .and_then(|_| {
-            StratPool::setup(pool_uuid, devices, timestamp, &metadata).or_else(|e| {
-                let err_msg = format!(
-                    "failed to set up pool for {}: reason: {:?}",
-                    info_string(),
-                    e
-                );
-                Err(StratisError::Engine(ErrorEnum::Error, err_msg))
-            })
         })
         .and_then(|(pool_name, pool)| {
             devlinks::setup_pool_devlinks(&pool_name, &pool);

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -192,19 +192,14 @@ impl StratEngine {
                 match setup_pool(pool_uuid, &devices, &self.pools) {
                     Ok((pool_name, pool)) => {
                         self.pools.insert(pool_name, pool_uuid, pool);
-                        Some((
-                            pool_uuid,
-                            self.get_mut_pool(pool_uuid)
-                                .expect("pool was just inserted")
-                                .1,
-                        ))
                     }
                     Err(err) => {
                         warn!("no pool set up, reason: {:?}", err);
                         self.incomplete_pools.insert(pool_uuid, devices);
-                        None
                     }
-                }
+                };
+                self.get_mut_pool(pool_uuid)
+                    .map(|(_, pool)| (pool_uuid, pool))
             }
         })
     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -198,8 +198,9 @@ impl StratEngine {
                         self.incomplete_pools.insert(pool_uuid, devices);
                     }
                 };
-                self.get_mut_pool(pool_uuid)
-                    .map(|(_, pool)| (pool_uuid, pool))
+                self.pools
+                    .get_mut_by_uuid(pool_uuid)
+                    .map(|(_, pool)| (pool_uuid, pool as &mut dyn Pool))
             }
         })
     }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -131,23 +131,19 @@ impl StratEngine {
                 return Err(StratisError::Engine(ErrorEnum::AlreadyExists, err_msg));
             }
 
-            StratPool::setup(pool_uuid, devices, timestamp, &metadata)
-                .or_else(|e| {
-                    let err_msg = format!(
-                        "failed to set up pool for {}: reason: {:?}",
-                        info_string(),
-                        e
-                    );
-                    Err(StratisError::Engine(ErrorEnum::Error, err_msg))
-                })
-                .and_then(|(pool_name, pool)| {
-                    devlinks::setup_pool_devlinks(&pool_name, &pool);
-                    Ok((pool_name, pool))
-                })
+            StratPool::setup(pool_uuid, devices, timestamp, &metadata).or_else(|e| {
+                let err_msg = format!(
+                    "failed to set up pool for {}: reason: {:?}",
+                    info_string(),
+                    e
+                );
+                Err(StratisError::Engine(ErrorEnum::Error, err_msg))
+            })
         }
 
         match setup_pool(pool_uuid, &devices, &self.pools) {
             Ok((pool_name, pool)) => {
+                devlinks::setup_pool_devlinks(&pool_name, &pool);
                 self.pools.insert(pool_name, pool_uuid, pool);
             }
             Err(err) => {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -161,12 +161,8 @@ impl StratEngine {
 
     /// Given a udev database entry, process the entry.
     ///
-    /// If all the devices are present in the pool and the pool isn't already
-    /// up and running, it will get setup and the newly created pool and UUID
-    /// will be returned.
-    ///
-    /// Logs a warning if the block devices appears to be a Stratis block
-    /// device and no pool is set up.
+    /// If a new pool is created as a result of the processing, return
+    /// the newly created pool and its UUID, otherwise return None.
     fn block_evaluate(&mut self, device: &libudev::Device) -> Option<(PoolUuid, &mut dyn Pool)> {
         identify_block_device(device).and_then(move |(pool_uuid, _, device, dev_node)| {
             if self.pools.contains_uuid(pool_uuid) {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -19,7 +19,7 @@ use crate::{
     engine::{
         engine::{BlockDev, Filesystem, Pool},
         strat_engine::{
-            backstore::{Backstore, MDADataSize, StratBlockDev},
+            backstore::{Backstore, MDADataSize},
             names::validate_name,
             serde_structs::{FlexDevsSave, PoolSave, Recordable},
             thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE},
@@ -271,10 +271,6 @@ impl StratPool {
             thinpool_dev: self.thin_pool.record(),
         }
     }
-
-    pub fn get_strat_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &StratBlockDev)> {
-        self.backstore.get_blockdev_by_uuid(uuid)
-    }
 }
 
 impl Pool for StratPool {
@@ -463,7 +459,8 @@ impl Pool for StratPool {
     }
 
     fn get_blockdev(&self, uuid: DevUuid) -> Option<(BlockDevTier, &dyn BlockDev)> {
-        self.get_strat_blockdev(uuid)
+        self.backstore
+            .get_blockdev_by_uuid(uuid)
             .map(|(t, b)| (t, b as &dyn BlockDev))
     }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -69,7 +69,7 @@ fn next_index(flex_devs: &FlexDevsSave) -> Sectors {
 /// Check the metadata of an individual pool for consistency.
 /// Precondition: This method is called only when setting up a pool, which
 /// ensures that the flex devs metadata lists are all non-empty.
-pub fn check_metadata(metadata: &PoolSave) -> StratisResult<()> {
+fn check_metadata(metadata: &PoolSave) -> StratisResult<()> {
     let flex_devs = &metadata.flex_devs;
     let next = next_index(flex_devs);
     let allocated_from_cap = metadata.backstore.cap.allocs[0].1;
@@ -195,6 +195,8 @@ impl StratPool {
         timestamp: DateTime<Utc>,
         metadata: &PoolSave,
     ) -> StratisResult<(Name, StratPool)> {
+        check_metadata(metadata)?;
+
         let mut backstore = Backstore::setup(uuid, &metadata.backstore, devnodes, timestamp)?;
         let mut thinpool = ThinPool::setup(
             uuid,


### PR DESCRIPTION
Related: #1659.

The two main contributions of this PR is that unifies the code for setting up the pool into a single
method rather than leaving it as two blocks of duplicated but not identical code, and that it distinguishes between failures to set up a pool that indicate that something might be wrong, and failures to set up a pool which are actually normal conditions.

It also includes a bunch of minor tidies within the code affected.

It does not include a text representation of every device involved in the error messages logged about failure to set up a pool. Doing this is definitely a convenience during development, but could seem far too verbose in the presence of production pools with possibly many devices and potentially numerous udev events.

I added #1780 as future work, and removed some related code in this PR that did not fully cover the problem described in the issue and wouldn't prevent it.

Also related: https://github.com/stratis-storage/project/issues/29, since the PR removes at least three unnecessary expects.