### PR TITLE
Make beta task mandatory again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ language: rust
 matrix:
     fast_finish: true
     allow_failures:
-        # Temporarily allow beta lint task to fail
-        - rust: beta
         # Allow audit task to fail
         - env: TASK=audit
     include:

--- a/src/dbus_api/util.rs
+++ b/src/dbus_api/util.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::error::Error;
-
 use dbus::{
     self,
     arg::{ArgType, Iter, IterAppend, RefArg, Variant},
@@ -97,7 +95,7 @@ pub fn engine_to_dbus_err_tuple(err: &StratisError) -> (u16, String) {
     };
     let description = match *err {
         StratisError::DM(DmError::Core(ref err)) => err.to_string(),
-        ref err => err.description().to_owned(),
+        ref err => err.to_string(),
     };
     (error as u16, description)
 }

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -15,6 +15,9 @@ use crate::engine::strat_engine::{
 };
 
 mod cleanup_errors {
+    // FIXME: It should be possible to remove this allow when the next
+    // version of error_chain is released.
+    #![allow(deprecated)]
     use libmount;
     use nix;
     use std;

--- a/src/stratis/errors.rs
+++ b/src/stratis/errors.rs
@@ -63,23 +63,6 @@ impl fmt::Display for StratisError {
 }
 
 impl Error for StratisError {
-    fn description(&self) -> &str {
-        match *self {
-            StratisError::Error(ref s) => s,
-            StratisError::Engine(_, ref msg) => msg,
-            StratisError::Io(ref err) => err.description(),
-            StratisError::Nix(ref err) => err.description(),
-            StratisError::Uuid(_) => "Uuid::ParseError",
-            StratisError::Utf8(ref err) => err.description(),
-            StratisError::Serde(ref err) => err.description(),
-            StratisError::DM(ref err) => err.description(),
-
-            #[cfg(feature = "dbus_enabled")]
-            StratisError::Dbus(ref err) => err.message().unwrap_or("D-Bus Error"),
-            StratisError::Udev(ref err) => Error::description(err),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             StratisError::Error(_) | StratisError::Engine(_, _) => None,


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/139.

Note that there will be a slight change in the text of error messages that are sent over the D-Bus, the constructor, which roughly corresponds to the crate which originated the error message, will also be included. 