### PR TITLE
Remove beta clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     allow_failures:
         # Allow audit task to fail
         - env: TASK=audit
+        - env: TASK=clippy
+          rust: beta
     include:
 
         # MANDATORY CHECKS USING CURRENT DEVELOPMENT COMPILER


### PR DESCRIPTION
Beta clippy should not be mandatory. There are occasionally clippy lints where the fixes do not work on our lowest supported compiler but are required by the beta clippy.

See here: https://travis-ci.org/stratis-storage/stratisd/jobs/648939084?utm_medium=notification&utm_source=github_status

Also, the original motivating beta failures: https://travis-ci.org/stratis-storage/stratisd/jobs/648913770?utm_medium=notification&utm_source=github_status