### PR TITLE
Increase lowest supported Rust toolchain to 1.41

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ matrix:
 
         # MANDATORY TESTING USING LOWEST SUPPORTED COMPILER
         - name: "run Rust unit tests on lowest supported toolchain"
-          rust: 1.40.0
+          rust: 1.41.0
           env: TASK=test
         - name: "build release on lowest supported toolchain"
-          rust: 1.40.0
+          rust: 1.41.0
           env: TASK=release
 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ versions of the compiler may disagree with the CI tasks on some points,
 so should be avoided.
 
 #### Building
-Stratisd requires Rust 1.40+ and Cargo to build. These may be available via
+Stratisd requires Rust 1.41+ and Cargo to build. These may be available via
 your distribution's package manager. If not, [Rustup](https://www.rustup.rs/)
 is available to install and update the Rust toolchain.
 Once toolchain and other dependencies are in place, run `make build` to build, and then run the


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/146