### PR TITLE
Point libcryptsetup-rs in Cargo.toml at crates.io and fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,23 +329,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.1.0"
-source = "git+https://github.com/stratis-storage/libcryptsetup-rs#1dbb88b5ec9da63e34573e6268a6a40028fbae0b"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "libcryptsetup-rs-sys 0.1.0 (git+https://github.com/stratis-storage/libcryptsetup-rs)",
+ "libcryptsetup-rs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libcryptsetup-rs-sys"
-version = "0.1.0"
-source = "git+https://github.com/stratis-storage/libcryptsetup-rs#1dbb88b5ec9da63e34573e6268a6a40028fbae0b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.53.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -391,7 +393,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "libcryptsetup-rs 0.1.0 (git+https://github.com/stratis-storage/libcryptsetup-rs)",
+ "libcryptsetup-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libmount 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "libudev 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -997,8 +999,8 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum libcryptsetup-rs 0.1.0 (git+https://github.com/stratis-storage/libcryptsetup-rs)" = "<none>"
-"checksum libcryptsetup-rs-sys 0.1.0 (git+https://github.com/stratis-storage/libcryptsetup-rs)" = "<none>"
+"checksum libcryptsetup-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0177fd0ec022a5adb247e13e3238309913c28102a811227ad5de6a55697f152"
+"checksum libcryptsetup-rs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "41ad97fd149ed999fd62201af107021dc3f0afb67610c3fb2a61f4033abd5542"
 "checksum libdbus-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc12a3bc971424edbbf7edaf6e5740483444db63aa8e23d3751ff12a30f306f0"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum libmount 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "fb5543ddc79983a086a52c23a857bd7d9965be2c25a779e0dbc0739b0871e0c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ libudev = "0.2.0"
 lazy_static = "1.4.0"
 timerfd = "1.0.0"
 itertools = "0.8.0"
-libcryptsetup-rs = "0.1.0"
+libcryptsetup-rs = "0.2.0"
 
 [dependencies.uuid]
 version = "0.7"


### PR DESCRIPTION
Supersedes #1845 