### PR TITLE
Static header offset

### DIFF
--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -213,6 +213,7 @@ pub fn initialize_devices(
         let mut f = OpenOptions::new().write(true).open(&dev_info.devnode)?;
         let bda = BDA::initialize(
             &mut f,
+            0usize,
             StratisIdentifiers::new(pool_uuid, Uuid::new_v4()),
             mda_data_size,
             BlockdevSize::new(dev_info.size.sectors()),

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -31,7 +31,7 @@ impl BDA {
     /// Initialize a blockdev with a Stratis BDA.
     pub fn initialize<F>(
         f: &mut F,
-        index: usize,
+        offset: usize,
         identifiers: StratisIdentifiers,
         mda_data_size: MDADataSize,
         blkdev_size: BlockdevSize,
@@ -47,7 +47,7 @@ impl BDA {
             initialization_time,
         );
 
-        header.write(f, index, MetadataLocation::Both)?;
+        header.write(f, offset, MetadataLocation::Both)?;
 
         let regions =
             mda::MDARegions::initialize(STATIC_HEADER_SIZE.sectors().bytes(), header.mda_size, f)?;
@@ -57,11 +57,11 @@ impl BDA {
 
     /// Load a BDA on initial setup of a device.
     /// Returns None if no BDA appears to exist.
-    pub fn load<F>(f: &mut F, index: usize) -> StratisResult<Option<BDA>>
+    pub fn load<F>(f: &mut F, offset: usize) -> StratisResult<Option<BDA>>
     where
         F: Read + Seek + SyncAll,
     {
-        let header = match StaticHeader::setup(f, index)? {
+        let header = match StaticHeader::setup(f, offset)? {
             Some(header) => header,
             None => return Ok(None),
         };

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -60,7 +60,7 @@ impl BDA {
     where
         F: Read + Seek + SyncAll,
     {
-        let header = match StaticHeader::setup(f)? {
+        let header = match StaticHeader::setup(f, 0usize)? {
             Some(header) => header,
             None => return Ok(None),
         };

--- a/src/engine/strat_engine/backstore/metadata/bda.rs
+++ b/src/engine/strat_engine/backstore/metadata/bda.rs
@@ -46,7 +46,7 @@ impl BDA {
             initialization_time,
         );
 
-        header.write(f, MetadataLocation::Both)?;
+        header.write(f, 0usize, MetadataLocation::Both)?;
 
         let regions =
             mda::MDARegions::initialize(STATIC_HEADER_SIZE.sectors().bytes(), header.mda_size, f)?;

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -186,8 +186,8 @@ impl StaticHeader {
         if which == MetadataLocation::Both || which == MetadataLocation::First {
             write_region(f, &signature_block, &zeroed)?;
         } else {
-            f.seek(SeekFrom::Start(
-                (index + bytes!(static_header_size::SIGBLOCK_REGION_SECTORS)) as u64,
+            f.seek(SeekFrom::Current(
+                (bytes!(static_header_size::SIGBLOCK_REGION_SECTORS)) as u64,
             ))?;
         }
 

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -133,30 +133,26 @@ impl StaticHeader {
         let mut buf_loc_2 = [0u8; bytes!(static_header_size::SIGBLOCK_SECTORS)];
         fn read_sector_at_offset<F>(
             f: &mut F,
-            index: usize,
             offset: usize,
             mut buf: &mut [u8],
         ) -> io::Result<()>
         where
             F: Read + Seek,
         {
-            let start_index: usize = index + offset;
-            f.seek(SeekFrom::Start(start_index as u64))
+            f.seek(SeekFrom::Start(offset as u64))
                 .and_then(|_| f.read_exact(&mut buf))
         }
 
         (
             read_sector_at_offset(
                 f,
-                bytes!(index),
-                bytes!(static_header_size::FIRST_SIGBLOCK_START_SECTORS),
+                index + bytes!(static_header_size::FIRST_SIGBLOCK_START_SECTORS),
                 &mut buf_loc_1,
             )
             .map(|_| buf_loc_1),
             read_sector_at_offset(
                 f,
-                bytes!(index),
-                bytes!(static_header_size::SECOND_SIGBLOCK_START_SECTORS),
+                index + bytes!(static_header_size::SECOND_SIGBLOCK_START_SECTORS),
                 &mut buf_loc_2,
             )
             .map(|_| buf_loc_2),

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -469,7 +469,7 @@ pub mod tests {
 
             prop_assert!(StaticHeader::setup(&mut buf, 0usize)
                          .unwrap()
-                         .map(|new_sh| new_sh == sh)
+                         .map(|new_sh| new_sh == *sh)
                          .unwrap_or(false));
 
             StaticHeader::wipe(&mut buf).unwrap();

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -187,7 +187,7 @@ impl StaticHeader {
             write_region(f, &signature_block, &zeroed)?;
         } else {
             f.seek(SeekFrom::Current(
-                (bytes!(static_header_size::SIGBLOCK_REGION_SECTORS)) as u64,
+                (bytes!(static_header_size::SIGBLOCK_REGION_SECTORS)) as i64,
             ))?;
         }
 

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -460,20 +460,20 @@ pub mod tests {
         /// Verify that Stratis buffer validates.
         /// Wipe the static header.
         /// Verify that the buffer is again unowned.
-        fn test_ownership(ref sh in static_header_strategy()) {
+        fn test_ownership(ref sh in static_header_strategy(), offset in 0..bytes!(static_header_size::STATIC_HEADER_SECTORS)){
             let buf_size = bytes!(static_header_size::STATIC_HEADER_SECTORS);
             let mut buf = Cursor::new(vec![0; buf_size]);
-            prop_assert!(StaticHeader::setup(&mut buf, 0usize).unwrap().is_none());
+            prop_assert!(StaticHeader::setup(&mut buf, offset).unwrap().is_none());
 
-            sh.write(&mut buf, 0usize, MetadataLocation::Both).unwrap();
+            sh.write(&mut buf, offset, MetadataLocation::Both).unwrap();
 
-            prop_assert!(StaticHeader::setup(&mut buf, 0usize)
+            prop_assert!(StaticHeader::setup(&mut buf, offset)
                          .unwrap()
                          .map(|new_sh| new_sh == *sh)
                          .unwrap_or(false));
 
             StaticHeader::wipe(&mut buf).unwrap();
-            prop_assert!(StaticHeader::setup(&mut buf, 0usize).unwrap().is_none());
+            prop_assert!(StaticHeader::setup(&mut buf, offset).unwrap().is_none());
         }
     }
 

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -131,23 +131,30 @@ impl StaticHeader {
         let mut buf_loc_1 = [0u8; bytes!(static_header_size::SIGBLOCK_SECTORS)];
         let mut buf_loc_2 = [0u8; bytes!(static_header_size::SIGBLOCK_SECTORS)];
 
-        fn read_sector_at_offset<F>(f: &mut F, offset: usize, mut buf: &mut [u8]) -> io::Result<()>
+        fn read_sector_at_offset<F>(
+            f: &mut F,
+            index: usize,
+            offset: usize,
+            mut buf: &mut [u8],
+        ) -> io::Result<()>
         where
             F: Read + Seek,
         {
-            f.seek(SeekFrom::Start(offset as u64))
+            f.seek(SeekFrom::Start((index + offset) as u64))
                 .and_then(|_| f.read_exact(&mut buf))
         }
 
         (
             read_sector_at_offset(
                 f,
+                bytes!(0usize),
                 bytes!(static_header_size::FIRST_SIGBLOCK_START_SECTORS),
                 &mut buf_loc_1,
             )
             .map(|_| buf_loc_1),
             read_sector_at_offset(
                 f,
+                bytes!(0usize),
                 bytes!(static_header_size::SECOND_SIGBLOCK_START_SECTORS),
                 &mut buf_loc_2,
             )

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -131,7 +131,11 @@ impl StaticHeader {
     {
         let mut buf_loc_1 = [0u8; bytes!(static_header_size::SIGBLOCK_SECTORS)];
         let mut buf_loc_2 = [0u8; bytes!(static_header_size::SIGBLOCK_SECTORS)];
-        fn read_sector_at_offset<F>(f: &mut F, offset: usize, mut buf: &mut [u8]) -> io::Result<()>
+        fn read_sector_at_offset<F>(
+            f: &mut F,
+            offset: usize,
+            mut buf: &mut [u8],
+        ) -> io::Result<()>
         where
             F: Read + Seek,
         {
@@ -319,13 +323,9 @@ impl StaticHeader {
                 }
             },
             // Copy 1 read OK, 2 resulted in an IO error
-            (Ok(buf_loc_1), Err(_)) => {
-                copy_ok_err_handling(f, index, buf_loc_1, MetadataLocation::Second)
-            }
+            (Ok(buf_loc_1), Err(_)) => copy_ok_err_handling(f, index, buf_loc_1, MetadataLocation::Second),
             // Copy 2 read OK, 1 resulted in IO Error
-            (Err(_), Ok(buf_loc_2)) => {
-                copy_ok_err_handling(f, index, buf_loc_2, MetadataLocation::First)
-            }
+            (Err(_), Ok(buf_loc_2)) => copy_ok_err_handling(f, index, buf_loc_2, MetadataLocation::First),
             (Err(_), Err(_)) => {
                 // Unable to read the device at all.
                 let err_str = "Unable to read data at sigblock locations.";

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -465,7 +465,7 @@ pub mod tests {
             let mut buf = Cursor::new(vec![0; buf_size]);
             prop_assert!(StaticHeader::setup(&mut buf, 0usize).unwrap().is_none());
 
-            sh.write(&mut buf, MetadataLocation::Both).unwrap();
+            sh.write(&mut buf, 0usize, MetadataLocation::Both).unwrap();
 
             prop_assert!(StaticHeader::setup(&mut buf, 0usize)
                          .unwrap()
@@ -532,10 +532,10 @@ pub mod tests {
             let buf_size = bytes!(static_header_size::STATIC_HEADER_SECTORS);
 
             let mut reference_buf = Cursor::new(vec![0; buf_size]);
-            sh.write(&mut reference_buf, MetadataLocation::Both).unwrap();
+            sh.write(&mut reference_buf, 0usize, MetadataLocation::Both).unwrap();
 
             let mut buf = Cursor::new(vec![0; buf_size]);
-            sh.write(&mut buf, MetadataLocation::Both).unwrap();
+            sh.write(&mut buf, 0usize, MetadataLocation::Both).unwrap();
 
             if let Some(index) = primary {
                 corrupt_byte(
@@ -616,7 +616,7 @@ pub mod tests {
 
         let mut reference_buf = Cursor::new(vec![0; buf_size]);
         sh_newer
-            .write(&mut reference_buf, MetadataLocation::Both)
+            .write(&mut reference_buf, 0usize, MetadataLocation::Both)
             .unwrap();
 
         // Test that StaticHeader::setup succeeds by writing the older
@@ -631,8 +631,8 @@ pub mod tests {
                             older_location: MetadataLocation,
                             newer_location: MetadataLocation| {
             let mut buf = Cursor::new(vec![0; buf_size]);
-            sh_older.write(&mut buf, older_location).unwrap();
-            sh_newer.write(&mut buf, newer_location).unwrap();
+            sh_older.write(&mut buf, 0usize, older_location).unwrap();
+            sh_newer.write(&mut buf, 0usize, newer_location).unwrap();
             assert_ne!(buf.get_ref(), reference_buf.get_ref());
             assert_eq!(
                 StaticHeader::setup(&mut buf, 0usize).unwrap().as_ref(),

--- a/src/engine/strat_engine/backstore/metadata/static_header.rs
+++ b/src/engine/strat_engine/backstore/metadata/static_header.rs
@@ -469,7 +469,7 @@ pub mod tests {
 
             prop_assert!(StaticHeader::setup(&mut buf, 0usize)
                          .unwrap()
-                         .map(|new_sh| new_sh.identifiers == sh.identifiers)
+                         .map(|new_sh| new_sh == sh)
                          .unwrap_or(false));
 
             StaticHeader::wipe(&mut buf).unwrap();

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -41,7 +41,7 @@ pub fn get_metadata(
     // the newest metadata.
     let mut bdas = Vec::new();
     for devnode in devnodes.values() {
-        let bda = BDA::load(&mut OpenOptions::new().read(true).open(devnode)?)?;
+        let bda = BDA::load(&mut OpenOptions::new().read(true).open(devnode)?, 0usize)?;
         if let Some(bda) = bda {
             if bda.pool_uuid() == pool_uuid {
                 bdas.push((devnode, bda));
@@ -220,7 +220,7 @@ pub fn get_blockdevs(
 
     let (mut datadevs, mut cachedevs): (Vec<StratBlockDev>, Vec<StratBlockDev>) = (vec![], vec![]);
     for (device, devnode) in devnodes {
-        let bda = BDA::load(&mut OpenOptions::new().read(true).open(devnode)?)?.ok_or_else(|| {
+        let bda = BDA::load(&mut OpenOptions::new().read(true).open(devnode)?, 0usize)?.ok_or_else(|| {
             StratisError::Engine(ErrorEnum::NotFound,
                                                  format!("Device {} with devnode {} was previously determined to belong to pool with uuid {} but no BDA was found",
                                                  device,


### PR DESCRIPTION
Related #1840 

The index variable has been added to BDA's `load` and `initialize` methods. Currently, the tests in `bda.rs `and `static_header.rs` use an index of 0, but I will expand this to test other offsets, if this looks good so far.