### PR TITLE
Use cryptsetup 2.3 instead of 2.2 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_install:
   - sudo apt-get -q update
   # cryptsetup-bin conflicts with custom built cryptsetup
   - sudo apt-get remove cryptsetup-bin
+  # Linking fails if libcryptsetup 2.2 is present - must force
+  # remove due to system dependencies
+  - sudo dpkg --purge --force-all libcryptsetup12
   - sudo apt-get install -y libargon2-0 libjson-c3
   - wget "https://github.com/jbaublitz/stratisd/raw/deb/cryptsetup_2.3.0-1_amd64.deb"
   - sudo dpkg -i ./cryptsetup_2.3.0-1_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ before_install:
   - sudo apt-get -q update
   # cryptsetup-bin conflicts with custom built cryptsetup
   - sudo apt-get remove cryptsetup-bin
-  # Linking fails if libcryptsetup 2.2 is present - must force
-  # remove due to system dependencies
-  - sudo dpkg --purge --force-all libcryptsetup12
   - sudo apt-get install -y libargon2-0 libjson-c3
   - wget "https://github.com/jbaublitz/stratisd/raw/deb/cryptsetup_2.3.0-1_amd64.deb"
   - sudo dpkg -i ./cryptsetup_2.3.0-1_amd64.deb
+  # Linking fails if libcryptsetup 2.2 is present - must force
+  # remove due to system dependencies
+  - sudo dpkg --purge --force-all libcryptsetup12
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,15 @@ addons:
 
 language: rust
 
-# Use a repository which supplies at least cryptesetup 2.2.0 which is required
-# by libcryptesetup-rs v0.1.0.
+# Use a package which supplies cryptsetup 2.3.0 which is required
+# by features added in libcryptsetup-rs that are used in stratisd.
 before_install:
-  - sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu/ eoan main"
   - sudo apt-get -q update
-  - sudo apt-get -y install libcryptsetup-dev
-
+  # cryptsetup-bin conflicts with custom built cryptsetup
+  - sudo apt-get remove cryptsetup-bin
+  - sudo apt-get install -y libargon2-0 libjson-c3
+  - wget "https://github.com/jbaublitz/stratisd/raw/deb/cryptsetup_2.3.0-1_amd64.deb"
+  - sudo dpkg -i ./cryptsetup_2.3.0-1_amd64.deb
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
Supersedes #1861 
Related to stratis-storage/project#152