### PR TITLE
beta clippy: remove redundant imports and unit return types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
     allow_failures:
         # Allow audit task to fail
         - env: TASK=audit
-        - env: TASK=clippy
-          rust: beta
     include:
 
         # MANDATORY CHECKS USING CURRENT DEVELOPMENT COMPILER

--- a/src/dbus_api/connection.rs
+++ b/src/dbus_api/connection.rs
@@ -9,7 +9,6 @@ use dbus::{
     ffidisp::{BusType, Connection, ConnectionItem, NameFlag, WatchEvent},
     tree::{MTFn, Tree},
 };
-use libc;
 
 use crate::{
     dbus_api::{

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -37,7 +37,7 @@ pub trait Filesystem: Debug {
     fn used(&self) -> StratisResult<Bytes>;
 
     /// Set dbus path associated with the Pool.
-    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();
+    fn set_dbus_path(&mut self, path: MaybeDbusPath);
 
     /// Get dbus path associated with the Pool.
     fn get_dbus_path(&self) -> &MaybeDbusPath;
@@ -61,7 +61,7 @@ pub trait BlockDev: Debug {
     fn size(&self) -> Sectors;
 
     /// Set dbus path associated with the BlockDev.
-    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();
+    fn set_dbus_path(&mut self, path: MaybeDbusPath);
 
     /// Get dbus path associated with the BlockDev.
     fn get_dbus_path(&self) -> &MaybeDbusPath;
@@ -178,7 +178,7 @@ pub trait Pool: Debug {
     ) -> StratisResult<RenameAction<DevUuid>>;
 
     /// Set dbus path associated with the Pool.
-    fn set_dbus_path(&mut self, path: MaybeDbusPath) -> ();
+    fn set_dbus_path(&mut self, path: MaybeDbusPath);
 
     /// Get dbus path associated with the Pool.
     fn get_dbus_path(&self) -> &MaybeDbusPath;

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -4,8 +4,6 @@
 
 use chrono::{DateTime, Utc};
 
-use rand;
-
 use std::path::PathBuf;
 
 use devicemapper::Bytes;

--- a/src/engine/strat_engine/backstore/identify.rs
+++ b/src/engine/strat_engine/backstore/identify.rs
@@ -48,8 +48,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use libudev;
-
 use devicemapper::Device;
 
 use crate::engine::{

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use serde_json;
 
 use devicemapper::{Device, Sectors};
 

--- a/src/engine/strat_engine/backstore/udev.rs
+++ b/src/engine/strat_engine/backstore/udev.rs
@@ -5,8 +5,6 @@
 //! udev-related methods
 use std::{ffi::OsStr, fmt, path::Path};
 
-use libudev;
-
 use crate::stratis::{StratisError, StratisResult};
 
 /// Make an enumerator for enumerating block devices. Return an error if there

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -8,8 +8,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use libudev;
-
 use devicemapper::{Device, DmNameBuf};
 
 #[cfg(test)]

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use serde_json;
 use uuid::Uuid;
 
 use devicemapper::{Device, DmName, DmNameBuf, Sectors};
@@ -525,7 +524,6 @@ mod tests {
     };
 
     use nix::mount::{mount, umount, MsFlags};
-    use tempfile;
 
     use devicemapper::{Bytes, IEC, SECTOR_SIZE};
 

--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -10,8 +10,6 @@ use std::{
 };
 
 use loopdev::{LoopControl, LoopDevice};
-use nix;
-use tempfile;
 
 use devicemapper::{Bytes, Sectors, IEC};
 

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -4,7 +4,6 @@
 
 use std::{fs::File, io::Read, path::PathBuf};
 
-use libmount;
 use nix::mount::{umount2, MntFlags};
 
 use devicemapper::{DevId, DmOptions};
@@ -18,9 +17,6 @@ mod cleanup_errors {
     // FIXME: It should be possible to remove this allow when the next
     // version of error_chain is released.
     #![allow(deprecated)]
-    use libmount;
-    use nix;
-    use std;
 
     error_chain! {
         foreign_links {

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -17,12 +17,10 @@ use devicemapper::{
     Bytes, DmDevice, DmName, DmUuid, Sectors, ThinDev, ThinDevId, ThinPoolDev, ThinStatus, IEC,
 };
 
-use libmount;
 use nix::{
     mount::{mount, umount, MsFlags},
     sys::statvfs::statvfs,
 };
-use tempfile;
 
 use crate::{
     engine::{

--- a/src/engine/strat_engine/thinpool/mdv.rs
+++ b/src/engine/strat_engine/thinpool/mdv.rs
@@ -15,7 +15,6 @@ use nix::{
     self,
     mount::{mount, umount, MsFlags},
 };
-use serde_json;
 
 use devicemapper::{DmDevice, LinearDev, LinearDevTargetParams, TargetLine};
 

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1238,7 +1238,6 @@ mod tests {
     };
 
     use nix::mount::{mount, umount, MsFlags};
-    use tempfile;
     use uuid::Uuid;
 
     use devicemapper::{Bytes, SECTOR_SIZE};

--- a/src/engine/structures.rs
+++ b/src/engine/structures.rs
@@ -267,7 +267,6 @@ impl<T> Table<T> {
 #[cfg(test)]
 mod tests {
 
-    use rand;
     use uuid::Uuid;
 
     use crate::engine::Name;

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -9,8 +9,6 @@ pub use crate::engine::types::actions::{
     CreateAction, DeleteAction, EngineAction, RenameAction, SetCreateAction, SetDeleteAction,
 };
 
-#[cfg(feature = "dbus_enabled")]
-use dbus;
 use uuid::Uuid;
 
 pub type DevUuid = Uuid;

--- a/src/stratis/errors.rs
+++ b/src/stratis/errors.rs
@@ -4,15 +4,6 @@
 
 use std::{error::Error, fmt, io, str};
 
-#[cfg(feature = "dbus_enabled")]
-use dbus;
-use libudev;
-use nix;
-use serde_json;
-use uuid;
-
-use devicemapper;
-
 pub type StratisResult<T> = Result<T, StratisError>;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Supersedes: #1883
Related: https://github.com/stratis-storage/project/issues/155