### PR TITLE
More udev test tidies

### DIFF
--- a/tests/client-dbus/tests/udev/_loopback.py
+++ b/tests/client-dbus/tests/udev/_loopback.py
@@ -118,8 +118,11 @@ class LoopBackDevices:
         :param token: Opaque representation of some loop back device
         :return: Full file path or None if not currently attached
         :raises: KeyError if token is unknown
+        :raises: AssertionError if devnode is None
         """
-        return self.devices[token][0]
+        devnode, _ = self.devices[token]
+        assert devnode is not None
+        return devnode
 
     def destroy_devices(self):
         """

--- a/tests/client-dbus/tests/udev/_loopback.py
+++ b/tests/client-dbus/tests/udev/_loopback.py
@@ -117,8 +117,9 @@ class LoopBackDevices:
         Return the block device full name for a loopback token
         :param token: Opaque representation of some loop back device
         :return: Full file path or None if not currently attached
+        :raises: KeyError if token is unknown
         """
-        return self.devices[token][0] if token in self.devices else None
+        return self.devices[token][0]
 
     def destroy_devices(self):
         """

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -129,7 +129,7 @@ def _dump_state(context, expected_paths):
 
     print("Udev db dump of all block devices")
     for d in context.list_devices(subsystem="block"):
-        for k, v in d.items():
+        for k, v in d.properties.items():
             print("%s:%s" % (k, str(v)))
         print("")
 

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -57,39 +57,134 @@ def rs(l):
     )
 
 
+def _create_pool(name, devices):
+    """
+    Creates a stratis pool. Tries three times before giving up.
+    Raises an assertion error if it does not succeed after three tries.
+    :param name:    Name of pool
+    :param devices:  Devices to use for pool
+    :return: Dbus proxy object representing pool.
+    """
+    error_reasons = []
+    for _ in range(3):
+        ((_, (pool_object_path, _)), exit_code, error_str) = Manager.Methods.CreatePool(
+            get_object(TOP_OBJECT),
+            {"name": name, "redundancy": (True, 0), "devices": devices},
+        )
+        if exit_code == StratisdErrors.OK:
+            return get_object(pool_object_path)
+
+        error_reasons.append(error_str)
+        time.sleep(1)
+
+    raise AssertionError(
+        "Unable to create a pool %s %s reasons: %s" % (name, devices, error_reasons)
+    )
+
+
+def _get_pools(name=None):
+    """
+    Returns a list of all pools found by GetManagedObjects, or a list
+    of pools with names matching the specified name, if passed.
+    :param name: filter for pool name
+    :type name: str or NoneType
+    :return: list of pool information found
+    :rtype: list of (str * dict)
+    """
+    managed_objects = ObjectManager.Methods.GetManagedObjects(
+        get_object(TOP_OBJECT), {}
+    )
+
+    return list(
+        pools(props={} if name is None else {"Name": name}).search(managed_objects)
+    )
+
+
+def _settle():
+    """
+    Wait some amount and then call udevadm settle.
+    :return: None
+    """
+    time.sleep(2)
+    subprocess.check_call(["udevadm", "settle"])
+
+
+def _dump_state(context, expected_paths):
+    """
+    Dump everything we can when we are missing stratis devices!
+    :param context:  udev context
+    :param expected_paths: list of devices which we know should have
+           signatures
+    :return: None
+    """
+    print("We expect Stratis signatures on %d device(s)" % len(expected_paths))
+    for d in expected_paths:
+        signature = stratis_signature(d)
+        print("%s shows signature check of %s" % (d, signature))
+
+        if signature is None:
+            # We are really expecting this device to have the signature
+            # lets dump the signature area of the disk
+            dump_stratis_signature_area(d)
+
+    print("Udev db dump of all block devices")
+    for d in context.list_devices(subsystem="block"):
+        for k, v in d.items():
+            print("%s:%s" % (k, str(v)))
+        print("")
+
+
+def _expected_stratis_block_devices(expected_paths):
+    """
+    Look for Stratis devices. Check as many times as can be done in
+    10 seconds or until the number of devices found equals the number
+    of devices expected. Always get the result of at least 1 Stratis
+    enumeration.
+    :param expected_paths: devnodes of paths that should belong to Stratis
+    :type expected_paths: list of str
+    :return: None (May assert)
+    """
+
+    num_expected = len(expected_paths)
+
+    found = None
+    context = pyudev.Context()
+    end_time = time.time() + 10.0
+
+    while time.time() < end_time and found != num_expected:
+        found = sum(
+            1 for _ in context.list_devices(subsystem="block", ID_FS_TYPE="stratis")
+        )
+        time.sleep(1)
+
+    if found != num_expected:
+        _dump_state(context, expected_paths)
+
+    assert found == num_expected
+
+
+def _process_exists(name):
+    """
+    Look through processes, using their pids, to find one matching 'name'.
+    Return None if no such process found, else return the pid.
+    :param name: name of process to check
+    :type name: str
+    :return: pid or None
+    :rtype: int or NoneType
+    """
+    for proc in psutil.process_iter(["name"]):
+        try:
+            if proc.name() == name:
+                return proc.pid
+        except psutil.NoSuchProcess:
+            pass
+    return None
+
+
 class UdevAdd(unittest.TestCase):
     """
     Test udev add event support.
     """
-
-    @staticmethod
-    def _create_pool(name, devices):
-        """
-        Creates a stratis pool. Tries three times before giving up.
-        Raises an assertion error if it does not succeed after three tries.
-        :param name:    Name of pool
-        :param devices:  Devices to use for pool
-        :return: Dbus proxy object representing pool.
-        """
-        error_reasons = []
-        for _ in range(3):
-            (
-                (_, (pool_object_path, _)),
-                exit_code,
-                error_str,
-            ) = Manager.Methods.CreatePool(
-                get_object(TOP_OBJECT),
-                {"name": name, "redundancy": (True, 0), "devices": devices},
-            )
-            if exit_code == StratisdErrors.OK:
-                return get_object(pool_object_path)
-
-            error_reasons.append(error_str)
-            time.sleep(1)
-
-        raise AssertionError(
-            "Unable to create a pool %s %s reasons: %s" % (name, devices, error_reasons)
-        )
 
     def _device_files(self, tokens):
         """
@@ -113,21 +208,6 @@ class UdevAdd(unittest.TestCase):
         self._stop_service_remove_dm_tables()
         self._lb_mgr.destroy_all()
 
-    @staticmethod
-    def _get_pools(name=None):
-        """
-        Returns a list of the pools or a list with 1 element if name is set and
-        found, else empty list
-        :param name: Optional filter for pool name
-        :return:
-        """
-        managed_objects = ObjectManager.Methods.GetManagedObjects(
-            get_object(TOP_OBJECT), {}
-        )
-
-        selector = {} if name is None else {"Name": name}
-        return list(pools(props=selector).search(managed_objects))
-
     def _start_service(self):
         """
         Starts the stratisd service if it is not already started. Verifies
@@ -137,9 +217,9 @@ class UdevAdd(unittest.TestCase):
         """
 
         if getattr(self, "_service", None) is None:
-            self._settle()
+            _settle()
 
-            assert UdevAdd._process_exists("stratisd") is None
+            assert _process_exists("stratisd") is None
             assert _get_stratis_devices() == []
 
             self._service = subprocess.Popen(  # pylint: disable=attribute-defined-outside-init
@@ -180,88 +260,7 @@ class UdevAdd(unittest.TestCase):
         remove_stratis_setup()
 
         assert _get_stratis_devices() == []
-        assert UdevAdd._process_exists("stratisd") is None
-
-    @staticmethod
-    def _settle():
-        """
-        Wait some amount and then call udevadm settle.
-        :return: None
-        """
-        time.sleep(2)
-        subprocess.check_call(["udevadm", "settle"])
-
-    @staticmethod
-    def dump_state(context, expected_paths):
-        """
-        Dump everything we can when we are missing stratis devices!
-        :param context:  udev context
-        :param expected_paths: list of devices which we know should have
-               signatures
-        :return: None
-        """
-        print("We expect Stratis signatures on %d device(s)" % len(expected_paths))
-        for d in expected_paths:
-            signature = stratis_signature(d)
-            print("%s shows signature check of %s" % (d, signature))
-
-            if signature is None:
-                # We are really expecting this device to have the signature
-                # lets dump the signature area of the disk
-                dump_stratis_signature_area(d)
-
-        print("Udev db dump of all block devices")
-        for d in context.list_devices(subsystem="block"):
-            for k, v in d.items():
-                print("%s:%s" % (k, str(v)))
-            print("")
-
-    @staticmethod
-    def _expected_stratis_block_devices(expected_paths):
-        """
-        Look for Stratis devices. Check as many times as can be done in
-        10 seconds or until the number of devices found equals the number
-        of devices expected. Always get the result of at least 1 Stratis
-        enumeration.
-        :param expected_paths: devnodes of paths that should belong to Stratis
-        :type expected_paths: list of str
-        :return: None (May assert)
-        """
-
-        num_expected = len(expected_paths)
-
-        found = None
-        context = pyudev.Context()
-        end_time = time.time() + 10.0
-
-        while time.time() < end_time and found != num_expected:
-            found = sum(
-                1 for _ in context.list_devices(subsystem="block", ID_FS_TYPE="stratis")
-            )
-            time.sleep(1)
-
-        if found != num_expected:
-            UdevAdd.dump_state(context, expected_paths)
-
-        assert found == num_expected
-
-    @staticmethod
-    def _process_exists(name):
-        """
-        Look through processes, using their pids, to find one matching 'name'.
-        Return None if no such process found, else return the pid.
-        :param name: name of process to check
-        :type name: str
-        :return: pid or None
-        :rtype: int or NoneType
-        """
-        for proc in psutil.process_iter(["name"]):
-            try:
-                if proc.name() == name:
-                    return proc.pid
-            except psutil.NoSuchProcess:
-                pass
-        return None
+        assert _process_exists("stratisd") is None
 
     def _test_driver(  # pylint: disable=bad-continuation
         self, number_of_pools, dev_count_pool, some_existing=False
@@ -301,33 +300,33 @@ class UdevAdd(unittest.TestCase):
             device_tokens = [
                 self._lb_mgr.create_device() for _ in range(dev_count_pool)
             ]
-            self._settle()
+            _settle()
 
             pool_name = rs(5)
             devnodes = self._device_files(device_tokens)
 
-            UdevAdd._create_pool(pool_name, devnodes)
+            _create_pool(pool_name, devnodes)
             pool_data[pool_name] = device_tokens
             expected_stratis_devices.extend(devnodes)
 
         self._stop_service_remove_dm_tables()
 
-        UdevAdd._expected_stratis_block_devices(expected_stratis_devices)
+        _expected_stratis_block_devices(expected_stratis_devices)
 
         self._start_service()
 
-        self.assertEqual(len(UdevAdd._get_pools()), number_of_pools)
+        self.assertEqual(len(_get_pools()), number_of_pools)
 
         self._stop_service_remove_dm_tables()
 
         for d in (d for device_tokens in pool_data.values() for d in device_tokens):
             self._lb_mgr.unplug(d)
 
-        UdevAdd._expected_stratis_block_devices([])
+        _expected_stratis_block_devices([])
 
         self._start_service()
 
-        self.assertEqual(len(UdevAdd._get_pools()), 0)
+        self.assertEqual(len(_get_pools()), 0)
 
         # Add all but the last device for each pool
         running_devices = []
@@ -336,26 +335,26 @@ class UdevAdd(unittest.TestCase):
                 device_token = devices[i]
                 self._lb_mgr.hotplug(device_token)
                 running_devices.extend(self._device_files([device_token]))
-                UdevAdd._expected_stratis_block_devices(running_devices)
+                _expected_stratis_block_devices(running_devices)
 
             if some_existing:
                 self._stop_service_remove_dm_tables()
                 self._start_service()
             else:
-                self._settle()
+                _settle()
 
-        self.assertEqual(len(UdevAdd._get_pools()), 0)
+        self.assertEqual(len(_get_pools()), 0)
 
         # Add the last device that makes each pool complete
         last_index = dev_count_pool - 1
         for _, devices in pool_data.items():
             self._lb_mgr.hotplug(devices[last_index])
 
-        self._settle()
-        self.assertEqual(len(UdevAdd._get_pools()), number_of_pools)
+        _settle()
+        self.assertEqual(len(_get_pools()), number_of_pools)
 
         for pn in pool_data:
-            self.assertEqual(len(self._get_pools(pn)), 1)
+            self.assertEqual(len(_get_pools(pn)), 1)
 
     def test_no_stops(self):
         """
@@ -391,51 +390,51 @@ class UdevAdd(unittest.TestCase):
         :return: None
         """
         self._start_service()
-        self.assertEqual(len(UdevAdd._get_pools()), 0)
+        self.assertEqual(len(_get_pools()), 0)
 
         device_tokens = [self._lb_mgr.create_device() for _ in range(num_devices)]
         devnodes = self._device_files(device_tokens)
 
-        self._settle()
+        _settle()
 
         pool_name = rs(5)
-        UdevAdd._create_pool(pool_name, devnodes)
-        self.assertEqual(len(UdevAdd._get_pools()), 1)
+        _create_pool(pool_name, devnodes)
+        self.assertEqual(len(_get_pools()), 1)
 
         self._stop_service_remove_dm_tables()
 
-        UdevAdd._expected_stratis_block_devices(devnodes)
+        _expected_stratis_block_devices(devnodes)
 
         self._start_service()
 
-        self.assertEqual(len(UdevAdd._get_pools()), 1)
+        self.assertEqual(len(_get_pools()), 1)
 
         self._stop_service_remove_dm_tables()
 
         for d in device_tokens:
             self._lb_mgr.unplug(d)
-        UdevAdd._expected_stratis_block_devices([])
+        _expected_stratis_block_devices([])
 
         self._start_service()
 
-        self.assertEqual(len(UdevAdd._get_pools()), 0)
+        self.assertEqual(len(_get_pools()), 0)
 
         for d in device_tokens:
             self._lb_mgr.hotplug(d)
 
-        self._settle()
-        UdevAdd._expected_stratis_block_devices(devnodes)
+        _settle()
+        _expected_stratis_block_devices(devnodes)
 
-        self.assertEqual(len(UdevAdd._get_pools()), 1)
+        self.assertEqual(len(_get_pools()), 1)
 
         for _ in range(num_hotplugs):
             for d in device_tokens:
                 self._lb_mgr.generate_udev_add_event(d)
 
-        self._settle()
-        UdevAdd._expected_stratis_block_devices(devnodes)
+        _settle()
+        _expected_stratis_block_devices(devnodes)
 
-        self.assertEqual(len(UdevAdd._get_pools()), 1)
+        self.assertEqual(len(_get_pools()), 1)
 
     def test_simultaneous(self):
         """
@@ -475,20 +474,20 @@ class UdevAdd(unittest.TestCase):
 
             this_pool = [self._lb_mgr.create_device() for _ in range(i + 1)]
 
-            self._settle()
+            _settle()
 
             pool_tokens.append(this_pool)
             devices = self._device_files(this_pool)
-            UdevAdd._create_pool(pool_name, devices)
+            _create_pool(pool_name, devices)
 
             self._stop_service_remove_dm_tables()
 
-            UdevAdd._expected_stratis_block_devices(devices)
+            _expected_stratis_block_devices(devices)
 
             for d in this_pool:
                 self._lb_mgr.unplug(d)
 
-            UdevAdd._expected_stratis_block_devices([])
+            _expected_stratis_block_devices([])
 
         self._start_service()
 
@@ -500,18 +499,18 @@ class UdevAdd(unittest.TestCase):
                 self._lb_mgr.hotplug(d)
                 devices_plugged.extend(self._device_files([d]))
 
-            self._settle()
-            UdevAdd._expected_stratis_block_devices(devices_plugged)
+            _settle()
+            _expected_stratis_block_devices(devices_plugged)
 
             # The number of pools should never exceed one, since all the pools
             # previously formed in the test have the same name.
-            self.assertEqual(len(UdevAdd._get_pools()), 1)
+            self.assertEqual(len(_get_pools()), 1)
 
         # Dynamically rename all active pools to a randomly chosen name,
         # then generate synthetic add events for every loopbacked device.
         # After num_pools - 1 iterations, all pools should have been set up.
         for _ in range(num_pools - 1):
-            current_pools = UdevAdd._get_pools()
+            current_pools = _get_pools()
 
             # Rename all active pools to a randomly selected new name
             for object_path, _ in current_pools:
@@ -521,8 +520,8 @@ class UdevAdd(unittest.TestCase):
             for d in (d for sublist in pool_tokens for d in sublist):
                 self._lb_mgr.generate_udev_add_event(d)
 
-            self._settle()
-            UdevAdd._expected_stratis_block_devices(devices_plugged)
-            self.assertEqual(len(UdevAdd._get_pools()), len(current_pools) + 1)
+            _settle()
+            _expected_stratis_block_devices(devices_plugged)
+            self.assertEqual(len(_get_pools()), len(current_pools) + 1)
 
-        self.assertEqual(len(UdevAdd._get_pools()), num_pools)
+        self.assertEqual(len(_get_pools()), num_pools)


### PR DESCRIPTION
This does not yet display stratisd log entries, because most likely some of the work for that needs to be done on stratisd itself, not just the tests:

The contributions of this PR are:
* It moves support code out of the test class, and into the containing module. This means that fewer methods take self as an argument unnecessarily, and that only test methods are in the test class.
* It changes the behavior of LoopBackDevices.device_file so that it raises some kind of exception if there is no device file. Previously, it returned None, in both cases. In both cases, this was a mistake.
* It removes some deprecated pyudev usage. This usage was deprecated just one release, but also 4 years ago. High time to drop it, especially since it floods the test output with deprecation warnings whenever there is a failure.
* It uses a context manager for starting and stopping the daemon. This helps clarify the test code; and is likely to make the eventual displaying of the logs easier.

Related: #1855.