### PR TITLE
Remove process_unowned_devices

### DIFF
--- a/src/engine/strat_engine/backstore/identify.rs
+++ b/src/engine/strat_engine/backstore/identify.rs
@@ -35,12 +35,8 @@
 //! in general, general purpose methods that can be used in any situation.
 //!
 //! find_all is public because it is the method that is invoked by the
-//! engine on startup. find_all_block_devices_with_stratis_signatures is
-//! public for use in testing. identify_block_device is public because it
-//! is suitable for identifying a block device associated with a uevent,
-//! as the situation in which the uevent is handled is equivalent to that
-//! provided by the execution of the
-//! find_all_block_devices_with_stratis_signatures method.
+//! engine on startup. identify_block_device is public because it
+//! is suitable for identifying a block device associated with a uevent.
 
 use std::{
     collections::HashMap,
@@ -171,27 +167,6 @@ fn process_unowned_device(dev: &libudev::Device) -> Option<StratisInfo> {
             None
         }
     }
-}
-
-// Use udev to identify all block devices and return the subset of those
-// that have Stratis signatures.
-#[cfg(test)]
-pub fn find_all_block_devices_with_stratis_signatures(
-) -> libudev::Result<HashMap<PoolUuid, HashMap<Device, PathBuf>>> {
-    let context = libudev::Context::new()?;
-    let mut enumerator = block_enumerator(&context)?;
-
-    let pool_map = enumerator
-        .scan_devices()?
-        .filter_map(|dev| identify_block_device(&dev))
-        .fold(HashMap::new(), |mut acc, (identifiers, device, devnode)| {
-            acc.entry(identifiers.pool_uuid)
-                .or_insert_with(HashMap::new)
-                .insert(device, devnode);
-            acc
-        });
-
-    Ok(pool_map)
 }
 
 // Find all devices identified by udev as Stratis devices.

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -26,4 +26,4 @@ pub use self::{
 };
 
 #[cfg(test)]
-pub use self::{crypt::STRATIS_KEY_SIZE, identify::find_all_block_devices_with_stratis_signatures};
+pub use self::crypt::STRATIS_KEY_SIZE;


### PR DESCRIPTION
Related: #1656
Related: #1782

Also removes find_all_block_devices_with_stratis_signatures, a method used only for testing. In one case, a test was removed. For all other tests, a different mechanism for getting the necessary information was used. find_all_block_devices_with_stratis_signatures depended transitively on process_unowned_devices, and failed to find all devices if the use in identify_block_device was removed. The use in tests was the only reason to retain process_unowned_devices; at this point it can be removed entirely.