### PR TITLE
Remove unnecessary cfg directives

### DIFF
--- a/src/engine/strat_engine/backstore/crypt.rs
+++ b/src/engine/strat_engine/backstore/crypt.rs
@@ -133,9 +133,6 @@ impl CryptInitializer {
             device.keyslot_handle().add_by_key(
                 None,
                 None,
-                #[cfg(cryptsetup_compat)]
-                (*key).deref(),
-                #[cfg(not(cryptsetup_compat))]
                 key.as_ref(),
                 CryptVolumeKeyFlags::empty(),
             ),


### PR DESCRIPTION
Related #1908 

When removing the theoretical cryptsetup 2.2 support, this seems to have
made it into the codebase anyway. Remove as it is now unnecessary.