### PR TITLE
Extend udev tests for encryption

### DIFF
--- a/tests/client-dbus/Makefile
+++ b/tests/client-dbus/Makefile
@@ -25,7 +25,7 @@ fmt-travis:
 
 .PHONY: udev-tests
 udev-tests:
-	py.test-3 ${PYTEST_OPTS} -s ./tests/udev
+	python3 -m unittest discover --verbose tests.udev
 
 .PHONY: tests
 tests: dbus-tests misc-tests udev-tests

--- a/tests/client-dbus/tests/udev/_loopback.py
+++ b/tests/client-dbus/tests/udev/_loopback.py
@@ -41,65 +41,80 @@ class LoopBackDevices:
         self.count = 0
         self.devices = {}
 
-    def create_device(self):
+    def create_devices(self, number):
         """
-        Create a new loop back device, sparse backing file and attaching it.
+        Create new loop back devices.
 
         Note: The first time a loop back device is known it will generate
         a udev "add" event, subsequent backing file changes do not, thus we
         will need to generate it synthetically.
-        :return: opaque handle, done as device representing block device will
-                 change.
+        :param int number: the number of devices to create
+        :return: list of keys for the devices
+        :rtype: list of uuid.UUID
         """
-        backing_file = os.path.join(self.dir, "block_device_%d" % self.count)
-        self.count += 1
+        tokens = []
+        for _ in range(number):
+            backing_file = os.path.join(self.dir, "block_device_%d" % self.count)
+            self.count += 1
 
-        with open(backing_file, "ab") as dev:
-            dev.truncate(_SIZE_OF_DEVICE)
+            with open(backing_file, "ab") as dev:
+                dev.truncate(_SIZE_OF_DEVICE)
 
-        device = str.strip(
-            subprocess.check_output(
-                [_LOSETUP_BIN, "-f", "--show", backing_file]
-            ).decode("utf-8")
-        )
+            device = str.strip(
+                subprocess.check_output(
+                    [_LOSETUP_BIN, "-f", "--show", backing_file]
+                ).decode("utf-8")
+            )
 
-        token = uuid.uuid4()
-        self.devices[token] = (device, backing_file)
-        return token
+            token = uuid.uuid4()
+            self.devices[token] = (device, backing_file)
+            tokens.append(token)
 
-    def unplug(self, token):
+        return tokens
+
+    def unplug(self, tokens):
         """
-        Remove the device from the /dev tree, but doesn't remove backing file
-        :param token: Opaque representation of some loop back device
+        Remove the devices from the /dev tree, but doesn't remove backing file
+        :param tokens: Opaque representation of some loop back devices
+        :type tokens: list of uuid.UUID
         :return: None
+        :raises: AssertionError if any token not found
         """
-        if token in self.devices:
+        assert all(token in self.devices for token in tokens)
+        for token in tokens:
             (device, backing_file) = self.devices[token]
             subprocess.check_call([_LOSETUP_BIN, "-d", device])
             self.devices[token] = (None, backing_file)
 
-    def generate_udev_add_event(self, token):
+    def generate_udev_add_events(self, tokens):
         """
-        Synthetically create "add" udev event for this loop back device
-        :param token: Opaque representation of some loop back device
+        Synthetically create "add" udev event for specified loop back deviced
+        :param tokens: Opaque representation of some loop back devices
+        :type tokens: list of uuid.UUID
         :return: None
+        :raises AssertionError: if any token not found or missing device node
         """
-        if token in self.devices:
+        assert all(token in self.devices for token in tokens)
+        for token in tokens:
             (device, _) = self.devices[token]
 
-            if device is not None:
-                device_name = os.path.split(device)[-1]
-                ufile = os.path.join("/sys/block", device_name, "uevent")
-                with open(ufile, "w") as event:
-                    event.write("add")
+            assert device is not None
 
-    def hotplug(self, token):
+            device_name = os.path.split(device)[-1]
+            ufile = os.path.join("/sys/block", device_name, "uevent")
+            with open(ufile, "w") as event:
+                event.write("add")
+
+    def hotplug(self, tokens):
         """
-        Attaches an existing backing file to a loop back device
-        :param token: Opaque representation of some loop back device
+        Attaches an existing backing file to specified loop back devices
+        :param tokens: Opaque representation of some loop back devices
+        :type tokens: list of uuid.UUID
         :return: None
+        :raise AssertionError: if token not present
         """
-        if token in self.devices:
+        assert all(token in self.devices for token in tokens)
+        for token in tokens:
             (_, backing_file) = self.devices[token]
 
             device = str.strip(
@@ -109,20 +124,21 @@ class LoopBackDevices:
             )
             self.devices[token] = (device, backing_file)
 
-            # Make sure an add occurs
-            self.generate_udev_add_event(token)
+        self.generate_udev_add_events(tokens)
 
-    def device_file(self, token):
+    def device_files(self, tokens):
         """
-        Return the block device full name for a loopback token
-        :param token: Opaque representation of some loop back device
-        :return: Full file path or None if not currently attached
-        :raises: KeyError if token is unknown
-        :raises: AssertionError if devnode is None
+        Return the block device full names for a list of tokens
+        :param tokens: Opaque representation of some loop back devices
+        :type tokens: list of uuid.UUID
+        :return: The list devices corresponding to the tokens
+        :rtype: list of str
+        :raises: KeyError if any token is not found
+        :raises: AssertionError if any devnode is None
         """
-        devnode, _ = self.devices[token]
-        assert devnode is not None
-        return devnode
+        result = [self.devices[token][0] for token in tokens]
+        assert all([devnode is not None for devnode in result])
+        return result
 
     def destroy_devices(self):
         """

--- a/tests/client-dbus/tests/udev/_loopback.py
+++ b/tests/client-dbus/tests/udev/_loopback.py
@@ -88,7 +88,7 @@ class LoopBackDevices:
 
     def generate_udev_add_events(self, tokens):
         """
-        Synthetically create "add" udev event for specified loop back deviced
+        Synthetically create "add" udev event for specified loop back devices
         :param tokens: Opaque representation of some loop back devices
         :type tokens: list of uuid.UUID
         :return: None

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -510,6 +510,14 @@ class UdevAdd(unittest.TestCase):
         """
         self._single_pool(1, num_hotplugs=1)
 
+    @unittest.expectedFailure
+    def test_encryption(self):
+        """
+        See documentation for _single_pool.
+        """
+        with _KernelKey("test_key") as key_description:
+            self._single_pool(1, key_description=key_description)
+
     def test_duplicate_pool_name(self):
         """
         Create more than one pool with the same name, then dynamically fix it

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -110,7 +110,7 @@ def _settle():
     subprocess.check_call(["udevadm", "settle"])
 
 
-def _expected_stratis_block_devices(expected_paths):
+def _wait_for_udev(expected_paths):
     """
     Look for Stratis devices. Check as many times as can be done in
     10 seconds or until the number of devices found equals the number
@@ -305,7 +305,7 @@ class UdevAdd(unittest.TestCase):
                 pool_data[pool_name] = device_tokens
                 expected_stratis_devices.extend(devnodes)
 
-        _expected_stratis_block_devices(expected_stratis_devices)
+        _wait_for_udev(expected_stratis_devices)
 
         with _ServiceContextManager():
             self.assertEqual(len(_get_pools()), number_of_pools)
@@ -315,7 +315,7 @@ class UdevAdd(unittest.TestCase):
         ):
             self._lb_mgr.unplug(dev)
 
-        _expected_stratis_block_devices([])
+        _wait_for_udev([])
 
         last_index = dev_count_pool - 1
         with _ServiceContextManager():
@@ -328,7 +328,7 @@ class UdevAdd(unittest.TestCase):
                     device_token = devices[i]
                     self._lb_mgr.hotplug(device_token)
                     running_devices.append(self._lb_mgr.device_file(device_token))
-                    _expected_stratis_block_devices(running_devices)
+                    _wait_for_udev(running_devices)
                     _settle()
 
             self.assertEqual(len(_get_pools()), 0)
@@ -384,7 +384,7 @@ class UdevAdd(unittest.TestCase):
             _create_pool(pool_name, devnodes)
             self.assertEqual(len(_get_pools()), 1)
 
-        _expected_stratis_block_devices(devnodes)
+        _wait_for_udev(devnodes)
 
         with _ServiceContextManager():
             self.assertEqual(len(_get_pools()), 1)
@@ -392,7 +392,7 @@ class UdevAdd(unittest.TestCase):
         for dev in device_tokens:
             self._lb_mgr.unplug(dev)
 
-        _expected_stratis_block_devices([])
+        _wait_for_udev([])
 
         with _ServiceContextManager():
             self.assertEqual(len(_get_pools()), 0)
@@ -401,7 +401,7 @@ class UdevAdd(unittest.TestCase):
                 self._lb_mgr.hotplug(dev)
 
             _settle()
-            _expected_stratis_block_devices(devnodes)
+            _wait_for_udev(devnodes)
 
             self.assertEqual(len(_get_pools()), 1)
 
@@ -410,7 +410,7 @@ class UdevAdd(unittest.TestCase):
                     self._lb_mgr.generate_udev_add_event(dev)
 
             _settle()
-            _expected_stratis_block_devices(devnodes)
+            _wait_for_udev(devnodes)
 
             self.assertEqual(len(_get_pools()), 1)
 
@@ -452,12 +452,12 @@ class UdevAdd(unittest.TestCase):
             with _ServiceContextManager():
                 _create_pool(pool_name, devices)
 
-            _expected_stratis_block_devices(devices)
+            _wait_for_udev(devices)
 
             for dev in this_pool:
                 self._lb_mgr.unplug(dev)
 
-            _expected_stratis_block_devices([])
+            _wait_for_udev([])
 
         with _ServiceContextManager():
             # Hot plug activate each pool in sequence and force a duplicate name
@@ -469,7 +469,7 @@ class UdevAdd(unittest.TestCase):
                     devices_plugged.append(self._lb_mgr.device_file(dev))
 
             _settle()
-            _expected_stratis_block_devices(devices_plugged)
+            _wait_for_udev(devices_plugged)
 
             # The number of pools should never exceed one, since all the pools
             # previously formed in the test have the same name.
@@ -492,7 +492,7 @@ class UdevAdd(unittest.TestCase):
                     self._lb_mgr.generate_udev_add_event(dev)
 
                 _settle()
-                _expected_stratis_block_devices(devices_plugged)
+                _wait_for_udev(devices_plugged)
                 self.assertEqual(len(_get_pools()), len(current_pools) + 1)
 
             self.assertEqual(len(_get_pools()), num_pools)

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -113,27 +113,29 @@ def _settle():
 def _wait_for_udev(expected_paths):
     """
     Look for Stratis devices. Check as many times as can be done in
-    10 seconds or until the number of devices found equals the number
-    of devices expected. Always get the result of at least 1 Stratis
-    enumeration.
+    10 seconds or until the devices found are equal to the devices
+    expected. Always get the result of at least 1 Stratis enumeration.
     :param expected_paths: devnodes of paths that should belong to Stratis
     :type expected_paths: list of str
     :return: None (May assert)
     """
 
-    num_expected = len(expected_paths)
+    expected_devnodes = frozenset(expected_paths)
+    found_devnodes = None
 
-    found = None
     context = pyudev.Context()
     end_time = time.time() + 10.0
 
-    while time.time() < end_time and found != num_expected:
-        found = sum(
-            1 for _ in context.list_devices(subsystem="block", ID_FS_TYPE="stratis")
+    while time.time() < end_time and not expected_devnodes == found_devnodes:
+        found_devnodes = frozenset(
+            [
+                x.device_node
+                for x in context.list_devices(subsystem="block", ID_FS_TYPE="stratis")
+            ]
         )
         time.sleep(1)
 
-    assert found == num_expected
+    assert expected_devnodes == found_devnodes
 
 
 def _processes(name):

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -347,7 +347,7 @@ class UdevAdd(unittest.TestCase):
         """
         self._test_driver(2, 4)
 
-    def _single_pool(self, num_devices, num_hotplugs=0):
+    def _single_pool(self, num_devices, *, num_hotplugs=0):
         """
         Creates a single pool with specified number of devices.
 
@@ -414,13 +414,13 @@ class UdevAdd(unittest.TestCase):
         """
         See documentation for _single_pool.
         """
-        self._single_pool(4, 4)
+        self._single_pool(4, num_hotplugs=4)
 
     def test_simple_udev_add(self):
         """
         See documentation for _single_pool.
         """
-        self._single_pool(1, 1)
+        self._single_pool(1, num_hotplugs=1)
 
     def test_duplicate_pool_name(self):
         """


### PR DESCRIPTION
The contributions of this PR are:

* Add one pretty reasonable test for an encrypted pool and marks it as an expected failure. The purpose of this is to get in the necessary infrastructure and verify that all is working properly.
* Change the tests to be pure unittest instead of driven by pytest device discovery mechanism. This will allow us to improve the tests to distinguish between test errors and test faiures, and it seems to still work fine with the log capturing mechanism.
* Do some further rewrites of the udev test infrastructure for clarity and consistency.