### PR TITLE
Preliminary prototype of Report interface

### DIFF
--- a/src/dbus_api/api/mod.rs
+++ b/src/dbus_api/api/mod.rs
@@ -14,6 +14,7 @@ use crate::dbus_api::{
 
 pub mod manager_2_0;
 pub mod manager_2_1;
+pub mod report_2_1;
 pub mod shared;
 
 pub fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>, dbus::Path<'a>) {
@@ -38,6 +39,10 @@ pub fn get_base_tree<'a>(dbus_context: DbusContext) -> (Tree<MTFn<TData>, TData>
                 .add_m(manager_2_0::destroy_pool_method(&f))
                 .add_m(manager_2_0::configure_simulator_method(&f))
                 .add_p(manager_2_0::version_property(&f)),
+        )
+        .add(
+            f.interface(consts::REPORT_INTERFACE_NAME_2_1, ())
+                .add_m(report_2_1::get_report_method(&f)),
         );
 
     let path = obj_path.get_name().to_owned();

--- a/src/dbus_api/api/report_2_1/api.rs
+++ b/src/dbus_api/api/report_2_1/api.rs
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use dbus::tree::{Factory, MTFn, Method};
+
+use crate::dbus_api::{api::report_2_1::methods::get_report, types::TData};
+
+pub fn get_report_method(f: &Factory<MTFn<TData>, TData>) -> Method<MTFn<TData>, TData> {
+    f.method("GetReport", (), get_report)
+        .in_arg(("name", "s"))
+        // The report is a JSON object.
+        //
+        // b: boolean that is false if the default value is being returned in the case
+        //    of an error
+        // s: string representation of a JSON object containing the report
+        //
+        // Rust representation: (bool, serde_json::Value)
+        .out_arg(("result", "(bs)"))
+        .out_arg(("return_code", "q"))
+        .out_arg(("return_string", "s"))
+}

--- a/src/dbus_api/api/report_2_1/methods.rs
+++ b/src/dbus_api/api/report_2_1/methods.rs
@@ -15,7 +15,6 @@ use crate::{
         util::{engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok},
     },
     engine::ReportType,
-    stratis::StratisError,
 };
 
 pub fn get_report(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
@@ -40,7 +39,7 @@ pub fn get_report(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let msg = match serde_json::to_string(&engine.get_report(report_type)) {
         Ok(string) => return_message.append3((true, string), msg_code_ok(), msg_string_ok()),
         Err(e) => {
-            let (rc, rs) = engine_to_dbus_err_tuple(&StratisError::Serde(e));
+            let (rc, rs) = engine_to_dbus_err_tuple(&e.into());
             return_message.append3(default_return, rc, rs)
         }
     };

--- a/src/dbus_api/api/report_2_1/methods.rs
+++ b/src/dbus_api/api/report_2_1/methods.rs
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::convert::TryFrom;
+
+use dbus::{
+    tree::{MTFn, MethodInfo, MethodResult},
+    Message,
+};
+
+use crate::{
+    dbus_api::{
+        types::TData,
+        util::{engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok},
+    },
+    engine::ReportType,
+    stratis::StratisError,
+};
+
+pub fn get_report(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
+    let message: &Message = m.msg;
+    let mut iter = message.iter_init();
+    let report_name: &str = get_next_arg(&mut iter, 0)?;
+
+    let return_message = message.method_return();
+    let default_return = (false, String::new());
+
+    let report_type = match ReportType::try_from(report_name) {
+        Ok(rt) => rt,
+        Err(e) => {
+            let (rc, rs) = engine_to_dbus_err_tuple(&e);
+            return Ok(vec![return_message.append3(default_return, rc, rs)]);
+        }
+    };
+
+    let dbus_context = m.tree.get_data();
+    let engine = dbus_context.engine.borrow();
+
+    let msg = match serde_json::to_string(&engine.get_report(report_type)) {
+        Ok(string) => return_message.append3((true, string), msg_code_ok(), msg_string_ok()),
+        Err(e) => {
+            let (rc, rs) = engine_to_dbus_err_tuple(&StratisError::Serde(e));
+            return_message.append3(default_return, rc, rs)
+        }
+    };
+
+    Ok(vec![msg])
+}

--- a/src/dbus_api/api/report_2_1/mod.rs
+++ b/src/dbus_api/api/report_2_1/mod.rs
@@ -1,0 +1,4 @@
+mod api;
+mod methods;
+
+pub use api::get_report_method;

--- a/src/dbus_api/consts.rs
+++ b/src/dbus_api/consts.rs
@@ -7,6 +7,7 @@ pub const STRATIS_BASE_SERVICE: &str = "org.storage.stratis2";
 
 pub const MANAGER_INTERFACE_NAME: &str = "org.storage.stratis2.Manager";
 pub const MANAGER_INTERFACE_NAME_2_1: &str = "org.storage.stratis2.Manager.r1";
+pub const REPORT_INTERFACE_NAME_2_1: &str = "org.storage.stratis2.Report.r1";
 
 pub const PROPERTY_FETCH_INTERFACE_NAME: &str = "org.storage.stratis2.FetchProperties";
 pub const PROPERTY_FETCH_INTERFACE_NAME_2_1: &str = "org.storage.stratis2.FetchProperties.r1";

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::{
-    convert::TryFrom,
     fmt::Debug,
     os::unix::io::RawFd,
     path::{Path, PathBuf},
@@ -18,34 +17,12 @@ use devicemapper::{Bytes, Sectors};
 use crate::{
     engine::types::{
         BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid, MaybeDbusPath, Name,
-        PoolUuid, RenameAction, SetCreateAction, SetDeleteAction,
+        PoolUuid, RenameAction, ReportType, SetCreateAction, SetDeleteAction,
     },
-    stratis::{ErrorEnum, StratisError, StratisResult},
+    stratis::StratisResult,
 };
 
 pub const DEV_PATH: &str = "/stratis";
-
-/// The type of report for which to query.
-///
-/// * `PartialPoolDevices` returns the state of devices that were not able to create a
-/// complete pool.
-pub enum ReportType {
-    ErroredPoolDevices,
-}
-
-impl<'a> TryFrom<&'a str> for ReportType {
-    type Error = StratisError;
-
-    fn try_from(name: &str) -> StratisResult<ReportType> {
-        match name {
-            "errored_pool_report" => Ok(ReportType::ErroredPoolDevices),
-            _ => Err(StratisError::Engine(
-                ErrorEnum::NotFound,
-                format!("Report {} not found", name),
-            )),
-        }
-    }
-}
 
 /// An interface for reporting internal engine state.
 pub trait Report {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -30,7 +30,7 @@ pub const DEV_PATH: &str = "/stratis";
 /// * `PartialPoolDevices` returns the state of devices that were not able to create a
 /// complete pool.
 pub enum ReportType {
-    PartialPoolDevices,
+    ErroredPoolDevices,
 }
 
 impl<'a> TryFrom<&'a str> for ReportType {
@@ -38,7 +38,7 @@ impl<'a> TryFrom<&'a str> for ReportType {
 
     fn try_from(name: &str) -> StratisResult<ReportType> {
         match name {
-            "partial_pool_devices" => Ok(ReportType::PartialPoolDevices),
+            "errored_pool_report" => Ok(ReportType::ErroredPoolDevices),
             _ => Err(StratisError::Engine(
                 ErrorEnum::NotFound,
                 format!("Report {} not found", name),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub use self::{
-    engine::{BlockDev, Engine, Filesystem, Pool},
+    engine::{BlockDev, Engine, Filesystem, Pool, Report, ReportType},
     event::{get_engine_listener_list_mut, EngineEvent, EngineListener},
     sim_engine::SimEngine,
     strat_engine::StratEngine,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,14 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub use self::{
-    engine::{BlockDev, Engine, Filesystem, Pool, Report, ReportType},
+    engine::{BlockDev, Engine, Filesystem, Pool, Report},
     event::{get_engine_listener_list_mut, EngineEvent, EngineListener},
     sim_engine::SimEngine,
     strat_engine::StratEngine,
     types::{
         BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, EngineAction,
-        FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction, SetCreateAction,
-        SetDeleteAction,
+        FilesystemUuid, MaybeDbusPath, Name, PoolUuid, Redundancy, RenameAction, ReportType,
+        SetCreateAction, SetDeleteAction,
     },
 };
 

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -14,11 +14,11 @@ use serde_json::{json, Value};
 
 use crate::{
     engine::{
-        engine::{Engine, Eventable, Pool, Report, ReportType},
+        engine::{Engine, Eventable, Pool, Report},
         shared::create_pool_idempotent_or_err,
         sim_engine::{pool::SimPool, randomization::Randomizer},
         structures::Table,
-        types::{CreateAction, DeleteAction, Name, PoolUuid, RenameAction},
+        types::{CreateAction, DeleteAction, Name, PoolUuid, RenameAction, ReportType},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -10,9 +10,11 @@ use std::{
     rc::Rc,
 };
 
+use serde_json::{json, Value};
+
 use crate::{
     engine::{
-        engine::{Engine, Eventable, Pool},
+        engine::{Engine, Eventable, Pool, Report, ReportType},
         shared::create_pool_idempotent_or_err,
         sim_engine::{pool::SimPool, randomization::Randomizer},
         structures::Table,
@@ -27,7 +29,29 @@ pub struct SimEngine {
     rdm: Rc<RefCell<Randomizer>>,
 }
 
-impl SimEngine {}
+impl Report for SimEngine {
+    fn get_report(&self, report_type: ReportType) -> Value {
+        match report_type {
+            ReportType::PartialPoolDevices => json!([
+                {
+                    "pool_uuid": "0123456789abcdef0123456789abcdef",
+                    "devices": [
+                        "/dev/an/example/device",
+                        "/dev/another/example/device",
+                    ],
+                },
+                {
+                    "pool_uuid": "fedcba9876543210fedcba9876543210",
+                    "devices": [
+                        "/dev/more/example/devices",
+                        "/dev/yet/another/example/device",
+                        "/dev/last/example/device",
+                    ],
+                },
+            ]),
+        }
+    }
+}
 
 impl Engine for SimEngine {
     fn create_pool(

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -32,7 +32,7 @@ pub struct SimEngine {
 impl Report for SimEngine {
     fn get_report(&self, report_type: ReportType) -> Value {
         match report_type {
-            ReportType::PartialPoolDevices => json!([
+            ReportType::ErroredPoolDevices => json!([
                 {
                     "pool_uuid": "0123456789abcdef0123456789abcdef",
                     "devices": [

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -8,6 +8,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use serde_json::Value;
+
 use devicemapper::{Device, DmNameBuf};
 
 #[cfg(test)]
@@ -28,7 +30,7 @@ use crate::{
         },
         structures::Table,
         types::{CreateAction, DeleteAction, RenameAction},
-        Engine, EngineEvent, Name, Pool, PoolUuid,
+        Engine, EngineEvent, Name, Pool, PoolUuid, Report, ReportType,
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
@@ -41,7 +43,7 @@ pub struct StratEngine {
 
     // Map of stratis devices that have been found but one or more stratis block devices are missing
     // which prevents the associated pools from being setup.
-    incomplete_pools: HashMap<PoolUuid, HashMap<Device, PathBuf>>,
+    partial_pool_devices: HashMap<PoolUuid, HashMap<Device, PathBuf>>,
 
     // Maps name of DM devices we are watching to the most recent event number
     // we've handled for each
@@ -74,7 +76,7 @@ impl StratEngine {
 
         let mut engine = StratEngine {
             pools: Table::default(),
-            incomplete_pools: HashMap::new(),
+            partial_pool_devices: HashMap::new(),
             watched_dev_last_event_nrs: HashMap::new(),
         };
 
@@ -88,7 +90,7 @@ impl StratEngine {
     }
 
     // Given a set of devices, try to set up a pool. If the setup fails,
-    // insert the devices into incomplete_pools.
+    // insert the devices into partial_pool_devices.
     fn try_setup_pool(&mut self, pool_uuid: PoolUuid, devices: HashMap<Device, PathBuf>) {
         // Setup a pool from constituent devices in the context of some already
         // setup pools.
@@ -151,7 +153,7 @@ impl StratEngine {
                 self.pools.insert(pool_name, pool_uuid, pool);
             }
             _ => {
-                self.incomplete_pools.insert(pool_uuid, devices);
+                self.partial_pool_devices.insert(pool_uuid, devices);
             }
         }
     }
@@ -173,7 +175,7 @@ impl StratEngine {
                 None
             } else {
                 let mut devices = self
-                    .incomplete_pools
+                    .partial_pool_devices
                     .remove(&pool_uuid)
                     .unwrap_or_else(HashMap::new);
 
@@ -202,6 +204,27 @@ impl StratEngine {
                     .map(|(_, pool)| (pool_uuid, pool as &mut dyn Pool))
             }
         })
+    }
+}
+
+/// Provide the report for pools which only have a subset of the devices required
+/// to reconstruct the pool available.
+fn partial_pool_report(
+    partial_pool_devices: &HashMap<PoolUuid, HashMap<Device, PathBuf>>,
+) -> Value {
+    Value::Array(partial_pool_devices.iter().map(|(uuid, map)| {
+        json!({
+            "pool_uuid": uuid.to_simple_ref().to_string(),
+            "devices": Value::Array(map.values().map(|p| Value::from(p.display().to_string())).collect()),
+        })
+    }).collect())
+}
+
+impl Report for StratEngine {
+    fn get_report(&self, report_type: ReportType) -> Value {
+        match report_type {
+            ReportType::PartialPoolDevices => partial_pool_report(&self.partial_pool_devices),
+        }
     }
 }
 
@@ -453,7 +476,7 @@ mod test {
         remove_dir_all(DEV_PATH).unwrap();
 
         let engine = StratEngine::initialize().unwrap();
-        assert_eq!(engine.incomplete_pools, HashMap::new());
+        assert_eq!(engine.partial_pool_devices, HashMap::new());
 
         assert!(engine.get_pool(uuid1).is_some());
         assert!(engine.get_pool(uuid2).is_some());

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -43,7 +43,7 @@ pub struct StratEngine {
 
     // Map of stratis devices that have been found but one or more stratis block devices are missing
     // which prevents the associated pools from being setup.
-    partial_pool_devices: HashMap<PoolUuid, HashMap<Device, PathBuf>>,
+    errored_pool_devices: HashMap<PoolUuid, HashMap<Device, PathBuf>>,
 
     // Maps name of DM devices we are watching to the most recent event number
     // we've handled for each
@@ -76,7 +76,7 @@ impl StratEngine {
 
         let mut engine = StratEngine {
             pools: Table::default(),
-            partial_pool_devices: HashMap::new(),
+            errored_pool_devices: HashMap::new(),
             watched_dev_last_event_nrs: HashMap::new(),
         };
 
@@ -90,7 +90,7 @@ impl StratEngine {
     }
 
     // Given a set of devices, try to set up a pool. If the setup fails,
-    // insert the devices into partial_pool_devices.
+    // insert the devices into errored_pool_devices.
     fn try_setup_pool(&mut self, pool_uuid: PoolUuid, devices: HashMap<Device, PathBuf>) {
         // Setup a pool from constituent devices in the context of some already
         // setup pools.
@@ -153,7 +153,7 @@ impl StratEngine {
                 self.pools.insert(pool_name, pool_uuid, pool);
             }
             _ => {
-                self.partial_pool_devices.insert(pool_uuid, devices);
+                self.errored_pool_devices.insert(pool_uuid, devices);
             }
         }
     }
@@ -175,7 +175,7 @@ impl StratEngine {
                 None
             } else {
                 let mut devices = self
-                    .partial_pool_devices
+                    .errored_pool_devices
                     .remove(&pool_uuid)
                     .unwrap_or_else(HashMap::new);
 
@@ -209,10 +209,10 @@ impl StratEngine {
 
 /// Provide the report for pools which only have a subset of the devices required
 /// to reconstruct the pool available.
-fn partial_pool_report(
-    partial_pool_devices: &HashMap<PoolUuid, HashMap<Device, PathBuf>>,
+fn errored_pool_report(
+    errored_pool_devices: &HashMap<PoolUuid, HashMap<Device, PathBuf>>,
 ) -> Value {
-    Value::Array(partial_pool_devices.iter().map(|(uuid, map)| {
+    Value::Array(errored_pool_devices.iter().map(|(uuid, map)| {
         json!({
             "pool_uuid": uuid.to_simple_ref().to_string(),
             "devices": Value::Array(map.values().map(|p| Value::from(p.display().to_string())).collect()),
@@ -223,7 +223,7 @@ fn partial_pool_report(
 impl Report for StratEngine {
     fn get_report(&self, report_type: ReportType) -> Value {
         match report_type {
-            ReportType::PartialPoolDevices => partial_pool_report(&self.partial_pool_devices),
+            ReportType::ErroredPoolDevices => errored_pool_report(&self.errored_pool_devices),
         }
     }
 }
@@ -476,7 +476,7 @@ mod test {
         remove_dir_all(DEV_PATH).unwrap();
 
         let engine = StratEngine::initialize().unwrap();
-        assert_eq!(engine.partial_pool_devices, HashMap::new());
+        assert_eq!(engine.errored_pool_devices, HashMap::new());
 
         assert!(engine.get_pool(uuid1).is_some());
         assert!(engine.get_pool(uuid2).is_some());

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -29,8 +29,8 @@ use crate::{
             pool::StratPool,
         },
         structures::Table,
-        types::{CreateAction, DeleteAction, RenameAction},
-        Engine, EngineEvent, Name, Pool, PoolUuid, Report, ReportType,
+        types::{CreateAction, DeleteAction, RenameAction, ReportType},
+        Engine, EngineEvent, Name, Pool, PoolUuid, Report,
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{borrow::Borrow, fmt, ops::Deref, rc::Rc};
+use std::{borrow::Borrow, convert::TryFrom, fmt, ops::Deref, rc::Rc};
 
 mod actions;
 pub use crate::engine::types::actions::{
     CreateAction, DeleteAction, EngineAction, RenameAction, SetCreateAction, SetDeleteAction,
 };
+use crate::stratis::{ErrorEnum, StratisError, StratisResult};
 
 use uuid::Uuid;
 
@@ -120,5 +121,27 @@ impl Borrow<str> for Name {
 impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// The type of report for which to query.
+///
+/// * `ErroredPoolDevices` returns the state of devices that caused an error while
+/// attempting to reconstruct a pool.
+pub enum ReportType {
+    ErroredPoolDevices,
+}
+
+impl<'a> TryFrom<&'a str> for ReportType {
+    type Error = StratisError;
+
+    fn try_from(name: &str) -> StratisResult<ReportType> {
+        match name {
+            "errored_pool_report" => Ok(ReportType::ErroredPoolDevices),
+            _ => Err(StratisError::Engine(
+                ErrorEnum::NotFound,
+                format!("Report name {} not understood", name),
+            )),
+        }
     }
 }

--- a/stratisd.conf
+++ b/stratisd.conf
@@ -23,6 +23,9 @@
 	 send_interface="org.storage.stratis2.FetchProperties.r1"/>
 
   <allow send_destination="org.storage.stratis2"
+         send_interface="org.storage.stratis2.Report.r1"/>
+
+  <allow send_destination="org.storage.stratis2"
          send_interface="org.freedesktop.DBus.Properties"
          send_member="Get"/>
 

--- a/tests/client-dbus/src/stratisd_client_dbus/__init__.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/__init__.py
@@ -26,6 +26,7 @@ from ._implementation import ManagerR1
 from ._implementation import ObjectManager
 from ._implementation import Pool
 from ._implementation import PoolR1
+from ._implementation import ReportR1
 from ._implementation import blockdevs
 from ._implementation import pools
 from ._implementation import filesystems

--- a/tests/client-dbus/src/stratisd_client_dbus/_data.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_data.py
@@ -45,6 +45,16 @@ SPECS = {
 </method>
 </interface>
 """,
+    "org.storage.stratis2.Report.r1": """
+<interface name="org.storage.stratis2.Report.r1">
+<method name="GetReport">
+<arg name="name" type="s" direction="in"/>
+<arg name="result" type="(bs)" direction="out"/>
+<arg name="return_code" type="q" direction="out"/>
+<arg name="return_string" type="s" direction="out"/>
+</method>
+</interface>
+""",
     "org.storage.stratis2.Manager": """
 <interface name="org.storage.stratis2.Manager">
 <method name="ConfigureSimulator">

--- a/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_implementation.py
@@ -42,6 +42,9 @@ ObjectManager = make_class(
     ET.fromstring(SPECS["org.freedesktop.DBus.ObjectManager"]),
     TIME_OUT,
 )
+ReportR1 = make_class(
+    "ReportR1", ET.fromstring(SPECS["org.storage.stratis2.Report.r1"]), TIME_OUT
+)
 Manager = make_class(
     "Manager", ET.fromstring(SPECS["org.storage.stratis2.Manager"]), TIME_OUT
 )

--- a/tests/client-dbus/tests/dbus/report/test_get_report.py
+++ b/tests/client-dbus/tests/dbus/report/test_get_report.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Red Hat, Inc.
+# Copyright 2020 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/client-dbus/tests/dbus/report/test_get_report.py
+++ b/tests/client-dbus/tests/dbus/report/test_get_report.py
@@ -1,0 +1,65 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test the reporting interface in stratisd.
+"""
+
+# isort: STDLIB
+import json
+
+# isort: LOCAL
+from stratisd_client_dbus import ReportR1, get_object
+from stratisd_client_dbus._constants import TOP_OBJECT
+
+from .._misc import SimTestCase, device_name_list
+
+_DEVICE_STRATEGY = device_name_list(1)
+
+
+class GetReportTestCase(SimTestCase):
+    """
+    Test that getting valid reports succeeds and that getting invalid reports
+    fails.
+    """
+
+    _POOLNAME = "reportpool"
+
+    def setUp(self):
+        """
+        Start stratisd.
+        """
+        super().setUp()
+        self._proxy = get_object(TOP_OBJECT)
+
+    def test_valid_report_name(self):
+        """
+        Test that errored_pool_report returns a valid JSON response.
+        """
+        ((is_some, json_str), return_code, _) = ReportR1.Methods.GetReport(
+            self._proxy, {"name": "errored_pool_report"}
+        )
+        self.assertEqual(is_some, True)
+        self.assertEqual(return_code, 0)
+        # Test that JSON is valid - will raise ValueError if not
+        json.loads(json_str)
+
+    def test_invalid_report_name(self):
+        """
+        Test that an invalid report name returns an error.
+        """
+        ((is_some, _), return_code, _) = ReportR1.Methods.GetReport(
+            self._proxy, {"name": "nonexistent_report"}
+        )
+        self.assertEqual(is_some, False)
+        self.assertNotEqual(return_code, 0)


### PR DESCRIPTION
Related to #1122 

@mulkieran Happy to change the name from `partial_pool_devices` to something better but this was the best I could think of at the moment.

TODOs:
* Testing
  * Test that sim engine responds with a successful mock result on valid input and error on invalid input
  * Generate a situation with an incomplete pool in the Rust unit tests and check that the value reported by this interface is correct
* Discuss providing an engine state report as we used to do in our logging
  * Should this be provided by a different method like "get_unstable_report"?
  * Is there another way to indicate that the interface may change?
* Do we want to allow unprivileged users to get reports or just root?