### PR TITLE
Various minor improvements to device discovery

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -118,7 +118,7 @@ impl Backstore {
     pub fn setup(
         pool_uuid: PoolUuid,
         backstore_save: &BackstoreSave,
-        devnodes: &HashMap<Device, PathBuf>,
+        devnodes: &HashMap<Device, (DevUuid, PathBuf)>,
         last_update_time: DateTime<Utc>,
     ) -> StratisResult<Backstore> {
         let (datadevs, cachedevs) = get_blockdevs(pool_uuid, backstore_save, devnodes)?;
@@ -909,7 +909,9 @@ mod tests {
                 backstore
                     .blockdevs()
                     .iter()
-                    .map(|(_, blockdev)| (*blockdev.device(), blockdev.devnode()))
+                    .map(|(device_uuid, blockdev)| {
+                        (*blockdev.device(), (*device_uuid, blockdev.devnode()))
+                    })
                     .collect(),
             )
         };

--- a/src/engine/strat_engine/backstore/identify.rs
+++ b/src/engine/strat_engine/backstore/identify.rs
@@ -54,9 +54,14 @@ use crate::engine::{
     types::PoolUuid,
 };
 
-// A miscellaneous group of identifiers found when identifiying a Stratis
-// device.
-pub type StratisInfo = (StratisIdentifiers, Device, PathBuf);
+/// A miscellaneous group of identifiers found when identifying a Stratis
+/// device.
+#[derive(Debug, Eq, PartialEq)]
+pub struct StratisInfo {
+    pub identifiers: StratisIdentifiers,
+    pub device_number: Device,
+    pub devnode: PathBuf,
+}
 
 // A wrapper for obtaining the device number as a devicemapper Device
 // which interprets absence of the value as an error, which it is in this
@@ -119,9 +124,11 @@ fn process_stratis_device(dev: &libudev::Device) -> Option<StratisInfo> {
                           devnode.display());
                     None
                 }
-                (Ok(devno), Ok(Ok(Some(identifiers)))) => {
-                    Some((identifiers, devno, devnode.to_path_buf()))
-                }
+                (Ok(device_number), Ok(Ok(Some(identifiers)))) => Some(StratisInfo {
+                    identifiers,
+                    device_number,
+                    devnode: devnode.to_path_buf(),
+                }),
             }
         }
         None => {
@@ -140,10 +147,10 @@ fn find_all_stratis_devices() -> libudev::Result<HashMap<PoolUuid, HashMap<Devic
     let pool_map = enumerator
         .scan_devices()?
         .filter_map(|dev| identify_stratis_device(&dev))
-        .fold(HashMap::new(), |mut acc, (identifiers, device, devnode)| {
-            acc.entry(identifiers.pool_uuid)
+        .fold(HashMap::new(), |mut acc, info| {
+            acc.entry(info.identifiers.pool_uuid)
                 .or_insert_with(HashMap::new)
-                .insert(device, devnode);
+                .insert(info.device_number, info.devnode);
             acc
         });
     Ok(pool_map)
@@ -175,14 +182,14 @@ fn identify_stratis_device(dev: &libudev::Device) -> Option<StratisInfo> {
             }
         },
     }
-    .map(|(identifiers, device, devnode)| {
+    .map(|info| {
         info!("Stratis block device with device number \"{}\", device node \"{}\", pool UUID \"{}\", and device UUID \"{}\" discovered during initial search",
-              device,
-              devnode.display(),
-              identifiers.pool_uuid.to_simple_ref(),
-              identifiers.device_uuid.to_simple_ref()
+              info.device_number,
+              info.devnode.display(),
+              info.identifiers.pool_uuid.to_simple_ref(),
+              info.identifiers.device_uuid.to_simple_ref()
         );
-        (identifiers, device, devnode)
+        info
     })
 }
 
@@ -209,14 +216,14 @@ pub fn identify_block_device(dev: &libudev::Device) -> Option<StratisInfo> {
             _ => None,
         },
     }
-    .map(|(identifiers, device, devnode)| {
+    .map(|info| {
         debug!("Stratis block device with device number \"{}\", device node \"{}\", pool UUID \"{}\", and device UUID \"{}\" identified",
-              device,
-              devnode.display(),
-              identifiers.pool_uuid.to_simple_ref(),
-              identifiers.device_uuid.to_simple_ref()
+              info.device_number,
+              info.devnode.display(),
+              info.identifiers.pool_uuid.to_simple_ref(),
+              info.identifiers.device_uuid.to_simple_ref()
         );
-        (identifiers, device, devnode)
+        info
     })
 }
 
@@ -275,13 +282,12 @@ mod tests {
         .unwrap();
 
         for path in paths {
-            let (identifiers, _, dev_node) =
-                block_device_apply(path, |dev| process_stratis_device(dev))
-                    .unwrap()
-                    .unwrap()
-                    .unwrap();
-            assert_eq!(identifiers.pool_uuid, pool_uuid);
-            assert_eq!(&&dev_node, path);
+            let info = block_device_apply(path, |dev| process_stratis_device(dev))
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            assert_eq!(info.identifiers.pool_uuid, pool_uuid);
+            assert_eq!(&&info.devnode, path);
         }
     }
 

--- a/src/engine/strat_engine/backstore/setup.rs
+++ b/src/engine/strat_engine/backstore/setup.rs
@@ -224,6 +224,8 @@ pub fn get_blockdevs(
             tier,
             StratBlockDev::new(
                 device,
+                // FIXME: This block device could represent an encrypted or
+                // an unencrypted device.
                 BlockDevPath::Unencrypted(devnode.to_owned()),
                 bda,
                 segments.unwrap_or(&vec![]),

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -41,8 +41,8 @@ const REQUIRED_DM_MINOR_VERSION: u32 = 37;
 pub struct StratEngine {
     pools: Table<StratPool>,
 
-    // Map of stratis devices that have been found but one or more stratis block devices are missing
-    // which prevents the associated pools from being setup.
+    // Maps pool UUIDs to information about sets of devices that are
+    // associated with that UUID but have not been converted into a pool.
     errored_pool_devices: HashMap<PoolUuid, HashMap<Device, PathBuf>>,
 
     // Maps name of DM devices we are watching to the most recent event number
@@ -207,8 +207,8 @@ impl StratEngine {
     }
 }
 
-/// Provide the report for pools which only have a subset of the devices required
-/// to reconstruct the pool available.
+/// Report about sets of devices which are associated with a particular pool
+/// UUID but which have not been converted into a Stratis pool.
 fn errored_pool_report(
     errored_pool_devices: &HashMap<PoolUuid, HashMap<Device, PathBuf>>,
 ) -> Value {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -30,7 +30,7 @@ use crate::{
         },
         structures::Table,
         types::{CreateAction, DeleteAction, RenameAction, ReportType},
-        Engine, EngineEvent, Name, Pool, PoolUuid, Report,
+        DevUuid, Engine, EngineEvent, Name, Pool, PoolUuid, Report,
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
@@ -43,7 +43,7 @@ pub struct StratEngine {
 
     // Maps pool UUIDs to information about sets of devices that are
     // associated with that UUID but have not been converted into a pool.
-    errored_pool_devices: HashMap<PoolUuid, HashMap<Device, PathBuf>>,
+    errored_pool_devices: HashMap<PoolUuid, HashMap<Device, (DevUuid, PathBuf)>>,
 
     // Maps name of DM devices we are watching to the most recent event number
     // we've handled for each
@@ -91,7 +91,11 @@ impl StratEngine {
 
     // Given a set of devices, try to set up a pool. If the setup fails,
     // insert the devices into errored_pool_devices.
-    fn try_setup_pool(&mut self, pool_uuid: PoolUuid, devices: HashMap<Device, PathBuf>) {
+    fn try_setup_pool(
+        &mut self,
+        pool_uuid: PoolUuid,
+        devices: HashMap<Device, (DevUuid, PathBuf)>,
+    ) {
         // Setup a pool from constituent devices in the context of some already
         // setup pools.
         // Return None if the pool's metadata was not found. This is a
@@ -105,7 +109,7 @@ impl StratEngine {
         // to the pool with pool_uuid.
         fn setup_pool(
             pool_uuid: PoolUuid,
-            devices: &HashMap<Device, PathBuf>,
+            devices: &HashMap<Device, (DevUuid, PathBuf)>,
             pools: &Table<StratPool>,
         ) -> Result<Option<(Name, StratPool)>, String> {
             let (timestamp, metadata) = match get_metadata(pool_uuid, devices) {
@@ -179,7 +183,7 @@ impl StratEngine {
                     .remove(&pool_uuid)
                     .unwrap_or_else(HashMap::new);
 
-                if devices.insert(info.device_number, info.devnode).is_none() {
+                if devices.insert(info.device_number, (info.identifiers.device_uuid, info.devnode)).is_none() {
                     info!(
                         "Stratis block device with device number \"{}\", pool UUID \"{}\", and device UUID \"{}\" discovered, i.e., identified for the first time during this execution of stratisd",
                         info.device_number,
@@ -210,12 +214,12 @@ impl StratEngine {
 /// Report about sets of devices which are associated with a particular pool
 /// UUID but which have not been converted into a Stratis pool.
 fn errored_pool_report(
-    errored_pool_devices: &HashMap<PoolUuid, HashMap<Device, PathBuf>>,
+    errored_pool_devices: &HashMap<PoolUuid, HashMap<Device, (DevUuid, PathBuf)>>,
 ) -> Value {
     Value::Array(errored_pool_devices.iter().map(|(uuid, map)| {
         json!({
             "pool_uuid": uuid.to_simple_ref().to_string(),
-            "devices": Value::Array(map.values().map(|p| Value::from(p.display().to_string())).collect()),
+            "devices": Value::Array(map.values().map(|(_, p)| Value::from(p.display().to_string())).collect()),
         })
     }).collect())
 }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -169,8 +169,8 @@ impl StratEngine {
     /// If a new pool is created as a result of the processing, return
     /// the newly created pool and its UUID, otherwise return None.
     fn block_evaluate(&mut self, device: &libudev::Device) -> Option<(PoolUuid, &mut dyn Pool)> {
-        identify_block_device(device).and_then(move |(identifiers, device, dev_node)| {
-            let pool_uuid = identifiers.pool_uuid;
+        identify_block_device(device).and_then(move |info| {
+            let pool_uuid = info.identifiers.pool_uuid;
             if self.pools.contains_uuid(pool_uuid) {
                 None
             } else {
@@ -179,12 +179,12 @@ impl StratEngine {
                     .remove(&pool_uuid)
                     .unwrap_or_else(HashMap::new);
 
-                if devices.insert(device, dev_node).is_none() {
+                if devices.insert(info.device_number, info.devnode).is_none() {
                     info!(
                         "Stratis block device with device number \"{}\", pool UUID \"{}\", and device UUID \"{}\" discovered, i.e., identified for the first time during this execution of stratisd",
-                        device,
-                        identifiers.pool_uuid.to_simple_ref(),
-                        identifiers.device_uuid.to_simple_ref(),
+                        info.device_number,
+                        info.identifiers.pool_uuid.to_simple_ref(),
+                        info.identifiers.device_uuid.to_simple_ref(),
                     );
                 }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -193,7 +193,7 @@ impl StratPool {
     /// Precondition: A metadata verification step has already been run.
     pub fn setup(
         uuid: PoolUuid,
-        devnodes: &HashMap<Device, PathBuf>,
+        devnodes: &HashMap<Device, (DevUuid, PathBuf)>,
         timestamp: DateTime<Utc>,
         metadata: &PoolSave,
     ) -> StratisResult<(Name, StratPool)> {
@@ -630,14 +630,14 @@ mod tests {
             .backstore
             .blockdevs()
             .iter()
-            .map(|(_, blockdev)| (*blockdev.device(), blockdev.devnode()))
+            .map(|(device_uuid, blockdev)| (*blockdev.device(), (*device_uuid, blockdev.devnode())))
             .collect();
 
         let devnodes2 = pool2
             .backstore
             .blockdevs()
             .iter()
-            .map(|(_, blockdev)| (*blockdev.device(), blockdev.devnode()))
+            .map(|(device_uuid, blockdev)| (*blockdev.device(), (*device_uuid, blockdev.devnode())))
             .collect();
 
         let (_, pool_save1) = get_metadata(uuid1, &devnodes1).unwrap().unwrap();
@@ -764,7 +764,7 @@ mod tests {
             .backstore
             .blockdevs()
             .iter()
-            .map(|(_, blockdev)| (*blockdev.device(), blockdev.devnode()))
+            .map(|(device_uuid, blockdev)| (*blockdev.device(), (*device_uuid, blockdev.devnode())))
             .collect();
 
         pool.teardown().unwrap();


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/171

This PR is a staging PR, I want it to clear before more radical changes. Thus, some of the code added here is not expected to endure very long, especially the FIXME. The next step is to move some of the handling of those liminal devices into a separate module. List of changes below:

* some comment changes
* one obvious refactoring, change a tuple to a struct.
* one mechanical change, passing back the device UUID as well as the pool UUID when identifying devices. These days, you can't get one without the other and they're both important, so might as well hang on to both.
* one small semantic change; the ```get_metadata``` method returns an error if any of the devices do not have their expected device and pool UUID. It used to be that the devices were just silently ignored in that case, but since the method is called only in the case where they must be the same, there's no point to that. No tests had to be changed, because none of them made use of the extra generality.
* adds a FIXME in get_blockdevs. This FIXME marks an important spot where further information must be available in order to correctly set up a pool.

This PR does not address the problem where the BDAs for every block devices are read twice when trying to set up a pool and it does not try to make the error-checking on BDA loading in setup::get_blockdevs as complete as that in setup::get_metadata. There is a separate issue for those concerns:
https://github.com/stratis-storage/stratisd/issues/1652; I hope to be able to address it in some near future PR.
