### PR TITLE
Require blockdev() invocations to specify the path type

### DIFF
--- a/src/dbus_api/blockdev/blockdev_2_0/props.rs
+++ b/src/dbus_api/blockdev/blockdev_2_0/props.rs
@@ -36,7 +36,9 @@ pub fn get_blockdev_devnode(
     i: &mut IterAppend,
     p: &PropInfo<MTFn<TData>, TData>,
 ) -> Result<(), MethodErr> {
-    get_blockdev_property(i, p, |_, p| Ok(format!("{}", p.devnode().display())))
+    get_blockdev_property(i, p, |_, p| {
+        Ok(format!("{}", p.devnode().user_path().display()))
+    })
 }
 
 pub fn get_blockdev_hardware_info(

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -16,8 +16,8 @@ use devicemapper::{Bytes, Sectors};
 
 use crate::{
     engine::types::{
-        BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid, MaybeDbusPath, Name,
-        PoolUuid, RenameAction, ReportType, SetCreateAction, SetDeleteAction,
+        BlockDevPath, BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid,
+        MaybeDbusPath, Name, PoolUuid, RenameAction, ReportType, SetCreateAction, SetDeleteAction,
     },
     stratis::StratisResult,
 };
@@ -50,9 +50,8 @@ pub trait Filesystem: Debug {
 }
 
 pub trait BlockDev: Debug {
-    /// Get the path of the device node for writing Stratis metadata to this
-    /// device.
-    fn devnode(&self) -> PathBuf;
+    /// Get the structure representing block device paths.
+    fn devnode(&self) -> &BlockDevPath;
 
     /// Get the user-settable string associated with this blockdev.
     fn user_info(&self) -> Option<&str>;

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -31,7 +31,7 @@ pub fn create_pool_idempotent_or_err(
     let existing_paths: HashSet<PathBuf, _> = pool
         .blockdevs()
         .iter()
-        .map(|(_, bd)| bd.devnode())
+        .map(|(_, bd)| bd.devnode().physical_path().to_owned())
         .collect();
 
     if input_devices == existing_paths {

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -2,11 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{
-    cell::RefCell,
-    path::{Path, PathBuf},
-    rc::Rc,
-};
+use std::{cell::RefCell, path::Path, rc::Rc};
 
 use chrono::{DateTime, TimeZone, Utc};
 use uuid::Uuid;
@@ -14,13 +10,14 @@ use uuid::Uuid;
 use devicemapper::{Bytes, Sectors, IEC};
 
 use crate::engine::{
-    engine::BlockDev, sim_engine::randomization::Randomizer, types::MaybeDbusPath,
+    engine::BlockDev, sim_engine::randomization::Randomizer, types::BlockDevPath,
+    types::MaybeDbusPath,
 };
 
 #[derive(Debug)]
 /// A simulated device.
 pub struct SimDev {
-    devnode: PathBuf,
+    devnode: BlockDevPath,
     rdm: Rc<RefCell<Randomizer>>,
     user_info: Option<String>,
     hardware_info: Option<String>,
@@ -30,8 +27,8 @@ pub struct SimDev {
 }
 
 impl BlockDev for SimDev {
-    fn devnode(&self) -> PathBuf {
-        self.devnode.clone()
+    fn devnode(&self) -> &BlockDevPath {
+        &self.devnode
     }
 
     fn user_info(&self) -> Option<&str> {
@@ -73,7 +70,7 @@ impl SimDev {
         (
             Uuid::new_v4(),
             SimDev {
-                devnode: devnode.to_owned(),
+                devnode: BlockDevPath::physical_device_path(devnode),
                 rdm,
                 user_info: None,
                 hardware_info: None,

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -26,9 +26,16 @@ pub struct SimDev {
     key_description: Option<String>,
 }
 
+impl SimDev {
+    /// Access a structure containing the simulated device path
+    pub fn devnode(&self) -> &BlockDevPath {
+        &self.devnode
+    }
+}
+
 impl BlockDev for SimDev {
     fn devnode(&self) -> &BlockDevPath {
-        &self.devnode
+        self.devnode()
     }
 
     fn user_info(&self) -> Option<&str> {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -129,7 +129,9 @@ impl Pool for SimPool {
         } else {
             init_cache_idempotent_or_err(
                 blockdevs,
-                self.cache_devs.iter().map(|(_, bd)| bd.devnode()),
+                self.cache_devs
+                    .iter()
+                    .map(|(_, bd)| bd.devnode().physical_path().to_owned()),
             )
         }
     }
@@ -195,10 +197,13 @@ impl Pool for SimPool {
             BlockDevTier::Data => &mut self.block_devs,
         };
 
-        let filter: Vec<_> = the_vec.values().map(|d| d.devnode()).collect();
+        let filter: Vec<_> = the_vec
+            .values()
+            .map(|d| d.devnode().physical_path())
+            .collect();
         let filtered_device_pairs: Vec<_> = device_pairs
             .into_iter()
-            .filter(|(_, sd)| !filter.contains(&sd.devnode()))
+            .filter(|(_, sd)| !filter.contains(&sd.devnode().physical_path()))
             .collect();
 
         let ret_uuids = filtered_device_pairs

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -647,14 +647,11 @@ mod tests {
 
     use devicemapper::{CacheDevStatus, DataBlocks, IEC};
 
-    use crate::engine::{
-        engine::BlockDev,
-        strat_engine::{
-            backstore::metadata::device_identifiers,
-            cmd,
-            liminal::{add_bdas, get_blockdevs},
-            tests::{loopbacked, real},
-        },
+    use crate::engine::strat_engine::{
+        backstore::metadata::device_identifiers,
+        cmd,
+        liminal::{add_bdas, get_blockdevs},
+        tests::{loopbacked, real},
     };
 
     use super::*;

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -906,7 +906,10 @@ mod tests {
                     .blockdevs()
                     .iter()
                     .map(|(device_uuid, blockdev)| {
-                        (*blockdev.device(), (*device_uuid, blockdev.devnode()))
+                        (
+                            *blockdev.device(),
+                            (*device_uuid, blockdev.devnode().physical_path().to_owned()),
+                        )
                     })
                     .collect(),
             )

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -173,11 +173,17 @@ impl StratBlockDev {
     pub fn set_user_info(&mut self, user_info: Option<&str>) -> bool {
         set_blockdev_user_info!(self; user_info)
     }
+
+    /// Get the structure containing paths (such as physical and logical device
+    /// paths) for the device.
+    pub fn devnode(&self) -> &BlockDevPath {
+        &self.devnode
+    }
 }
 
 impl BlockDev for StratBlockDev {
     fn devnode(&self) -> &BlockDevPath {
-        &self.devnode
+        self.devnode()
     }
 
     fn user_info(&self) -> Option<&str> {

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -4,10 +4,7 @@
 
 // Code to handle a single block device.
 
-use std::{
-    fs::OpenOptions,
-    path::{Path, PathBuf},
-};
+use std::fs::OpenOptions;
 
 use chrono::{DateTime, TimeZone, Utc};
 
@@ -21,11 +18,10 @@ use crate::{
                 crypt::CryptHandle,
                 metadata::{disown_device, BDAExtendedSize, BlockdevSize, MDADataSize, BDA},
                 range_alloc::RangeAllocator,
-                shared::BlockDevPath,
             },
             serde_structs::{BaseBlockDevSave, Recordable},
         },
-        types::{DevUuid, MaybeDbusPath},
+        types::{BlockDevPath, DevUuid, MaybeDbusPath},
     },
     stratis::{StratisError, StratisResult},
 };
@@ -89,12 +85,6 @@ impl StratBlockDev {
     /// Returns the blockdev's Device
     pub fn device(&self) -> &Device {
         &self.dev
-    }
-
-    /// Return the path to the physical device on which data is stored either
-    /// encrypted or unencrypted.
-    pub fn physical_path(&self) -> &Path {
-        self.devnode.physical_path()
     }
 
     /// Remove information that identifies this device as belonging to Stratis
@@ -186,8 +176,8 @@ impl StratBlockDev {
 }
 
 impl BlockDev for StratBlockDev {
-    fn devnode(&self) -> PathBuf {
-        self.devnode.metadata_path().to_owned()
+    fn devnode(&self) -> &BlockDevPath {
+        &self.devnode
     }
 
     fn user_info(&self) -> Option<&str> {

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -16,6 +16,7 @@ use devicemapper::{Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sec
 
 use crate::{
     engine::{
+        engine::BlockDev,
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,
@@ -161,6 +162,7 @@ impl BlockDevMgr {
                 .iter()
                 .next()
                 .expect("Must have at least one blockdev")
+                .devnode()
                 .physical_path(),
         )
     }

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -16,7 +16,6 @@ use devicemapper::{Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sec
 
 use crate::{
     engine::{
-        engine::BlockDev,
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -18,6 +18,7 @@ use devicemapper::{Bytes, Device, Sectors, IEC};
 
 use crate::{
     engine::{
+        engine::BlockDev,
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,
@@ -26,12 +27,11 @@ use crate::{
                     device_identifiers, disown_device, BlockdevSize, MDADataSize,
                     StratisIdentifiers, BDA,
                 },
-                shared::BlockDevPath,
                 udev::{block_device_apply, decide_ownership, get_udev_property, UdevOwnership},
             },
             device::blkdev_size,
         },
-        types::{DevUuid, PoolUuid},
+        types::{BlockDevPath, DevUuid, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
@@ -262,10 +262,10 @@ impl MaybeEncrypted {
     fn to_blockdev_path(&self) -> StratisResult<BlockDevPath> {
         match *self {
             MaybeEncrypted::Unencrypted(ref path, _) => {
-                Ok(BlockDevPath::Unencrypted(path.to_owned()))
+                Ok(BlockDevPath::physical_device_path(path))
             }
             MaybeEncrypted::Encrypted(ref handle) => {
-                let physical = handle.physical_device_path().to_owned();
+                let physical = handle.physical_device_path();
                 let logical = handle.logical_device_path().ok_or_else(|| {
                     StratisError::Error(
                         "Path required for writing Stratis metadata on an \
@@ -273,7 +273,7 @@ impl MaybeEncrypted {
                             .to_string(),
                     )
                 })?;
-                Ok(BlockDevPath::Encrypted { logical, physical })
+                Ok(BlockDevPath::mapped_device_path(physical, &logical)?)
             }
         }
     }
@@ -653,7 +653,7 @@ pub fn wipe_blockdevs(blockdevs: &[StratBlockDev]) -> StratisResult<()> {
     let unerased_devnodes: Vec<_> = blockdevs
         .iter()
         .filter_map(|bd| match bd.disown() {
-            Err(_) => Some(bd.physical_path()),
+            Err(_) => Some(bd.devnode().physical_path()),
             _ => None,
         })
         .collect();
@@ -722,7 +722,10 @@ mod tests {
             )));
         }
 
-        let stratis_devnodes: Vec<PathBuf> = blockdevs.iter().map(|bd| bd.devnode()).collect();
+        let stratis_devnodes: Vec<PathBuf> = blockdevs
+            .iter()
+            .map(|bd| bd.devnode().metadata_path().to_owned())
+            .collect();
 
         let stratis_identifiers: Vec<Option<StratisIdentifiers>> = stratis_devnodes
             .iter()

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -18,7 +18,6 @@ use devicemapper::{Bytes, Device, Sectors, IEC};
 
 use crate::{
     engine::{
-        engine::BlockDev,
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,
@@ -675,12 +674,9 @@ mod tests {
 
     use uuid::Uuid;
 
-    use crate::engine::{
-        engine::BlockDev,
-        strat_engine::{
-            backstore::{crypt::CryptHandle, metadata::device_identifiers},
-            tests::{crypt, loopbacked, real},
-        },
+    use crate::engine::strat_engine::{
+        backstore::{crypt::CryptHandle, metadata::device_identifiers},
+        tests::{crypt, loopbacked, real},
     };
 
     use super::*;

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -21,7 +21,6 @@ pub use self::{
     blockdev::StratBlockDev,
     identify::{find_all, identify_block_device},
     metadata::{MDADataSize, BDA},
-    shared::BlockDevPath,
 };
 
 #[cfg(test)]

--- a/src/engine/strat_engine/backstore/shared.rs
+++ b/src/engine/strat_engine/backstore/shared.rs
@@ -4,10 +4,7 @@
 
 // Methods that are shared by the cache tier and the data tier.
 
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::collections::HashMap;
 
 use devicemapper::Device;
 
@@ -21,28 +18,6 @@ use crate::{
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
-
-#[derive(Clone, Debug)]
-pub enum BlockDevPath {
-    Encrypted { physical: PathBuf, logical: PathBuf },
-    Unencrypted(PathBuf),
-}
-
-impl BlockDevPath {
-    pub fn physical_path(&self) -> &Path {
-        match *self {
-            BlockDevPath::Encrypted { ref physical, .. } => physical,
-            BlockDevPath::Unencrypted(ref path) => path,
-        }
-    }
-
-    pub fn metadata_path(&self) -> &Path {
-        match *self {
-            BlockDevPath::Encrypted { ref logical, .. } => logical,
-            BlockDevPath::Unencrypted(ref path) => path,
-        }
-    }
-}
 
 /// Given a function that translates a Stratis UUID to a device
 /// number, and some metadata that describes a particular segment within

--- a/src/engine/strat_engine/liminal.rs
+++ b/src/engine/strat_engine/liminal.rs
@@ -18,14 +18,14 @@ use devicemapper::{Device, Sectors};
 use crate::{
     engine::{
         strat_engine::{
-            backstore::{identify_block_device, BlockDevPath, StratBlockDev, BDA},
+            backstore::{identify_block_device, StratBlockDev, BDA},
             device::blkdev_size,
             devlinks::setup_pool_devlinks,
             pool::StratPool,
             serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave},
         },
         structures::Table,
-        types::{BlockDevTier, DevUuid, Name, PoolUuid},
+        types::{BlockDevPath, BlockDevTier, DevUuid, Name, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
@@ -239,7 +239,7 @@ pub fn get_blockdevs(
                 device,
                 // FIXME: This block device could represent an encrypted or
                 // an unencrypted device.
-                BlockDevPath::Unencrypted(devnode.to_owned()),
+                BlockDevPath::physical_device_path(devnode),
                 bda,
                 segments.unwrap_or(&vec![]),
                 bd_save.user_info.clone(),

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -313,7 +313,7 @@ impl Pool for StratPool {
                 self.backstore
                     .cachedevs()
                     .into_iter()
-                    .map(|(_, bd)| bd.devnode()),
+                    .map(|(_, bd)| bd.devnode().physical_path().to_owned()),
             )
         }
     }
@@ -618,14 +618,24 @@ mod tests {
             .backstore
             .blockdevs()
             .iter()
-            .map(|(device_uuid, blockdev)| (*blockdev.device(), (*device_uuid, blockdev.devnode())))
+            .map(|(device_uuid, blockdev)| {
+                (
+                    *blockdev.device(),
+                    (*device_uuid, blockdev.devnode().metadata_path().to_owned()),
+                )
+            })
             .collect();
 
         let devnodes2 = pool2
             .backstore
             .blockdevs()
             .iter()
-            .map(|(device_uuid, blockdev)| (*blockdev.device(), (*device_uuid, blockdev.devnode())))
+            .map(|(device_uuid, blockdev)| {
+                (
+                    *blockdev.device(),
+                    (*device_uuid, blockdev.devnode().metadata_path().to_owned()),
+                )
+            })
             .collect();
 
         let infos1 = add_bdas(uuid1, &devnodes1).unwrap();
@@ -758,7 +768,12 @@ mod tests {
             .backstore
             .blockdevs()
             .iter()
-            .map(|(device_uuid, blockdev)| (*blockdev.device(), (*device_uuid, blockdev.devnode())))
+            .map(|(device_uuid, blockdev)| {
+                (
+                    *blockdev.device(),
+                    (*device_uuid, blockdev.devnode().metadata_path().to_owned()),
+                )
+            })
             .collect();
 
         pool.teardown().unwrap();

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -2,7 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{borrow::Borrow, convert::TryFrom, fmt, ops::Deref, rc::Rc};
+use std::{
+    borrow::Borrow,
+    convert::TryFrom,
+    fmt, io,
+    ops::Deref,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 mod actions;
 pub use crate::engine::types::actions::{
@@ -142,6 +149,63 @@ impl<'a> TryFrom<&'a str> for ReportType {
                 ErrorEnum::NotFound,
                 format!("Report name {} not understood", name),
             )),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BlockDevPath {
+    /// Path to the physical device.
+    physical_path: PathBuf,
+    /// Optional tuple for encrypted devices. The first path is the internal
+    /// path of the logical device and the second is the canonicalized path
+    /// of the logical device.
+    logical_path: Option<(PathBuf, PathBuf)>,
+}
+
+impl BlockDevPath {
+    /// Path for a device that only has a physical path.
+    pub fn physical_device_path(physical: &Path) -> BlockDevPath {
+        BlockDevPath {
+            physical_path: physical.to_owned(),
+            logical_path: None,
+        }
+    }
+
+    /// Path for a device that has both an associated physical path and a mapped
+    /// logical path.
+    pub fn mapped_device_path(physical: &Path, logical: &Path) -> Result<BlockDevPath, io::Error> {
+        let logical_path = Some((logical.to_owned(), logical.canonicalize()?));
+        Ok(BlockDevPath {
+            physical_path: physical.to_owned(),
+            logical_path,
+        })
+    }
+
+    /// Path to the physical device storing the data.
+    pub fn physical_path(&self) -> &Path {
+        &self.physical_path
+    }
+
+    /// Path to the physical or logical device where the metadata should be written.
+    pub fn metadata_path(&self) -> &Path {
+        if let Some((ref path, _)) = self.logical_path {
+            path
+        } else {
+            &self.physical_path
+        }
+    }
+
+    /// This is the path of devices that will be reported to the user.
+    ///
+    /// In the case of an encrypted device, this will be the canonicalized path of
+    /// the path of the device path where metadata should be written. In the
+    /// case of an unencrypted device, it returns the user provided path.
+    pub fn user_path(&self) -> &Path {
+        if let Some((_, ref path)) = self.logical_path {
+            path
+        } else {
+            &self.physical_path
         }
     }
 }

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -187,7 +187,8 @@ impl BlockDevPath {
         &self.physical_path
     }
 
-    /// Path to the physical or logical device where the metadata should be written.
+    /// Path to the physical or logical device where the Stratis metadata should
+    /// be written.
     pub fn metadata_path(&self) -> &Path {
         if let Some((ref path, _)) = self.logical_path {
             path


### PR DESCRIPTION
Closes #2007 

@mulkieran I have taken a different approach from what we discussed.

I decided to make `.devnode()` allowed internally as well as externally. This is necessary because of some of the places we operate on `&dyn BlockDev` types where we cannot use any methods other than the ones in the `BlockDev` trait. My way of mitigating our issue of not know what type of path we are getting back is converting `BlockDevPath` into a struct and making the fields private with two different methods to initialize a `BlockDevPath` type that should be easily extensible if we decide to add additional paths that we want to keep track of in the future.

`.devnode()` now returns a `BlockDevPath` reference which implements a number of different path getters. This then requires the user calling `devnode()` to explicitly state the type of path that they want which may actually help with code clarity. A typical invocation for the metadata_path has changed from:
```rust
bd.devnode()
```
to:
```rust
bd.devnode().metadata_path()
```
for example. Let me know what you think of this direction.