### PR TITLE
Move functionality from stratisd.rs into libstratis

### DIFF
--- a/src/bin/stratisd.rs
+++ b/src/bin/stratisd.rs
@@ -30,17 +30,10 @@ use nix::{
     },
     unistd::getpid,
 };
-use uuid::Uuid;
-
-#[cfg(feature = "dbus_enabled")]
-use libstratis::{
-    dbus_api::{DbusConnectionData, EventHandler},
-    engine::get_engine_listener_list_mut,
-};
 
 use libstratis::{
-    engine::{Engine, Pool, SimEngine, StratEngine},
-    stratis::{buff_log, StratisError, StratisResult, VERSION},
+    engine::{Engine, SimEngine, StratEngine},
+    stratis::{buff_log, MaybeDbusSupport, StratisError, StratisResult, VERSION},
 };
 
 const STRATISD_PID_PATH: &str = "/run/stratisd.pid";
@@ -125,106 +118,6 @@ fn trylock_pid_file() -> StratisResult<File> {
                 pid_str
             )))
         }
-    }
-}
-
-// Conditionally compiled support for a D-Bus interface.
-struct MaybeDbusSupport {
-    #[cfg(feature = "dbus_enabled")]
-    handle: Option<libstratis::dbus_api::DbusConnectionData>,
-}
-
-// If D-Bus compiled out, do very little.
-#[cfg(not(feature = "dbus_enabled"))]
-impl MaybeDbusSupport {
-    fn new() -> MaybeDbusSupport {
-        MaybeDbusSupport {}
-    }
-
-    fn process(
-        &mut self,
-        _engine: &Rc<RefCell<dyn Engine>>,
-        _fds: &mut Vec<libc::pollfd>,
-        _dbus_client_index_start: usize,
-    ) {
-    }
-
-    fn register_pool(&mut self, _pool_uuid: Uuid, _pool: &mut dyn Pool) {}
-
-    fn poll_timeout(&self) -> i32 {
-        // Non-DBus timeout is infinite
-        -1
-    }
-}
-
-#[cfg(feature = "dbus_enabled")]
-impl MaybeDbusSupport {
-    fn new() -> MaybeDbusSupport {
-        MaybeDbusSupport { handle: None }
-    }
-
-    /// Connect to D-Bus and register pools, if not already connected.
-    /// Return the connection, if made or already existing, otherwise, None.
-    fn setup_connection(
-        &mut self,
-        engine: &Rc<RefCell<dyn Engine>>,
-    ) -> Option<&mut DbusConnectionData> {
-        if self.handle.is_none() {
-            match libstratis::dbus_api::DbusConnectionData::connect(Rc::clone(engine)) {
-                Err(err) => {
-                    warn!("D-Bus API is not available: {}", err);
-                }
-                Ok(mut handle) => {
-                    info!("D-Bus API is available");
-                    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
-                    get_engine_listener_list_mut().register_listener(event_handler);
-                    // Register all the pools with dbus
-                    for (_, pool_uuid, pool) in engine.borrow_mut().pools_mut() {
-                        handle.register_pool(pool_uuid, pool)
-                    }
-                    self.handle = Some(handle);
-                }
-            }
-        };
-        self.handle.as_mut()
-    }
-
-    /// Handle any client dbus requests.
-    fn process(
-        &mut self,
-        engine: &Rc<RefCell<dyn Engine>>,
-        fds: &mut Vec<libc::pollfd>,
-        dbus_client_index_start: usize,
-    ) {
-        if let Some(handle) = self.setup_connection(engine) {
-            handle.handle(&fds[dbus_client_index_start..]);
-
-            // Refresh list of dbus fds to poll for. This can change as
-            // D-Bus clients come and go.
-            fds.truncate(dbus_client_index_start);
-            fds.extend(
-                handle
-                    .connection
-                    .borrow()
-                    .watch_fds()
-                    .iter()
-                    .map(|w| w.to_pollfd()),
-            );
-        }
-    }
-
-    fn register_pool(&mut self, pool_uuid: Uuid, pool: &mut dyn Pool) {
-        if let Some(h) = self.handle.as_mut() {
-            h.register_pool(pool_uuid, pool)
-        }
-    }
-
-    fn poll_timeout(&self) -> i32 {
-        // If there is no D-Bus connection set timeout to 1 sec (1000 ms), so
-        // that stratisd can periodically attempt to set up a connection.
-        // If the connection is up, set the timeout to infinite; there is no
-        // need to poll as events will be received.
-        self.handle.as_ref().map_or(1000, |_| -1)
     }
 }
 

--- a/src/stratis/dbus_support.rs
+++ b/src/stratis/dbus_support.rs
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Conditionally compiled support for a D-Bus interface.
+
+// Allow new_without_default lint, because otherwise it would be necessary
+// to implement Default twice, one implementation for the supported version
+// and one for the unsupported version. Also, Default is not really a
+// helpful concept here.
+
+use std::{cell::RefCell, rc::Rc};
+
+use crate::engine::{Engine, Pool, PoolUuid};
+
+#[cfg(feature = "dbus_enabled")]
+use crate::{
+    dbus_api::{DbusConnectionData, EventHandler},
+    engine::get_engine_listener_list_mut,
+};
+
+pub struct MaybeDbusSupport {
+    #[cfg(feature = "dbus_enabled")]
+    handle: Option<DbusConnectionData>,
+}
+
+// If D-Bus compiled out, do very little.
+#[cfg(not(feature = "dbus_enabled"))]
+impl MaybeDbusSupport {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> MaybeDbusSupport {
+        MaybeDbusSupport {}
+    }
+
+    pub fn process(
+        &mut self,
+        _engine: &Rc<RefCell<dyn Engine>>,
+        _fds: &mut Vec<libc::pollfd>,
+        _dbus_client_index_start: usize,
+    ) {
+    }
+
+    pub fn register_pool(&mut self, _pool_uuid: PoolUuid, _pool: &mut dyn Pool) {}
+
+    pub fn poll_timeout(&self) -> i32 {
+        // Non-DBus timeout is infinite
+        -1
+    }
+}
+
+#[cfg(feature = "dbus_enabled")]
+impl MaybeDbusSupport {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> MaybeDbusSupport {
+        MaybeDbusSupport { handle: None }
+    }
+
+    /// Connect to D-Bus and register pools, if not already connected.
+    /// Return the connection, if made or already existing, otherwise, None.
+    fn setup_connection(
+        &mut self,
+        engine: &Rc<RefCell<dyn Engine>>,
+    ) -> Option<&mut DbusConnectionData> {
+        if self.handle.is_none() {
+            match DbusConnectionData::connect(Rc::clone(engine)) {
+                Err(err) => {
+                    warn!("D-Bus API is not available: {}", err);
+                }
+                Ok(mut handle) => {
+                    info!("D-Bus API is available");
+                    let event_handler = Box::new(EventHandler::new(Rc::clone(&handle.connection)));
+                    get_engine_listener_list_mut().register_listener(event_handler);
+                    // Register all the pools with dbus
+                    for (_, pool_uuid, pool) in engine.borrow_mut().pools_mut() {
+                        handle.register_pool(pool_uuid, pool)
+                    }
+                    self.handle = Some(handle);
+                }
+            }
+        };
+        self.handle.as_mut()
+    }
+
+    /// Handle any client dbus requests.
+    pub fn process(
+        &mut self,
+        engine: &Rc<RefCell<dyn Engine>>,
+        fds: &mut Vec<libc::pollfd>,
+        dbus_client_index_start: usize,
+    ) {
+        if let Some(handle) = self.setup_connection(engine) {
+            handle.handle(&fds[dbus_client_index_start..]);
+
+            // Refresh list of dbus fds to poll for. This can change as
+            // D-Bus clients come and go.
+            fds.truncate(dbus_client_index_start);
+            fds.extend(
+                handle
+                    .connection
+                    .borrow()
+                    .watch_fds()
+                    .iter()
+                    .map(|w| w.to_pollfd()),
+            );
+        }
+    }
+
+    pub fn register_pool(&mut self, pool_uuid: PoolUuid, pool: &mut dyn Pool) {
+        if let Some(h) = self.handle.as_mut() {
+            h.register_pool(pool_uuid, pool)
+        }
+    }
+
+    pub fn poll_timeout(&self) -> i32 {
+        // If there is no D-Bus connection set timeout to 1 sec (1000 ms), so
+        // that stratisd can periodically attempt to set up a connection.
+        // If the connection is up, set the timeout to infinite; there is no
+        // need to poll as events will be received.
+        self.handle.as_ref().map_or(1000, |_| -1)
+    }
+}

--- a/src/stratis/mod.rs
+++ b/src/stratis/mod.rs
@@ -6,6 +6,7 @@ pub use self::{
     dbus_support::MaybeDbusSupport,
     errors::{ErrorEnum, StratisError, StratisResult},
     stratis::VERSION,
+    udev_monitor::UdevMonitor,
 };
 
 pub mod buff_log;
@@ -13,3 +14,4 @@ mod dbus_support;
 mod errors;
 #[allow(clippy::module_inception)]
 mod stratis;
+mod udev_monitor;

--- a/src/stratis/mod.rs
+++ b/src/stratis/mod.rs
@@ -3,11 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 pub use self::{
+    dbus_support::MaybeDbusSupport,
     errors::{ErrorEnum, StratisError, StratisResult},
     stratis::VERSION,
 };
 
 pub mod buff_log;
+mod dbus_support;
 mod errors;
 #[allow(clippy::module_inception)]
 mod stratis;

--- a/src/stratis/udev_monitor.rs
+++ b/src/stratis/udev_monitor.rs
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Support for monitoring udev events.
+
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use crate::{
+    engine::Engine,
+    stratis::{dbus_support::MaybeDbusSupport, errors::StratisResult},
+};
+
+/// A facility for listening for and handling udev events that stratisd
+/// considers interesting.
+pub struct UdevMonitor<'a> {
+    socket: libudev::MonitorSocket<'a>,
+}
+
+impl<'a> UdevMonitor<'a> {
+    pub fn create(context: &'a libudev::Context) -> StratisResult<UdevMonitor<'a>> {
+        let mut monitor = libudev::Monitor::new(context)?;
+        monitor.match_subsystem("block")?;
+
+        Ok(UdevMonitor {
+            socket: monitor.listen()?,
+        })
+    }
+
+    pub fn as_raw_fd(&mut self) -> RawFd {
+        self.socket.as_raw_fd()
+    }
+
+    /// Handle udev events.
+    /// Check if a pool can be constructed and update engine and D-Bus layer
+    /// data structures if so.
+    pub fn handle_events(&mut self, engine: &mut dyn Engine, dbus_support: &mut MaybeDbusSupport) {
+        while let Some(event) = self.socket.receive_event() {
+            if let Some((pool_uuid, pool)) = engine.handle_event(&event) {
+                dbus_support.register_pool(pool_uuid, pool);
+            }
+        }
+    }
+}


### PR DESCRIPTION
To enable testing of behavior in rust unit or integration tests instead of just across the D-Bus.