### PR TITLE
Better device discovery logging

### DIFF
--- a/src/engine/strat_engine/liminal.rs
+++ b/src/engine/strat_engine/liminal.rs
@@ -747,10 +747,6 @@ impl LiminalDevices {
 
         let result = setup_pool(pools, pool_uuid, &infos);
 
-        if let Err(err) = &result {
-            warn!("{}", err);
-        }
-
         match result {
             Ok(Some((pool_name, pool))) => {
                 setup_pool_devlinks(&pool_name, &pool);
@@ -761,7 +757,11 @@ impl LiminalDevices {
                 );
                 Some((pool_name, pool))
             }
-            Err(Destination::Hopeless(_)) => {
+            Err(Destination::Hopeless(err)) => {
+                warn!(
+                    "Attempt to set up pool failed, moving to hopeless devices: {}",
+                    err
+                );
                 self.hopeless_device_sets.insert(
                     pool_uuid,
                     infos
@@ -771,7 +771,22 @@ impl LiminalDevices {
                 );
                 None
             }
-            Err(Destination::Errored(_)) | Ok(None) => {
+            Err(Destination::Errored(err)) => {
+                info!("Attempt to set up pool failed, but it may be possible to set up the pool later, if the situation changes: {}", err);
+                self.errored_pool_devices.insert(
+                    pool_uuid,
+                    infos
+                        .drain()
+                        .map(|(pool_uuid, info)| (pool_uuid, LInfo::Stratis(info)))
+                        .collect(),
+                );
+                None
+            }
+            Ok(None) => {
+                info!(
+                    "Pool with UUID {} not set up for a normally occurring reason",
+                    pool_uuid.to_simple_ref()
+                );
                 self.errored_pool_devices.insert(
                     pool_uuid,
                     infos

--- a/src/engine/strat_engine/liminal.rs
+++ b/src/engine/strat_engine/liminal.rs
@@ -887,8 +887,9 @@ impl LiminalDevices {
         match devices.remove(&device_uuid) {
             None => {
                 info!(
-                    "device with Stratis identifiers {} discovered, i.e., identified for the first time during this execution of stratisd",
-                    stratis_identifiers);
+                    "Device information {} discovered and inserted into the set for its pool UUID",
+                    info
+                );
                 devices.insert(device_uuid, info);
                 Ok(devices)
             }
@@ -905,6 +906,9 @@ impl LiminalDevices {
                     Err(hopeless)
                 }
                 Ok(info) => {
+                    info!(
+                        "Device information {} replaces previous device information for the same device UUID in the set for its pool UUID",
+                        info);
                     devices.insert(device_uuid, info);
                     Ok(devices)
                 }


### PR DESCRIPTION
Reduces the volume of log entries and makes those entries that do appear make more sense with respect to the algorithm for managing information about discovered devices.