### PR TITLE
travis.yml: temporarily allow beta lint task to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ before_install:
 jobs:
   fast_finish: true
   allow_failures:
+    # Temporarily allow beta lint task to fail
+    - rust: beta
     # Allow audit task to fail
     - env: TASK=audit
   include:


### PR DESCRIPTION
Related: stratis-storage/project#188