### PR TITLE
Improve cacheing, use and logging of changes to thinpool state

### DIFF
--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -24,7 +24,7 @@ use crate::{
         structures::Table,
         types::{
             BlockDevTier, CreateAction, DevUuid, FilesystemUuid, KeyDescription, MaybeDbusPath,
-            Name, PoolExtendState, PoolState, PoolUuid, Redundancy, RenameAction, SetCreateAction,
+            Name, PoolExtendState, PoolUuid, Redundancy, RenameAction, SetCreateAction,
             SetDeleteAction,
         },
     },
@@ -44,7 +44,6 @@ pub struct SimPool {
     filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
-    pool_state: PoolState,
     pool_extend_state: PoolExtendState,
     dbus_path: MaybeDbusPath,
 }
@@ -70,7 +69,6 @@ impl SimPool {
                 filesystems: Table::default(),
                 redundancy,
                 rdm: Rc::clone(rdm),
-                pool_state: PoolState::Initializing,
                 pool_extend_state: PoolExtendState::Good,
                 dbus_path: MaybeDbusPath(None),
             },

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -29,24 +29,6 @@ pub type DevUuid = Uuid;
 pub type FilesystemUuid = Uuid;
 pub type PoolUuid = Uuid;
 
-/// A DM pool operates in 4 modes.  See drivers/md/dm-thin.c (enum pool_mode).
-/// The 4 modes map to Running, OutOfDataSpace, ReadOnly and Failed - in degrading
-/// order.  Stratis adds 2 additional modes - Initializing and Stopping.  The Stratis
-/// specific modes are used to represent the state when Stratis is either constructing
-/// the pool components or tearing them down.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PoolState {
-    Initializing = 1,   // Startup in progress
-    Running = 2,        // PM_WRITE - pool ok
-    OutOfDataSpace = 4, // Meta
-    ReadOnly = 3,       // The kernel reports PM_OUT_OF_META_SPACE or PM_READ_ONLY as the
-    // same state. PM_OUT_OF_META_SPACE may switch back to PM_WRITE when
-    // the meta data device is expanded.  PM_READ_ONLY requires user
-    // intervention to switch back to PM_WRITE mode.
-    Failed = 5,   // All I/O fails
-    Stopping = 6, // Teardown in progress
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PoolExtendState {
     Initializing = 1,


### PR DESCRIPTION
This PR corrects a number of problems.

These problems arose from a decision that was made to expose a PoolState field used and managed by the Thinpool implementation on the D-Bus interface. This was a poor design choice, because it did not allow proper abstraction and separation of concerns. This property was removed in 1.0.0 for those reasons and others.

This removal gives the internal implementation freedom to alter the internal structures of the Thinpool. In particular, it seems reasonable, rather than storing a value that could be used as a D-Bus property to simply store the result of the thinpool status() call since it is a complete representation of the data obtained from that call.

If this decision is made, then the result of ThinPool::total_physical_used can be calculated from the cached result of the thinpool status() call. Previously this was not possible, because the necessary information was discarded from the PoolState enum. This has the advantage that the value is consistent with the rest of the information in the thinpool and that it is not necessary to use an ioctl to get the value, it is now pure computation. Since the main use of this function is to calculate a value to export on the D-Bus, this is a useful gain in efficiency and stability.

A further improvement is the enhancement of the Thinpool::set_state() method to provide useful and informative logging. Previously, if the pool was in a bad state, various error! and warn! messages were emitted. This caused several problems. First, the journal could get inundated with repetitious messages. Second if the thinpool was restored to a good state, this event was not logged; the log reader could only infer from the cessation of the repeated messages that some improvements must have occurred. Third, several of the log entries were at the error level, which was incorrect, since stratisd would still be able to continue operation under these conditions. Fourth, the log entries did not clearly identify the device involved. Now, a single log entry is emitted when a _change_ of state is detected and it contains all the identifying information available. These log entries can be scrutinized in the existing stratisd test output, and are clearly more informative.

This PR does not address the problems with the test_add_datadevs test in pool.rs, but transforms it to be semantically equivalent to its previous version. I plan to do more work to improve the test and on the PoolExtendState type and associated field in a later PR.

Closes: #1255
Related: https://github.com/stratis-storage/stratisd/issues/1719