### PR TITLE
Remove pool_extend_state field from both engines

### DIFF
--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -24,8 +24,7 @@ use crate::{
         structures::Table,
         types::{
             BlockDevTier, CreateAction, DevUuid, FilesystemUuid, KeyDescription, MaybeDbusPath,
-            Name, PoolExtendState, PoolUuid, Redundancy, RenameAction, SetCreateAction,
-            SetDeleteAction,
+            Name, PoolUuid, Redundancy, RenameAction, SetCreateAction, SetDeleteAction,
         },
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
@@ -44,7 +43,6 @@ pub struct SimPool {
     filesystems: Table<SimFilesystem>,
     redundancy: Redundancy,
     rdm: Rc<RefCell<Randomizer>>,
-    pool_extend_state: PoolExtendState,
     dbus_path: MaybeDbusPath,
 }
 
@@ -69,7 +67,6 @@ impl SimPool {
                 filesystems: Table::default(),
                 redundancy,
                 rdm: Rc::clone(rdm),
-                pool_extend_state: PoolExtendState::Good,
                 dbus_path: MaybeDbusPath(None),
             },
         )

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -631,8 +631,9 @@ mod tests {
             devlinks,
             liminal::{get_bdas, get_blockdevs, get_metadata, LStratisInfo},
             tests::{loopbacked, real},
+            thinpool::PoolExtendState,
         },
-        types::{EngineAction, PoolExtendState, Redundancy},
+        types::{EngineAction, Redundancy},
     };
 
     use super::*;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -631,7 +631,6 @@ mod tests {
             devlinks,
             liminal::{get_bdas, get_blockdevs, get_metadata, LStratisInfo},
             tests::{loopbacked, real},
-            thinpool::PoolExtendState,
         },
         types::{EngineAction, Redundancy},
     };
@@ -937,14 +936,12 @@ mod tests {
 
             let mut amount_written = Sectors(0);
             let buffer_length = Bytes(buffer_length).sectors();
-            while pool.thin_pool.extend_state() == PoolExtendState::Good
-                && match pool.thin_pool.state() {
-                    Some(ThinPoolStatus::Working(working)) => {
-                        working.summary == ThinPoolStatusSummary::Good
-                    }
-                    _ => false,
+            while match pool.thin_pool.state() {
+                Some(ThinPoolStatus::Working(working)) => {
+                    working.summary == ThinPoolStatusSummary::Good
                 }
-            {
+                _ => false,
+            } {
                 f.write_all(buf).unwrap();
                 amount_written += Sectors(1);
                 // Run check roughly every time the buffer is cleared.
@@ -959,7 +956,6 @@ mod tests {
 
             pool.add_blockdevs(pool_uuid, name, paths2, BlockDevTier::Data)
                 .unwrap();
-            assert_matches!(pool.thin_pool.extend_state(), PoolExtendState::Good);
 
             match pool.thin_pool.state() {
                 Some(ThinPoolStatus::Working(working)) => {

--- a/src/engine/strat_engine/thinpool/mod.rs
+++ b/src/engine/strat_engine/thinpool/mod.rs
@@ -8,4 +8,4 @@ mod thinids;
 #[allow(clippy::module_inception)]
 mod thinpool;
 
-pub use self::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
+pub use self::thinpool::{PoolExtendState, ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};

--- a/src/engine/strat_engine/thinpool/mod.rs
+++ b/src/engine/strat_engine/thinpool/mod.rs
@@ -8,4 +8,4 @@ mod thinids;
 #[allow(clippy::module_inception)]
 mod thinpool;
 
-pub use self::thinpool::{PoolExtendState, ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};
+pub use self::thinpool::{ThinPool, ThinPoolSizeParams, DATA_BLOCK_SIZE};

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -191,7 +191,7 @@ struct Segments {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PoolExtendState {
+enum PoolExtendState {
     Initializing = 1,
     Good = 2,
     DataFailed = 3,
@@ -971,11 +971,6 @@ impl ThinPool {
     #[cfg(test)]
     pub fn state(&self) -> Option<&ThinPoolStatus> {
         self.thin_pool_status.as_ref()
-    }
-
-    #[cfg(test)]
-    pub fn extend_state(&self) -> PoolExtendState {
-        self.pool_extend_state
     }
 
     /// Rename a filesystem within the thin pool.

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -42,7 +42,7 @@ use crate::{
             },
         },
         structures::Table,
-        types::{FilesystemUuid, MaybeDbusPath, Name, PoolExtendState, PoolUuid},
+        types::{FilesystemUuid, MaybeDbusPath, Name, PoolUuid},
     },
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
@@ -188,6 +188,15 @@ struct Segments {
     meta_spare_segments: Vec<(Sectors, Sectors)>,
     data_segments: Vec<(Sectors, Sectors)>,
     mdv_segments: Vec<(Sectors, Sectors)>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PoolExtendState {
+    Initializing = 1,
+    Good = 2,
+    DataFailed = 3,
+    MetaFailed = 4,
+    MetaAndDataFailed = 5,
 }
 
 /// A way of digesting the status reported on the thinpool into a value

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -536,15 +536,14 @@ impl ThinPool {
                 let meta_request = target_meta_size - usage.total_meta;
 
                 if meta_request > MIN_META_SEGMENT_SIZE {
-                    let meta_extend_failed = match self.extend_thin_meta_device(
+                    should_save |= match self.extend_thin_meta_device(
                         pool_uuid,
                         backstore,
                         meta_request.sectors(),
                     ) {
-                        Ok(extend_size) => extend_size == Sectors(0),
-                        Err(_) => true,
+                        Ok(extend_size) => extend_size != Sectors(0),
+                        Err(_) => false,
                     };
-                    should_save |= !meta_extend_failed;
                 }
             }
 
@@ -558,8 +557,7 @@ impl ThinPool {
                         Ok(extend_size) => extend_size,
                         Err(_) => Sectors(0),
                     };
-                let data_extend_failed = amount_allocated == Sectors(0);
-                should_save |= !data_extend_failed;
+                should_save |= amount_allocated != Sectors(0);
                 sectors_to_datablocks(amount_allocated)
             };
 

--- a/src/engine/types/mod.rs
+++ b/src/engine/types/mod.rs
@@ -29,15 +29,6 @@ pub type DevUuid = Uuid;
 pub type FilesystemUuid = Uuid;
 pub type PoolUuid = Uuid;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PoolExtendState {
-    Initializing = 1,
-    Good = 2,
-    DataFailed = 3,
-    MetaFailed = 4,
-    MetaAndDataFailed = 5,
-}
-
 /// See Design Doc section 10.2.1 for more details.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockDevState {


### PR DESCRIPTION
This removes another field from the ThinPool implementation that was originally intended to be exported over the D-Bus but is no longer used. In this way it is similar to #2103.

Closes: #1256.