### PR TITLE
Search the keyring for a key before attempting activation

### DIFF
--- a/src/dbus_api/api/shared.rs
+++ b/src/dbus_api/api/shared.rs
@@ -89,7 +89,15 @@ pub fn list_keys(info: &MethodInfo<MTFn<TData>, TData>) -> Result<Vec<String>, S
     let dbus_context = info.tree.get_data();
 
     let engine = dbus_context.engine.borrow();
-    engine.get_key_handler().list().map_err(|e| e.to_string())
+    engine
+        .get_key_handler()
+        .list()
+        .map(|v| {
+            v.into_iter()
+                .map(|kd| kd.as_application_str().to_string())
+                .collect()
+        })
+        .map_err(|e| e.to_string())
 }
 
 pub fn locked_pool_uuids(info: &MethodInfo<MTFn<TData>, TData>) -> Result<Vec<String>, String> {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -17,8 +17,8 @@ use devicemapper::{Bytes, Sectors};
 use crate::{
     engine::types::{
         BlockDevPath, BlockDevTier, CreateAction, DeleteAction, DevUuid, FilesystemUuid,
-        MappingCreateAction, MaybeDbusPath, Name, PoolUuid, RenameAction, ReportType,
-        SetCreateAction, SetDeleteAction, SetUnlockAction,
+        KeyDescription, MappingCreateAction, MaybeDbusPath, Name, PoolUuid, RenameAction,
+        ReportType, SetCreateAction, SetDeleteAction, SetUnlockAction,
     },
     stratis::StratisResult,
 };
@@ -51,7 +51,7 @@ pub trait KeyActions {
 
     /// Return a list of all key descriptions of keys added to the keyring by
     /// Stratis that are still valid.
-    fn list(&self) -> StratisResult<Vec<String>>;
+    fn list(&self) -> StratisResult<Vec<KeyDescription>>;
 
     /// Unset a key with the given key description in the root persistent kernel
     /// keyring.

--- a/src/engine/sim_engine/keys.rs
+++ b/src/engine/sim_engine/keys.rs
@@ -103,12 +103,8 @@ impl KeyActions for SimKeyActions {
         }
     }
 
-    fn list(&self) -> StratisResult<Vec<String>> {
-        Ok(self
-            .0
-            .keys()
-            .map(|k| k.as_application_str().to_string())
-            .collect())
+    fn list(&self) -> StratisResult<Vec<KeyDescription>> {
+        Ok(self.0.keys().cloned().collect())
     }
 
     fn unset(&mut self, key_desc: &str) -> StratisResult<DeleteAction<()>> {

--- a/src/engine/strat_engine/backstore/crypt.rs
+++ b/src/engine/strat_engine/backstore/crypt.rs
@@ -611,7 +611,7 @@ fn activate_and_check_device_path(
     key_desc: &KeyDescription,
     name: &str,
 ) -> Result<()> {
-    let key_description_exists = keys::search_key_persistent(key_desc)
+    let key_description_missing = keys::search_key_persistent(key_desc)
         .map_err(|_| {
             LibcryptErr::Other(format!(
                 "Searching the persistent keyring for the key description {} failed.",
@@ -619,7 +619,7 @@ fn activate_and_check_device_path(
             ))
         })?
         .is_none();
-    if key_description_exists {
+    if key_description_missing {
         warn!(
             "Key description {} was not found in the keyring",
             key_desc.as_application_str()

--- a/src/engine/strat_engine/backstore/crypt.rs
+++ b/src/engine/strat_engine/backstore/crypt.rs
@@ -17,12 +17,8 @@ use libcryptsetup_rs::{
 };
 
 use crate::engine::{
-    strat_engine::{
-        backstore::metadata::StratisIdentifiers,
-        keys,
-        names::{format_crypt_name, KeyDescription},
-    },
-    types::SizedKeyMemory,
+    strat_engine::{backstore::metadata::StratisIdentifiers, keys, names::format_crypt_name},
+    types::{KeyDescription, SizedKeyMemory},
     DevUuid, PoolUuid,
 };
 
@@ -276,7 +272,7 @@ impl CryptInitializer {
             "Failed to create the Stratis token"
         );
 
-        activate_and_check_device_path(device, &activation_name)
+        activate_and_check_device_path(device, key_description, &activation_name)
     }
 
     /// Lay down properly configured LUKS2 metadata on a new physical device
@@ -532,7 +528,11 @@ impl CryptHandle {
     /// Activate encrypted Stratis device using the name stored in the
     /// Stratis token
     pub fn activate(&mut self) -> Result<()> {
-        activate_and_check_device_path(&mut self.device, &self.name.to_owned())
+        activate_and_check_device_path(
+            &mut self.device,
+            &self.key_description,
+            &self.name.to_owned(),
+        )
     }
 
     /// Deactivate the device referenced by the current device handle.
@@ -606,7 +606,31 @@ fn device_is_active(device: &mut CryptDevice, device_name: &str) -> bool {
 
 /// Activate device by token then check that the logical path exists corresponding
 /// to the activation name passed into this method.
-fn activate_and_check_device_path(crypt_device: &mut CryptDevice, name: &str) -> Result<()> {
+fn activate_and_check_device_path(
+    crypt_device: &mut CryptDevice,
+    key_desc: &KeyDescription,
+    name: &str,
+) -> Result<()> {
+    let key_description_exists = keys::search_key_persistent(key_desc)
+        .map_err(|_| {
+            LibcryptErr::Other(format!(
+                "Searching the persistent keyring for the key description {} failed.",
+                key_desc.as_application_str(),
+            ))
+        })?
+        .is_none();
+    if key_description_exists {
+        warn!(
+            "Key description {} was not found in the keyring",
+            key_desc.as_application_str()
+        );
+        return Err(LibcryptErr::Other(format!(
+            "The key description \"{}\" is not currently set. Set a key with \
+            the given key description to proceed.",
+            key_desc.as_application_str(),
+        )));
+    }
+
     // Activate by token
     log_on_failure!(
         crypt_device.token_handle().activate_by_token::<()>(
@@ -820,7 +844,7 @@ fn stratis_token_is_valid(json: &Value) -> bool {
 ///
 /// Requires cryptsetup 2.3
 fn read_key(key_description: &KeyDescription) -> Result<Option<SizedKeyMemory>> {
-    let read_key_result = keys::read_key(key_description);
+    let read_key_result = keys::read_key_persistent(key_description);
     if read_key_result.is_err() {
         warn!(
             "Failed to read the key with key description {} from the keyring; \

--- a/src/engine/strat_engine/backstore/crypt.rs
+++ b/src/engine/strat_engine/backstore/crypt.rs
@@ -625,8 +625,7 @@ fn activate_and_check_device_path(
             key_desc.as_application_str()
         );
         return Err(LibcryptErr::Other(format!(
-            "The key description \"{}\" is not currently set. Set a key with \
-            the given key description to proceed.",
+            "The key description \"{}\" is not currently set.",
             key_desc.as_application_str(),
         )));
     }

--- a/src/engine/strat_engine/backstore/crypt.rs
+++ b/src/engine/strat_engine/backstore/crypt.rs
@@ -853,7 +853,7 @@ fn read_key(key_description: &KeyDescription) -> Result<Option<SizedKeyMemory>> 
         );
     }
     read_key_result
-        .map(|(opt, _)| opt.map(|(_, mem)| mem))
+        .map(|opt| opt.map(|(_, mem)| mem))
         .map_err(|e| LibcryptErr::Other(e.to_string()))
 }
 


### PR DESCRIPTION
Closes #2114 

@mulkieran This PR also has some clean up that I can separate out into a preliminary PR if desired, but the basic rationale for this is that before some of your PR revisions, the `KeyDescription` struct was `strat_engine` specific and now that it is available to both engines, I think this is a much cleaner solution that simply returning a vector of strings. It allows us to keep the key descriptions typed all the way until they're used in the D-Bus layer.