### PR TITLE
blockdevmgr: do not use .iter().next() on an array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ before_install:
 jobs:
   fast_finish: true
   allow_failures:
-    # Temporarily allow beta lint task to fail
-    - rust: beta
     # Allow audit task to fail
     - env: TASK=audit
   include:

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -159,8 +159,7 @@ impl BlockDevMgr {
     pub fn has_valid_passphrase(&self) -> bool {
         CryptHandle::can_unlock(
             self.block_devs
-                .iter()
-                .next()
+                .get(0)
                 .expect("Must have at least one blockdev")
                 .devnode()
                 .physical_path(),


### PR DESCRIPTION
Related: stratis-storage/project#193