### PR TITLE
Remove mask for SIGUSR1

### DIFF
--- a/src/stratis/run.rs
+++ b/src/stratis/run.rs
@@ -123,7 +123,6 @@ pub fn run(sim: bool) -> StratisResult<()> {
     let mut sfd = {
         let mut mask = SigSet::empty();
         mask.add(signal::SIGINT);
-        mask.add(signal::SIGUSR1);
         mask.thread_block()?;
         SignalFd::with_flags(&mask, SfdFlags::SFD_NONBLOCK)?
     };


### PR DESCRIPTION
While looking into #2117, I realized we allow stratisd to pick up `SIGUSR1` without handling it. Given that `SIGUSR1` is a developer defined action, I'd argue that there is no clear answer to what it should do now. However, because we allow it in the mask but don't currently handle it [here](https://github.com/stratis-storage/stratisd/blob/abe2a10d8eccd4fe79bbe5adb3532fa76323392e/src/stratis/run.rs#L29-L37), `SIGUSR1` will cause stratisd to panic with "caught impossible signal". Until we come up with uses for `SIGUSR1` and `SIGUSR2`, I don't think this signal should be allowed in the mask.