### PR TITLE
Fix udev rule to probe with blkid

### DIFF
--- a/src/bin/stratis_uuids_to_names.rs
+++ b/src/bin/stratis_uuids_to_names.rs
@@ -145,16 +145,6 @@ fn main_report_error() -> Result<Option<(String, String)>, StratisUdevError> {
             ));
         }
     };
-    match args.next().as_deref() {
-        Some(action) => {
-            if action != "change" && action != "add" {
-                return Ok(None);
-            }
-        }
-        None => {
-            return Err(StratisUdevError::new("udev action required as argument."));
-        }
-    };
 
     let managed_objects = get_managed_objects()?;
 

--- a/udev/60-stratisd.rules
+++ b/udev/60-stratisd.rules
@@ -1,0 +1,1 @@
+ACTION="add|change", ENV{DM_NAME}=="stratis-1-[0-9a-f]*-thin-fs-[0-9a-f]*", PROGRAM="stratis_uuids_to_names $env{DM_NAME}", SYMLINK+="stratis/%c{1}/%c{2}", IMPORT{builtin}="blkid"

--- a/udev/99-stratisd.rules
+++ b/udev/99-stratisd.rules
@@ -1,1 +1,0 @@
-ENV{DM_NAME}=="stratis-1-[0-9a-f]*-thin-fs-[0-9a-f]*", PROGRAM="stratis_uuids_to_names $env{DM_NAME} $env{ACTION}", SYMLINK+="stratis/%c{1}/%c{2}"


### PR DESCRIPTION
Closes #2162 

This PR makes some changes due to the added import statement not being triggered on `add` events without an explicit condition for that. This also removes the need for some code in `stratis_uuids_to_names`.

@bgurney-rh I'm requesting your approval because the name of the udev rule has changed to make the priority numeric prefix consistent with other storage rules. This will require some changes to packaging.

@drckeefe I would also ask that you take a look at the name change of the udev rule for packaging purposes. Let me know if you have any concerns.

Before we merge, I'd be interested to see if this fixes your issue, @mvollmer. I was able to reproduce your issue before the change, and the issue seems resolved after the change, but I'd like to make sure this is resolved on your system as well.