### PR TITLE
Remove rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-merge_imports=true


### PR DESCRIPTION
This was accidentally included in a previous PR: #2165.