### PR TITLE
Add mechanism for easily flock'ing devices

### DIFF
--- a/src/engine/strat_engine/flock.rs
+++ b/src/engine/strat_engine/flock.rs
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::{
+    fs::File,
+    os::unix::io::AsRawFd,
+    path::{Path, PathBuf},
+};
+
+use nix::fcntl::{flock, FlockArg};
+
+use crate::stratis::StratisResult;
+
+#[allow(dead_code)]
+pub enum DevFlockFlags {
+    Ex,
+    ExNB,
+    Sh,
+    ShNB,
+}
+
+pub struct DevFlock(File, PathBuf);
+
+impl DevFlock {
+    #[allow(dead_code)]
+    pub fn new(dev_path: &Path, flag: DevFlockFlags) -> StratisResult<DevFlock> {
+        let file = File::open(dev_path)?;
+        flock(
+            file.as_raw_fd(),
+            match flag {
+                DevFlockFlags::Ex => FlockArg::LockExclusive,
+                DevFlockFlags::ExNB => FlockArg::LockExclusiveNonblock,
+                DevFlockFlags::Sh => FlockArg::LockShared,
+                DevFlockFlags::ShNB => FlockArg::LockSharedNonblock,
+            },
+        )?;
+        Ok(DevFlock(file, dev_path.to_owned()))
+    }
+}
+
+impl Drop for DevFlock {
+    fn drop(&mut self) {
+        if let Err(e) = flock(self.0.as_raw_fd(), FlockArg::Unlock) {
+            warn!(
+                "Failed to remove advisory lock on device {}: {}",
+                self.1.display(),
+                e,
+            );
+        }
+    }
+}

--- a/src/engine/strat_engine/flock.rs
+++ b/src/engine/strat_engine/flock.rs
@@ -74,3 +74,38 @@ impl Drop for DevFlock {
         }
     }
 }
+
+#[allow(dead_code)]
+pub enum RecursiveFlock {
+    Flock {
+        lock: DevFlock,
+        sublock: Box<RecursiveFlock>,
+    },
+    Base,
+}
+
+impl RecursiveFlock {
+    #[allow(dead_code)]
+    fn new(
+        path: &Path,
+        sublock: RecursiveFlock,
+        flag: DevFlockFlags,
+    ) -> StratisResult<RecursiveFlock> {
+        Ok(RecursiveFlock::Flock {
+            lock: DevFlock::new(path, flag)?,
+            sublock: Box::new(sublock),
+        })
+    }
+
+    #[allow(dead_code)]
+    fn new_from_fd(
+        fd: RawFd,
+        sublock: RecursiveFlock,
+        flag: DevFlockFlags,
+    ) -> StratisResult<RecursiveFlock> {
+        Ok(RecursiveFlock::Flock {
+            lock: DevFlock::new_from_fd(fd, flag)?,
+            sublock: Box::new(sublock),
+        })
+    }
+}

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -8,6 +8,7 @@ mod device;
 mod devlinks;
 mod dm;
 mod engine;
+mod flock;
 mod keys;
 mod liminal;
 mod metadata;


### PR DESCRIPTION
This is an exploratory PR for adding the equivalent of mutability locks on devices that are outside of Rust's mutability memory safety guarantees.