### PR TITLE
Make handling of idempotent return values consistent

### DIFF
--- a/src/dbus_api/api/manager_2_1/methods.rs
+++ b/src/dbus_api/api/manager_2_1/methods.rs
@@ -88,9 +88,7 @@ pub fn unlock_pool(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
                 .collect();
             return_message.append3((true, str_uuids), msg_code_ok(), msg_string_ok())
         }
-        Ok(_) => {
-            return_message.append3((true, Vec::<String>::new()), msg_code_ok(), msg_string_ok())
-        }
+        Ok(_) => return_message.append3(default_return, msg_code_ok(), msg_string_ok()),
         Err(e) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&e);
             return_message.append3(default_return, rc, rs)

--- a/src/dbus_api/api/shared.rs
+++ b/src/dbus_api/api/shared.rs
@@ -135,7 +135,7 @@ pub fn set_key_shared(
             let return_value = match idem_resp {
                 MappingCreateAction::Created(()) => (true, false),
                 MappingCreateAction::ValueChanged(()) => (true, true),
-                MappingCreateAction::Identity => (false, false),
+                MappingCreateAction::Identity => default_return,
             };
             return_message.append3(return_value, msg_code_ok(), msg_string_ok())
         }

--- a/tests/client-dbus/tests/udev/test_udev.py
+++ b/tests/client-dbus/tests/udev/test_udev.py
@@ -308,7 +308,7 @@ class UdevTest3(UdevTest):
                 self.assertEqual(option, False)
             else:
                 self.assertEqual(exit_code, StratisdErrors.OK)
-                self.assertEqual(option, True)
+                self.assertEqual(option, take_down_dm)
                 self.assertEqual(len(unlock_uuids), num_devices if take_down_dm else 0)
 
             wait_for_udev_count(num_devices)


### PR DESCRIPTION
Related to stratis-storage/project#186.

We may have to change the CLI to handle this fix.