### PR TITLE
Revise KeyAction method arguments to use KeyDescription

### DIFF
--- a/src/bin/stratis-min/key.rs
+++ b/src/bin/stratis-min/key.rs
@@ -5,7 +5,7 @@
 use std::{fs::File, io, os::unix::io::AsRawFd};
 
 use libstratis::{
-    engine::{DeleteAction, KeyActions, MappingCreateAction, StratKeyActions},
+    engine::{DeleteAction, KeyActions, KeyDescription, MappingCreateAction, StratKeyActions},
     stratis::{StratisError, StratisResult},
 };
 
@@ -15,7 +15,11 @@ use libstratis::{
 /// settings and settings such as `NOECHO` are not set. This option should be
 /// used carefully as it will cause the password to be echoed on the screen if
 /// invoked interactively.
-pub fn key_set(key_desc: &str, keyfile_path: Option<&str>, no_tty: bool) -> StratisResult<()> {
+pub fn key_set(
+    key_desc: &KeyDescription,
+    keyfile_path: Option<&str>,
+    no_tty: bool,
+) -> StratisResult<()> {
     let ret = match keyfile_path {
         Some(kp) => {
             let file = File::open(kp)?;
@@ -37,7 +41,7 @@ pub fn key_set(key_desc: &str, keyfile_path: Option<&str>, no_tty: bool) -> Stra
     }
 }
 
-pub fn key_unset(key_desc: &str) -> StratisResult<()> {
+pub fn key_unset(key_desc: &KeyDescription) -> StratisResult<()> {
     match StratKeyActions.unset(key_desc)? {
         DeleteAction::Deleted(()) => Ok(()),
         DeleteAction::Identity => Err(StratisError::Error(format!(

--- a/src/dbus_api/api/manager_2_1/methods.rs
+++ b/src/dbus_api/api/manager_2_1/methods.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::convert::TryFrom;
+
 use dbus::{
     tree::{MTFn, MethodInfo, MethodResult},
     Message,
@@ -13,7 +15,7 @@ use crate::{
         types::TData,
         util::{engine_to_dbus_err_tuple, get_next_arg, msg_code_ok, msg_string_ok},
     },
-    engine::{DeleteAction, EngineAction, PoolUuid},
+    engine::{DeleteAction, EngineAction, KeyDescription, PoolUuid},
     stratis::{ErrorEnum, StratisError},
 };
 
@@ -29,7 +31,7 @@ pub fn unset_key(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let key_desc: &str = get_next_arg(&mut iter, 0)?;
+    let key_desc_str: &str = get_next_arg(&mut iter, 0)?;
 
     let dbus_context = m.tree.get_data();
     let default_return = false;
@@ -39,8 +41,13 @@ pub fn unset_key(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         .engine
         .borrow_mut()
         .get_key_handler_mut()
-        .unset(key_desc)
-    {
+        .unset(match KeyDescription::try_from(key_desc_str.to_owned()) {
+            Ok(kd) => kd,
+            Err(e) => {
+                let (rc, rs) = engine_to_dbus_err_tuple(&e);
+                return Ok(vec![return_message.append3(default_return, rc, rs)]);
+            }
+        }) {
         Ok(idem_resp) => {
             let return_value = matches!(idem_resp, DeleteAction::Deleted(()));
             return_message.append3(return_value, msg_code_ok(), msg_string_ok())

--- a/src/dbus_api/api/manager_2_1/methods.rs
+++ b/src/dbus_api/api/manager_2_1/methods.rs
@@ -41,7 +41,7 @@ pub fn unset_key(m: &MethodInfo<MTFn<TData>, TData>) -> MethodResult {
         .engine
         .borrow_mut()
         .get_key_handler_mut()
-        .unset(match KeyDescription::try_from(key_desc_str.to_owned()) {
+        .unset(&match KeyDescription::try_from(key_desc_str.to_owned()) {
             Ok(kd) => kd,
             Err(e) => {
                 let (rc, rs) = engine_to_dbus_err_tuple(&e);

--- a/src/dbus_api/api/shared.rs
+++ b/src/dbus_api/api/shared.rs
@@ -139,7 +139,7 @@ pub fn set_key_shared(
     let return_message = message.method_return();
 
     let msg = match dbus_context.engine.borrow_mut().get_key_handler_mut().set(
-        match KeyDescription::try_from(key_desc_str.to_owned()) {
+        &match KeyDescription::try_from(key_desc_str.to_owned()) {
             Ok(kd) => kd,
             Err(e) => {
                 let (rc, rs) = engine_to_dbus_err_tuple(&e);

--- a/src/dbus_api/api/shared.rs
+++ b/src/dbus_api/api/shared.rs
@@ -130,7 +130,7 @@ pub fn set_key_shared(
     let message: &Message = m.msg;
     let mut iter = message.iter_init();
 
-    let key_desc: &str = get_next_arg(&mut iter, 0)?;
+    let key_desc_str: &str = get_next_arg(&mut iter, 0)?;
     let key_fd: OwnedFd = get_next_arg(&mut iter, 1)?;
     let interactive: bool = get_next_arg(&mut iter, 2)?;
 
@@ -139,7 +139,13 @@ pub fn set_key_shared(
     let return_message = message.method_return();
 
     let msg = match dbus_context.engine.borrow_mut().get_key_handler_mut().set(
-        key_desc,
+        match KeyDescription::try_from(key_desc_str.to_owned()) {
+            Ok(kd) => kd,
+            Err(e) => {
+                let (rc, rs) = engine_to_dbus_err_tuple(&e);
+                return Ok(vec![return_message.append3(default_return, rc, rs)]);
+            }
+        },
         key_fd.as_raw_fd(),
         tuple_to_option((interactive, set_terminal_settings)),
     ) {

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -52,7 +52,7 @@ pub trait KeyActions {
     /// in the keyring but the key data was updated.
     fn set(
         &mut self,
-        key_desc: KeyDescription,
+        key_desc: &KeyDescription,
         key_fd: RawFd,
         interactive: Option<bool>,
     ) -> StratisResult<MappingCreateAction<()>>;
@@ -63,7 +63,7 @@ pub trait KeyActions {
 
     /// Unset a key with the given key description in the root persistent kernel
     /// keyring.
-    fn unset(&mut self, key_desc: KeyDescription) -> StratisResult<DeleteAction<()>>;
+    fn unset(&mut self, key_desc: &KeyDescription) -> StratisResult<DeleteAction<()>>;
 }
 
 /// An interface for reporting internal engine state.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -52,7 +52,7 @@ pub trait KeyActions {
     /// in the keyring but the key data was updated.
     fn set(
         &mut self,
-        key_desc: &str,
+        key_desc: KeyDescription,
         key_fd: RawFd,
         interactive: Option<bool>,
     ) -> StratisResult<MappingCreateAction<()>>;
@@ -63,7 +63,7 @@ pub trait KeyActions {
 
     /// Unset a key with the given key description in the root persistent kernel
     /// keyring.
-    fn unset(&mut self, key_desc: &str) -> StratisResult<DeleteAction<()>>;
+    fn unset(&mut self, key_desc: KeyDescription) -> StratisResult<DeleteAction<()>>;
 }
 
 /// An interface for reporting internal engine state.

--- a/src/engine/sim_engine/keys.rs
+++ b/src/engine/sim_engine/keys.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{collections::HashMap, convert::TryFrom, io::Write, os::unix::io::RawFd};
+use std::{collections::HashMap, io::Write, os::unix::io::RawFd};
 
 use libcryptsetup_rs::SafeMemHandle;
 
@@ -40,24 +40,23 @@ impl SimKeyActions {
 impl KeyActions for SimKeyActions {
     fn set(
         &mut self,
-        key_desc: &str,
+        key_desc: KeyDescription,
         key_fd: RawFd,
         interactive: Option<bool>,
     ) -> StratisResult<MappingCreateAction<()>> {
         let memory = shared::set_key_shared(key_fd, interactive)?;
 
-        let key_description = KeyDescription::try_from(key_desc.to_string())?;
-        match self.read(&key_description) {
+        match self.read(&key_desc) {
             Ok(Some(key_data)) => {
                 if key_data.as_ref() == memory.as_ref() {
                     Ok(MappingCreateAction::Identity)
                 } else {
-                    self.0.insert(key_description.clone(), memory);
+                    self.0.insert(key_desc.clone(), memory);
                     Ok(MappingCreateAction::ValueChanged(()))
                 }
             }
             Ok(None) => {
-                self.0.insert(key_description.clone(), memory);
+                self.0.insert(key_desc.clone(), memory);
                 Ok(MappingCreateAction::Created(()))
             }
             Err(e) => Err(e),
@@ -68,9 +67,8 @@ impl KeyActions for SimKeyActions {
         Ok(self.0.keys().cloned().collect())
     }
 
-    fn unset(&mut self, key_desc: &str) -> StratisResult<DeleteAction<()>> {
-        let key_description = KeyDescription::try_from(key_desc.to_string())?;
-        match self.0.remove(&key_description) {
+    fn unset(&mut self, key_desc: KeyDescription) -> StratisResult<DeleteAction<()>> {
+        match self.0.remove(&key_desc) {
             Some(_) => Ok(DeleteAction::Deleted(())),
             None => Ok(DeleteAction::Identity),
         }

--- a/src/engine/sim_engine/keys.rs
+++ b/src/engine/sim_engine/keys.rs
@@ -40,23 +40,23 @@ impl SimKeyActions {
 impl KeyActions for SimKeyActions {
     fn set(
         &mut self,
-        key_desc: KeyDescription,
+        key_desc: &KeyDescription,
         key_fd: RawFd,
         interactive: Option<bool>,
     ) -> StratisResult<MappingCreateAction<()>> {
         let memory = shared::set_key_shared(key_fd, interactive)?;
 
-        match self.read(&key_desc) {
+        match self.read(key_desc) {
             Ok(Some(key_data)) => {
                 if key_data.as_ref() == memory.as_ref() {
                     Ok(MappingCreateAction::Identity)
                 } else {
-                    self.0.insert(key_desc.clone(), memory);
+                    self.0.insert((*key_desc).clone(), memory);
                     Ok(MappingCreateAction::ValueChanged(()))
                 }
             }
             Ok(None) => {
-                self.0.insert(key_desc.clone(), memory);
+                self.0.insert((*key_desc).clone(), memory);
                 Ok(MappingCreateAction::Created(()))
             }
             Err(e) => Err(e),
@@ -67,8 +67,8 @@ impl KeyActions for SimKeyActions {
         Ok(self.0.keys().cloned().collect())
     }
 
-    fn unset(&mut self, key_desc: KeyDescription) -> StratisResult<DeleteAction<()>> {
-        match self.0.remove(&key_desc) {
+    fn unset(&mut self, key_desc: &KeyDescription) -> StratisResult<DeleteAction<()>> {
+        match self.0.remove(key_desc) {
             Some(_) => Ok(DeleteAction::Deleted(())),
             None => Ok(DeleteAction::Identity),
         }

--- a/src/engine/strat_engine/keys.rs
+++ b/src/engine/strat_engine/keys.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{convert::TryFrom, ffi::CString, io, mem::size_of, os::unix::io::RawFd, str};
+use std::{ffi::CString, io, mem::size_of, os::unix::io::RawFd, str};
 
 use libc::{syscall, SYS_add_key, SYS_keyctl};
 
@@ -363,29 +363,23 @@ impl StratKeyActions {
     /// is not useful for testing using D-Bus.
     pub fn set_no_fd(
         &mut self,
-        key_desc: &str,
+        key_desc: KeyDescription,
         key: SizedKeyMemory,
     ) -> StratisResult<MappingCreateAction<()>> {
-        Ok(set_key_idem(
-            &KeyDescription::try_from(key_desc.to_string())?,
-            key,
-        )?)
+        Ok(set_key_idem(&key_desc, key)?)
     }
 }
 
 impl KeyActions for StratKeyActions {
     fn set(
         &mut self,
-        key_desc: &str,
+        key_desc: KeyDescription,
         key_fd: RawFd,
         interactive: Option<bool>,
     ) -> StratisResult<MappingCreateAction<()>> {
         let memory = shared::set_key_shared(key_fd, interactive)?;
 
-        Ok(set_key_idem(
-            &KeyDescription::try_from(key_desc.to_string())?,
-            memory,
-        )?)
+        Ok(set_key_idem(&key_desc, memory)?)
     }
 
     fn list(&self) -> StratisResult<Vec<KeyDescription>> {
@@ -394,12 +388,10 @@ impl KeyActions for StratKeyActions {
         key_ids.to_key_descs()
     }
 
-    fn unset(&mut self, key_desc: &str) -> StratisResult<DeleteAction<()>> {
+    fn unset(&mut self, key_desc: KeyDescription) -> StratisResult<DeleteAction<()>> {
         let keyring_id = get_persistent_keyring()?;
 
-        if let Some(key_id) =
-            search_key(keyring_id, &KeyDescription::try_from(key_desc.to_string())?)?
-        {
+        if let Some(key_id) = search_key(keyring_id, &key_desc)? {
             unset_key(key_id).map(|_| DeleteAction::Deleted(()))
         } else {
             Ok(DeleteAction::Identity)

--- a/src/engine/strat_engine/keys.rs
+++ b/src/engine/strat_engine/keys.rs
@@ -363,7 +363,7 @@ impl StratKeyActions {
     /// is not useful for testing using D-Bus.
     pub fn set_no_fd(
         &mut self,
-        key_desc: KeyDescription,
+        key_desc: &KeyDescription,
         key: SizedKeyMemory,
     ) -> StratisResult<MappingCreateAction<()>> {
         Ok(set_key_idem(&key_desc, key)?)
@@ -373,13 +373,13 @@ impl StratKeyActions {
 impl KeyActions for StratKeyActions {
     fn set(
         &mut self,
-        key_desc: KeyDescription,
+        key_desc: &KeyDescription,
         key_fd: RawFd,
         interactive: Option<bool>,
     ) -> StratisResult<MappingCreateAction<()>> {
         let memory = shared::set_key_shared(key_fd, interactive)?;
 
-        Ok(set_key_idem(&key_desc, memory)?)
+        Ok(set_key_idem(key_desc, memory)?)
     }
 
     fn list(&self) -> StratisResult<Vec<KeyDescription>> {
@@ -388,10 +388,10 @@ impl KeyActions for StratKeyActions {
         key_ids.to_key_descs()
     }
 
-    fn unset(&mut self, key_desc: KeyDescription) -> StratisResult<DeleteAction<()>> {
+    fn unset(&mut self, key_desc: &KeyDescription) -> StratisResult<DeleteAction<()>> {
         let keyring_id = get_persistent_keyring()?;
 
-        if let Some(key_id) = search_key(keyring_id, &key_desc)? {
+        if let Some(key_id) = search_key(keyring_id, key_desc)? {
             unset_key(key_id).map(|_| DeleteAction::Deleted(()))
         } else {
             Ok(DeleteAction::Identity)

--- a/src/engine/strat_engine/tests/crypt.rs
+++ b/src/engine/strat_engine/tests/crypt.rs
@@ -36,11 +36,11 @@ where
         .unwrap();
     let key_data = SizedKeyMemory::new(mem, MAX_STRATIS_PASS_SIZE);
 
-    key_handle.set_no_fd(key_description.clone(), key_data)?;
+    key_handle.set_no_fd(&key_description, key_data)?;
 
     let result = test(physical_paths, &key_description, input);
 
-    key_handle.unset(key_description)?;
+    key_handle.unset(&key_description)?;
 
     result
 }

--- a/src/engine/strat_engine/tests/crypt.rs
+++ b/src/engine/strat_engine/tests/crypt.rs
@@ -36,11 +36,11 @@ where
         .unwrap();
     let key_data = SizedKeyMemory::new(mem, MAX_STRATIS_PASS_SIZE);
 
-    key_handle.set_no_fd(desc_str, key_data)?;
+    key_handle.set_no_fd(key_description.clone(), key_data)?;
 
     let result = test(physical_paths, &key_description, input);
 
-    key_handle.unset(desc_str)?;
+    key_handle.unset(key_description)?;
 
     result
 }


### PR DESCRIPTION
Related: #2156 

KeyActions methods set() and unset() and StratKeyActions::set_no_fd() have been adjusted to use KeyDescription rather than &str. 

This revision required a test adjustment in which a keydescription is cloned. Is this the correct approach? Should the methods mentioned above take a &KeyDescription as an argument instead?