### PR TITLE
Decompose StaticHeader::setup() into two functions

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6,7 +6,7 @@ pub use self::{
     engine::{BlockDev, Engine, Filesystem, KeyActions, Pool, Report},
     event::{get_engine_listener_list_mut, EngineEvent, EngineListener},
     sim_engine::SimEngine,
-    strat_engine::{StratEngine, StratKeyActions, BDA},
+    strat_engine::{StaticHeader, StratEngine, StratKeyActions, BDA},
     types::{
         BlockDevState, BlockDevTier, CreateAction, DeleteAction, DevUuid, EngineAction,
         FilesystemUuid, KeyDescription, MappingCreateAction, MaybeDbusPath, Name, PoolUuid,

--- a/src/engine/strat_engine/metadata/bda.rs
+++ b/src/engine/strat_engine/metadata/bda.rs
@@ -60,7 +60,8 @@ impl BDA {
     where
         F: Read + Seek + SyncAll,
     {
-        let header = match StaticHeader::setup(f)? {
+        let read_results = StaticHeader::read_sigblocks(f);
+        let header = match StaticHeader::repair_sigblocks(f, read_results)? {
             Some(header) => header,
             None => return Ok(None),
         };

--- a/src/engine/strat_engine/metadata/mod.rs
+++ b/src/engine/strat_engine/metadata/mod.rs
@@ -18,5 +18,5 @@ mod static_header;
 pub use self::{
     bda::BDA,
     sizes::{BDAExtendedSize, BlockdevSize, MDADataSize},
-    static_header::{device_identifiers, disown_device, StratisIdentifiers},
+    static_header::{device_identifiers, disown_device, StaticHeader, StratisIdentifiers},
 };

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -18,7 +18,11 @@ mod thinpool;
 mod udev;
 mod writing;
 
-pub use self::{engine::StratEngine, keys::StratKeyActions, metadata::BDA};
+pub use self::{
+    engine::StratEngine,
+    keys::StratKeyActions,
+    metadata::{StaticHeader, BDA},
+};
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Related: #2133 

Step 1 of 3

Next steps:
2. Completely replace setup() with calls to these two new functions.
3. Adapt BDA::load() and also probably expose the new method read_buffer()
so that it can be used in the stratis_dump_metadata script. Make changes
elsewhere as necessary.