### PR TITLE
Issue project 52 u128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,13 +244,13 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.28.0"
-source = "git+https://github.com/jbaublitz/devicemapper-rs?branch=u128-bytes#aca885e6cf578c9c5568ea4d61568c75b7a4ff09"
+version = "0.28.1"
+source = "git+https://github.com/jbaublitz/devicemapper-rs?branch=u128-bytes#0900f2c2780e1df866346e88f93c6b941b72d574"
 dependencies = [
  "bitflags",
  "error-chain",
  "libc",
- "nix 0.14.0",
+ "nix 0.18.0",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,14 +244,13 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c41333e34258e919c0811c25c9340a157667fc53d63c2b6047e13a6bf27de37"
+version = "0.28.0"
+source = "git+https://github.com/jbaublitz/devicemapper-rs?branch=u128-bytes#aca885e6cf578c9c5568ea4d61568c75b7a4ff09"
 dependencies = [
  "bitflags",
  "error-chain",
  "libc",
- "nix 0.18.0",
+ "nix 0.14.0",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "devicemapper"
 version = "0.28.1"
-source = "git+https://github.com/jbaublitz/devicemapper-rs?branch=u128-bytes#0900f2c2780e1df866346e88f93c6b941b72d574"
+source = "git+https://github.com/jbaublitz/devicemapper-rs?branch=u128-bytes#4fb3306025cb1168358a491e956b58bf7512f971"
 dependencies = [
  "bitflags",
  "error-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["extras"]
 [dependencies]
 clap = "2"
 nix = "0.18"
-devicemapper = "0.28"
+devicemapper = { git = "https://github.com/jbaublitz/devicemapper-rs", branch = "u128-bytes" }
 crc = "1"
 byteorder = "1"
 chrono = "0.4"

--- a/src/dbus_api/blockdev/fetch_properties_2_0/methods.rs
+++ b/src/dbus_api/blockdev/fetch_properties_2_0/methods.rs
@@ -34,7 +34,7 @@ fn get_properties_shared(
                 result_to_tuple(blockdev_operation(
                     m.tree,
                     object_path.get_name(),
-                    |_, bd| Ok((*bd.size()).to_string()),
+                    |_, bd| Ok((*bd.size().bytes()).to_string()),
                 )),
             )),
             _ => None,

--- a/src/dbus_api/blockdev/fetch_properties_2_0/methods.rs
+++ b/src/dbus_api/blockdev/fetch_properties_2_0/methods.rs
@@ -26,24 +26,20 @@ fn get_properties_shared(
 
     let return_message = message.method_return();
 
-    let return_value: HashMap<String, (bool, Variant<Box<dyn RefArg>>)> =
-        properties
-            .unique()
-            .filter_map(|prop| match prop.as_str() {
-                consts::BLOCKDEV_TOTAL_SIZE_PROP => Some((
-                    prop,
-                    result_to_tuple(blockdev_operation(
-                        m.tree,
-                        object_path.get_name(),
-                        |_, bd| {
-                            Ok((u128::from(*bd.size()) * devicemapper::SECTOR_SIZE as u128)
-                                .to_string())
-                        },
-                    )),
+    let return_value: HashMap<String, (bool, Variant<Box<dyn RefArg>>)> = properties
+        .unique()
+        .filter_map(|prop| match prop.as_str() {
+            consts::BLOCKDEV_TOTAL_SIZE_PROP => Some((
+                prop,
+                result_to_tuple(blockdev_operation(
+                    m.tree,
+                    object_path.get_name(),
+                    |_, bd| Ok((*bd.size()).to_string()),
                 )),
-                _ => None,
-            })
-            .collect();
+            )),
+            _ => None,
+        })
+        .collect();
 
     Ok(vec![return_message.append1(return_value)])
 }

--- a/src/dbus_api/pool/shared.rs
+++ b/src/dbus_api/pool/shared.rs
@@ -76,10 +76,7 @@ pub fn get_pool_has_cache(m: &MethodInfo<MTFn<TData>, TData>) -> Result<bool, St
 
 pub fn get_pool_total_size(m: &MethodInfo<MTFn<TData>, TData>) -> Result<String, String> {
     pool_operation(m.tree, m.path.get_name(), |(_, _, pool)| {
-        Ok(
-            (u128::from(*pool.total_physical_size()) * devicemapper::SECTOR_SIZE as u128)
-                .to_string(),
-        )
+        Ok((*pool.total_physical_size().bytes()).to_string())
     })
 }
 
@@ -87,7 +84,7 @@ pub fn get_pool_total_used(m: &MethodInfo<MTFn<TData>, TData>) -> Result<String,
     pool_operation(m.tree, m.path.get_name(), |(_, _, pool)| {
         pool.total_physical_used()
             .map_err(|e| e.to_string())
-            .map(|size| (u128::from(*size) * devicemapper::SECTOR_SIZE as u128).to_string())
+            .map(|size| (*size.bytes()).to_string())
     })
 }
 

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -113,7 +113,7 @@ pub fn set_key_shared(key_fd: RawFd) -> StratisResult<SizedKeyMemory> {
                 ErrorEnum::Invalid,
                 format!(
                     "Provided key exceeded maximum allow length of {}",
-                    Bytes(MAX_STRATIS_PASS_SIZE as u128)
+                    Bytes::from(MAX_STRATIS_PASS_SIZE)
                 ),
             ));
         }

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -113,7 +113,7 @@ pub fn set_key_shared(key_fd: RawFd) -> StratisResult<SizedKeyMemory> {
                 ErrorEnum::Invalid,
                 format!(
                     "Provided key exceeded maximum allow length of {}",
-                    Bytes(MAX_STRATIS_PASS_SIZE as u64)
+                    Bytes(MAX_STRATIS_PASS_SIZE as u128)
                 ),
             ));
         }

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -51,7 +51,7 @@ impl BlockDev for SimDev {
     }
 
     fn size(&self) -> Sectors {
-        Bytes(IEC::Gi).sectors()
+        Bytes(u128::from(IEC::Gi)).sectors()
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {

--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -51,7 +51,7 @@ impl BlockDev for SimDev {
     }
 
     fn size(&self) -> Sectors {
-        Bytes(u128::from(IEC::Gi)).sectors()
+        Bytes::from(IEC::Gi).sectors()
     }
 
     fn set_dbus_path(&mut self, path: MaybeDbusPath) {

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -345,7 +345,7 @@ impl BlockDevMgr {
             current_time
         };
 
-        let data_size = Bytes(metadata.len() as u64);
+        let data_size = Bytes(metadata.len() as u128);
         let candidates = self
             .block_devs
             .iter_mut()

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -345,7 +345,7 @@ impl BlockDevMgr {
             current_time
         };
 
-        let data_size = Bytes(metadata.len() as u128);
+        let data_size = Bytes::from(metadata.len());
         let candidates = self
             .block_devs
             .iter_mut()

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -38,7 +38,7 @@ use crate::{
     stratis::{ErrorEnum, StratisError, StratisResult},
 };
 
-const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi);
+const MIN_DEV_SIZE: Bytes = Bytes(IEC::Gi as u128);
 
 // Get information that can be obtained from udev for the block device
 // identified by devnode. Return an error if there was an error finding the

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -28,6 +28,6 @@ pub fn blkdev_size(file: &File) -> StratisResult<Bytes> {
 
     match unsafe { blkgetsize64(file.as_raw_fd(), &mut val) } {
         Err(x) => Err(StratisError::Nix(x)),
-        Ok(_) => Ok(Bytes(val)),
+        Ok(_) => Ok(Bytes(u128::from(val))),
     }
 }

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -28,6 +28,6 @@ pub fn blkdev_size(file: &File) -> StratisResult<Bytes> {
 
     match unsafe { blkgetsize64(file.as_raw_fd(), &mut val) } {
         Err(x) => Err(StratisError::Nix(x)),
-        Ok(_) => Ok(Bytes(u128::from(val))),
+        Ok(_) => Ok(Bytes::from(val)),
     }
 }

--- a/src/engine/strat_engine/metadata/bda.rs
+++ b/src/engine/strat_engine/metadata/bda.rs
@@ -155,7 +155,7 @@ mod tests {
         /// Initialize a BDA.
         /// Verify that the last update time is None.
         fn empty_bda(ref sh in static_header_strategy()) {
-            let buf_size = convert_test!(*sh.mda_size.bda_size().sectors().bytes(), u64, usize);
+            let buf_size = convert_test!(*sh.mda_size.bda_size().sectors().bytes(), u128, usize);
             let mut buf = Cursor::new(vec![0; buf_size]);
             let bda = BDA::initialize(
                 &mut buf,
@@ -181,7 +181,7 @@ mod tests {
             0;
             convert_test!(
                 *sh.blkdev_size.sectors().bytes(),
-                u64,
+                u128,
                 usize
             )
         ]);
@@ -202,7 +202,7 @@ mod tests {
             0;
             convert_test!(
                 *sh.blkdev_size.sectors().bytes(),
-                u64,
+                u128,
                 usize
             )
         ]);
@@ -234,7 +234,7 @@ mod tests {
             ref state in vec(num::u8::ANY, 1..100),
             ref next_state in vec(num::u8::ANY, 1..100)
         ) {
-            let buf_size = convert_test!(*sh.mda_size.bda_size().sectors().bytes(), u64, usize);
+            let buf_size = convert_test!(*sh.mda_size.bda_size().sectors().bytes(), u128, usize);
             let mut buf = Cursor::new(vec![0; buf_size]);
             let mut bda = BDA::initialize(
                 &mut buf,

--- a/src/engine/strat_engine/metadata/mda.rs
+++ b/src/engine/strat_engine/metadata/mda.rs
@@ -158,7 +158,7 @@ impl MDARegions {
             ));
         }
 
-        let used = Bytes(data.len() as u128);
+        let used = Bytes::from(data.len());
         let max_available = self.max_data_size().bytes();
         if used > max_available {
             let err_msg = format!(
@@ -334,7 +334,7 @@ impl MDAHeader {
                 assert!(secs <= std::i64::MAX as u64);
 
                 Some(MDAHeader {
-                    used: MetaDataSize::new(Bytes(u128::from(used))),
+                    used: MetaDataSize::new(Bytes::from(used)),
                     last_updated: Utc.timestamp(secs as i64, LittleEndian::read_u32(&buf[24..28])),
                     data_crc: LittleEndian::read_u32(&buf[4..8]),
                 })
@@ -482,7 +482,7 @@ mod tests {
 
             let header = MDAHeader {
                 last_updated: Utc.timestamp(sec, nsec),
-                used: MetaDataSize::new(Bytes(data.len() as u128)),
+                used: MetaDataSize::new(Bytes::from(data.len())),
                 data_crc: crc32::checksum_castagnoli(data),
             };
             let buf = header.to_buf();
@@ -504,7 +504,7 @@ mod tests {
 
         let header = MDAHeader {
             last_updated: Utc::now(),
-            used: MetaDataSize::new(Bytes(data.len() as u128)),
+            used: MetaDataSize::new(Bytes::from(data.len())),
             data_crc: crc32::checksum_castagnoli(&data),
         };
         let mut buf = header.to_buf();

--- a/src/engine/strat_engine/metadata/sizes.rs
+++ b/src/engine/strat_engine/metadata/sizes.rs
@@ -48,7 +48,7 @@ pub mod mda_size {
     use devicemapper::{Bytes, Sectors};
 
     pub const _MDA_REGION_HDR_SIZE: usize = 32;
-    const MDA_REGION_HDR_SIZE: Bytes = Bytes(_MDA_REGION_HDR_SIZE as u64);
+    const MDA_REGION_HDR_SIZE: Bytes = Bytes(_MDA_REGION_HDR_SIZE as u128);
 
     // The minimum size allocated for variable length metadata
     pub const MIN_MDA_DATA_REGION_SIZE: Bytes = Bytes(260_064);

--- a/src/engine/strat_engine/metadata/static_header.rs
+++ b/src/engine/strat_engine/metadata/static_header.rs
@@ -503,11 +503,11 @@ pub mod tests {
         let pool_uuid = Uuid::new_v4();
         let dev_uuid = Uuid::new_v4();
         let mda_size = MDADataSize::new(
-            MDADataSize::default().bytes() + Bytes(u64::from(mda_size_factor * 4)),
+            MDADataSize::default().bytes() + Bytes(u128::from(mda_size_factor * 4)),
         )
         .region_size()
         .mda_size();
-        let blkdev_size = (Bytes(IEC::Mi) + Sectors(blkdev_size).bytes()).sectors();
+        let blkdev_size = (Bytes(u128::from(IEC::Mi)) + Sectors(blkdev_size).bytes()).sectors();
         StaticHeader::new(
             StratisIdentifiers::new(pool_uuid, dev_uuid),
             mda_size,

--- a/src/engine/strat_engine/metadata/static_header.rs
+++ b/src/engine/strat_engine/metadata/static_header.rs
@@ -502,12 +502,11 @@ pub mod tests {
     pub fn random_static_header(blkdev_size: u64, mda_size_factor: u32) -> StaticHeader {
         let pool_uuid = Uuid::new_v4();
         let dev_uuid = Uuid::new_v4();
-        let mda_size = MDADataSize::new(
-            MDADataSize::default().bytes() + Bytes(u128::from(mda_size_factor * 4)),
-        )
-        .region_size()
-        .mda_size();
-        let blkdev_size = (Bytes(u128::from(IEC::Mi)) + Sectors(blkdev_size).bytes()).sectors();
+        let mda_size =
+            MDADataSize::new(MDADataSize::default().bytes() + Bytes::from(mda_size_factor * 4))
+                .region_size()
+                .mda_size();
+        let blkdev_size = (Bytes::from(IEC::Mi) + Sectors(blkdev_size).bytes()).sectors();
         StaticHeader::new(
             StratisIdentifiers::new(pool_uuid, dev_uuid),
             mda_size,

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -789,7 +789,7 @@ mod tests {
             let buf = &[1u8; SECTOR_SIZE];
 
             let mut amount_written = Sectors(0);
-            let buffer_length = Bytes(buffer_length).sectors();
+            let buffer_length = Bytes(u128::from(buffer_length)).sectors();
             while match pool.thin_pool.state() {
                 Some(ThinPoolStatus::Working(working)) => {
                     working.summary == ThinPoolStatusSummary::Good
@@ -823,7 +823,11 @@ mod tests {
     #[test]
     fn loop_test_add_datadevs() {
         loopbacked::test_with_spec(
-            &loopbacked::DeviceLimits::Range(2, 3, Some((4u64 * Bytes(IEC::Gi)).sectors())),
+            &loopbacked::DeviceLimits::Range(
+                2,
+                3,
+                Some((4u64 * Bytes(u128::from(IEC::Gi))).sectors()),
+            ),
             test_add_datadevs,
         );
     }
@@ -833,8 +837,8 @@ mod tests {
         real::test_with_spec(
             &real::DeviceLimits::AtLeast(
                 2,
-                Some((2u64 * Bytes(IEC::Gi)).sectors()),
-                Some((4u64 * Bytes(IEC::Gi)).sectors()),
+                Some((2u64 * Bytes(u128::from(IEC::Gi))).sectors()),
+                Some((4u64 * Bytes(u128::from(IEC::Gi))).sectors()),
             ),
             test_add_datadevs,
         );

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -789,7 +789,7 @@ mod tests {
             let buf = &[1u8; SECTOR_SIZE];
 
             let mut amount_written = Sectors(0);
-            let buffer_length = Bytes(u128::from(buffer_length)).sectors();
+            let buffer_length = Bytes::from(buffer_length).sectors();
             while match pool.thin_pool.state() {
                 Some(ThinPoolStatus::Working(working)) => {
                     working.summary == ThinPoolStatusSummary::Good
@@ -823,11 +823,7 @@ mod tests {
     #[test]
     fn loop_test_add_datadevs() {
         loopbacked::test_with_spec(
-            &loopbacked::DeviceLimits::Range(
-                2,
-                3,
-                Some((4u64 * Bytes(u128::from(IEC::Gi))).sectors()),
-            ),
+            &loopbacked::DeviceLimits::Range(2, 3, Some(Bytes::from(IEC::Gi * 4).sectors())),
             test_add_datadevs,
         );
     }
@@ -837,8 +833,8 @@ mod tests {
         real::test_with_spec(
             &real::DeviceLimits::AtLeast(
                 2,
-                Some((2u64 * Bytes(u128::from(IEC::Gi))).sectors()),
-                Some((4u64 * Bytes(u128::from(IEC::Gi))).sectors()),
+                Some(Bytes::from(IEC::Gi * 2).sectors()),
+                Some(Bytes::from(IEC::Gi * 4).sectors()),
             ),
             test_add_datadevs,
         );

--- a/src/engine/strat_engine/tests/loopbacked.rs
+++ b/src/engine/strat_engine/tests/loopbacked.rs
@@ -37,7 +37,7 @@ impl LoopTestDev {
     /// Create its backing store of specified size. The file is sparse but
     /// will appear to be zeroed.
     pub fn new(lc: &LoopControl, path: &Path, size: Option<Sectors>) -> LoopTestDev {
-        let size = size.unwrap_or_else(|| Bytes(u128::from(IEC::Gi)).sectors());
+        let size = size.unwrap_or_else(|| Bytes::from(IEC::Gi).sectors());
 
         let f = OpenOptions::new()
             .read(true)

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -34,7 +34,12 @@ impl RealTestDev {
     /// Wipe initial MiB to clear metadata.
     pub fn new(dev: Either<PathBuf, LinearDev>) -> RealTestDev {
         let test_dev = RealTestDev { dev };
-        wipe_sectors(test_dev.as_path(), Sectors(0), Bytes(IEC::Mi).sectors()).unwrap();
+        wipe_sectors(
+            test_dev.as_path(),
+            Sectors(0),
+            Bytes(u128::from(IEC::Mi)).sectors(),
+        )
+        .unwrap();
         test_dev
     }
 
@@ -45,7 +50,12 @@ impl RealTestDev {
 
     /// Teardown a real test dev
     fn teardown(self) {
-        wipe_sectors(&self.as_path(), Sectors(0), Bytes(IEC::Mi).sectors()).unwrap();
+        wipe_sectors(
+            &self.as_path(),
+            Sectors(0),
+            Bytes(u128::from(IEC::Mi)).sectors(),
+        )
+        .unwrap();
         if let Some(mut ld) = self.dev.right() {
             ld.teardown(get_dm()).unwrap();
         }
@@ -89,7 +99,7 @@ fn get_device_runs<'a>(
         }
     };
 
-    let min_size = min_size.unwrap_or_else(|| Bytes(IEC::Gi).sectors());
+    let min_size = min_size.unwrap_or_else(|| Bytes(u128::from(IEC::Gi)).sectors());
 
     assert!(max_size.is_none() || Some(min_size) <= max_size);
 

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -37,7 +37,7 @@ impl RealTestDev {
         wipe_sectors(
             test_dev.as_path(),
             Sectors(0),
-            Bytes(u128::from(IEC::Mi)).sectors(),
+            Bytes::from(IEC::Mi).sectors(),
         )
         .unwrap();
         test_dev
@@ -50,12 +50,7 @@ impl RealTestDev {
 
     /// Teardown a real test dev
     fn teardown(self) {
-        wipe_sectors(
-            &self.as_path(),
-            Sectors(0),
-            Bytes(u128::from(IEC::Mi)).sectors(),
-        )
-        .unwrap();
+        wipe_sectors(&self.as_path(), Sectors(0), Bytes::from(IEC::Mi).sectors()).unwrap();
         if let Some(mut ld) = self.dev.right() {
             ld.teardown(get_dm()).unwrap();
         }
@@ -99,7 +94,7 @@ fn get_device_runs<'a>(
         }
     };
 
-    let min_size = min_size.unwrap_or_else(|| Bytes(u128::from(IEC::Gi)).sectors());
+    let min_size = min_size.unwrap_or_else(|| Bytes::from(IEC::Gi).sectors());
 
     assert!(max_size.is_none() || Some(min_size) <= max_size);
 

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -345,7 +345,7 @@ pub fn fs_usage(mount_point: &Path) -> StratisResult<(Bytes, Bytes)> {
         stat.blocks_free() as u64,
     );
     Ok((
-        Bytes(u128::from(block_size * blocks)),
-        Bytes(u128::from(block_size * (blocks - blocks_free))),
+        Bytes::from(block_size * blocks),
+        Bytes::from(block_size * (blocks - blocks_free)),
     ))
 }

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -345,7 +345,7 @@ pub fn fs_usage(mount_point: &Path) -> StratisResult<(Bytes, Bytes)> {
         stat.blocks_free() as u64,
     );
     Ok((
-        Bytes(block_size * blocks),
-        Bytes(block_size * (blocks - blocks_free)),
+        Bytes(u128::from(block_size * blocks)),
+        Bytes(u128::from(block_size * (blocks - blocks_free))),
     ))
 }

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1341,7 +1341,7 @@ mod tests {
     #[test]
     fn loop_test_full_pool() {
         loopbacked::test_with_spec(
-            &loopbacked::DeviceLimits::Exactly(2, Some(Bytes(IEC::Gi).sectors())),
+            &loopbacked::DeviceLimits::Exactly(2, Some(Bytes(u128::from(IEC::Gi)).sectors())),
             test_full_pool,
         );
     }
@@ -1351,8 +1351,8 @@ mod tests {
         real::test_with_spec(
             &real::DeviceLimits::Exactly(
                 2,
-                Some(Bytes(IEC::Gi).sectors()),
-                Some(Bytes(IEC::Gi * 4).sectors()),
+                Some(Bytes(u128::from(IEC::Gi)).sectors()),
+                Some(Bytes(u128::from(IEC::Gi) * 4).sectors()),
             ),
             test_full_pool,
         );
@@ -1641,7 +1641,7 @@ mod tests {
 
         // Create a filesystem as small as possible.  Allocate 1 MiB bigger than
         // the low water mark.
-        let fs_size = FILESYSTEM_LOWATER + Bytes(IEC::Mi).sectors();
+        let fs_size = FILESYSTEM_LOWATER + Bytes(u128::from(IEC::Mi)).sectors();
 
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool
@@ -1668,7 +1668,7 @@ mod tests {
         }
         // Write 2 MiB of data. The filesystem's free space is now 1 MiB
         // below FILESYSTEM_LOWATER.
-        let write_size = Bytes(IEC::Mi * 2).sectors();
+        let write_size = Bytes(u128::from(IEC::Mi) * 2).sectors();
         let buf = &[1u8; SECTOR_SIZE];
         for i in 0..*write_size {
             let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1341,7 +1341,7 @@ mod tests {
     #[test]
     fn loop_test_full_pool() {
         loopbacked::test_with_spec(
-            &loopbacked::DeviceLimits::Exactly(2, Some(Bytes(u128::from(IEC::Gi)).sectors())),
+            &loopbacked::DeviceLimits::Exactly(2, Some(Bytes::from(IEC::Gi).sectors())),
             test_full_pool,
         );
     }
@@ -1351,8 +1351,8 @@ mod tests {
         real::test_with_spec(
             &real::DeviceLimits::Exactly(
                 2,
-                Some(Bytes(u128::from(IEC::Gi)).sectors()),
-                Some(Bytes(u128::from(IEC::Gi) * 4).sectors()),
+                Some(Bytes::from(IEC::Gi).sectors()),
+                Some(Bytes::from(IEC::Gi * 4).sectors()),
             ),
             test_full_pool,
         );
@@ -1641,7 +1641,7 @@ mod tests {
 
         // Create a filesystem as small as possible.  Allocate 1 MiB bigger than
         // the low water mark.
-        let fs_size = FILESYSTEM_LOWATER + Bytes(u128::from(IEC::Mi)).sectors();
+        let fs_size = FILESYSTEM_LOWATER + Bytes::from(IEC::Mi).sectors();
 
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool
@@ -1668,7 +1668,7 @@ mod tests {
         }
         // Write 2 MiB of data. The filesystem's free space is now 1 MiB
         // below FILESYSTEM_LOWATER.
-        let write_size = Bytes(u128::from(IEC::Mi) * 2).sectors();
+        let write_size = Bytes::from(IEC::Mi * 2).sectors();
         let buf = &[1u8; SECTOR_SIZE];
         for i in 0..*write_size {
             let file_path = tmp_dir.path().join(format!("stratis_test{}.txt", i));

--- a/src/engine/strat_engine/writing.rs
+++ b/src/engine/strat_engine/writing.rs
@@ -60,11 +60,11 @@ fn write_sectors<P: AsRef<Path>>(
     buf: &[u8; SECTOR_SIZE],
 ) -> StratisResult<()> {
     let mut f = BufWriter::with_capacity(
-        convert_const!(min(IEC::Mi, *(length.bytes())), u64, usize),
+        convert_const!(min(u128::from(IEC::Mi), *(length.bytes())), u128, usize),
         OpenOptions::new().write(true).open(path)?,
     );
 
-    f.seek(SeekFrom::Start(*offset.bytes()))?;
+    f.seek(SeekFrom::Start(convert_int!(*offset.bytes(), u128, u64)?))?;
     for _ in 0..*length {
         f.write_all(buf)?;
     }


### PR DESCRIPTION
Supersedes #2320 

@mulkieran I think this is ready for review. Based on [this](https://github.com/rust-lang/rfcs/pull/1504), it appears that `u128` is supported on all architectures that Rust supports, even 32 bit ones. Given that our concern was stability, I think that should no longer be an issue.