### PR TITLE
Make new() functions for BDA and MDARegions

### DIFF
--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -490,17 +490,16 @@ pub fn initialize_devices(
             (_, None) => None,
         };
 
-        let bda = BDA::initialize(
-            &mut f,
+        let bda = BDA::new(
             StratisIdentifiers::new(pool_uuid, dev_uuid),
             mda_data_size,
             data_size,
             Utc::now().timestamp() as u64,
         );
 
-        bda.and_then(|bda| {
-            StratBlockDev::new(devno, physical_path, bda, &[], None, hw_id, crypt_handle)
-        })
+        bda.initialize(&mut f)?;
+
+        StratBlockDev::new(devno, physical_path, bda, &[], None, hw_id, crypt_handle)
     }
 
     /// Clean up an encrypted device after initialization failure.

--- a/src/engine/strat_engine/metadata/bda.rs
+++ b/src/engine/strat_engine/metadata/bda.rs
@@ -34,12 +34,8 @@ impl BDA {
         blkdev_size: BlockdevSize,
         initialization_time: u64,
     ) -> BDA {
-        let header = StaticHeader::new(
-            identifiers,
-            mda_data_size.region_size().mda_size(),
-            blkdev_size,
-            initialization_time,
-        );
+        let header =
+            StaticHeader::new(identifiers, mda_data_size, blkdev_size, initialization_time);
 
         let regions = mda::MDARegions::new(header.mda_size);
 


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/270

Make it possible to instantiate a BDA, and then find out its size, without initializing any block devices with Stratis metadata.