### PR TITLE
Exit in the client without sending a message if no bytes were read

### DIFF
--- a/src/jsonrpc/client/key.rs
+++ b/src/jsonrpc/client/key.rs
@@ -21,6 +21,9 @@ pub fn key_set(key_desc: KeyDescription, keyfile_path: Option<&str>) -> StratisR
         None => {
             let password =
                 rpassword::prompt_password_stdout("Enter passphrase followed by return:")?;
+            if password.is_empty() {
+                return Ok(());
+            }
             let (read_end, write_end) = pipe()?;
             write(write_end, password.as_bytes())?;
             do_request!(KeySet, key_desc; read_end)

--- a/src/jsonrpc/client/pool.rs
+++ b/src/jsonrpc/client/pool.rs
@@ -29,9 +29,11 @@ pub fn pool_unlock(
     prompt: bool,
 ) -> StratisResult<()> {
     if prompt {
+        let password = rpassword::prompt_password_stdout("Enter passphrase followed by return:")?;
+        if password.is_empty() {
+            return Ok(());
+        }
         do_request_standard!(PoolUnlock, unlock_method, uuid; {
-            let password =
-                rpassword::prompt_password_stdout("Enter passphrase followed by return:")?;
             let (read_end, write_end) = pipe()?;
             write(write_end, password.as_bytes())?;
             read_end


### PR DESCRIPTION
This fixes behavior where stratis-min will block until `ctrl-C` is issued if `ctrl-D` is passed to the password prompt or `</dev/null` is provided after the command.