### PR TITLE
add xfs_db in dracut module

### DIFF
--- a/dracut/90stratis/module-setup.sh
+++ b/dracut/90stratis/module-setup.sh
@@ -11,6 +11,7 @@ check() {
 	    xfs_admin \
 	    xfs_growfs \
 	    xfs_db \
+	    udevadm \
 	    plymouth \
 	    /usr/sbin/plymouthd \
 	    /usr/lib/udev/stratis-str-cmp \
@@ -41,6 +42,7 @@ install() {
 	    xfs_admin \
 	    xfs_growfs \
 	    xfs_db \
+	    udevadm \
 	    plymouth \
 	    /usr/sbin/plymouthd \
 	    /usr/lib/udev/stratis-str-cmp

--- a/dracut/90stratis/module-setup.sh
+++ b/dracut/90stratis/module-setup.sh
@@ -10,6 +10,7 @@ check() {
 	    mkfs.xfs \
 	    xfs_admin \
 	    xfs_growfs \
+	    xfs_db \
 	    plymouth \
 	    /usr/sbin/plymouthd \
 	    /usr/lib/udev/stratis-str-cmp \
@@ -39,6 +40,7 @@ install() {
 	    mkfs.xfs \
 	    xfs_admin \
 	    xfs_growfs \
+	    xfs_db \
 	    plymouth \
 	    /usr/sbin/plymouthd \
 	    /usr/lib/udev/stratis-str-cmp


### PR DESCRIPTION
Hey there,

I'm running Fedora 34 with the root fs on a stratis volume. When I upgraded to the 5.12 kernel, my initramfs was suddenly no longer able to mount the root fs. I investigated and found that apparently the xfs_db binary is needed in the initramfs. I modified the 90stratis dracut module to include it, and now it's working again, so I thought I'd share the fix.

Unfortunately I can't explain why it was working with the 5.11 kernel and then suddenly stopped when I upgraded to 5.12. Presumably some other dracut module (probably 99fs-lib) was including xfs_db before and for whatever reason stopped doing so 🤷🏻. Either way, if stratisd needs that tool, it needs to be included in the initramfs, so I think my fix is the correct thing to do regardless of the exact cause. 
