### PR TITLE
Do not call isort on non-existent check.py file

### DIFF
--- a/tests/client-dbus/Makefile
+++ b/tests/client-dbus/Makefile
@@ -11,12 +11,12 @@ misc-tests:
 
 .PHONY: fmt
 fmt:
-	isort --recursive check.py src tests
+	isort --recursive src tests
 	black .
 
 .PHONY: fmt-travis
 fmt-travis:
-	isort --recursive --diff --check-only check.py src tests
+	isort --recursive --diff --check-only src tests
 	black . --check
 
 .PHONY: udev-tests


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/308