### PR TITLE
Prepare for upgrade to Rust 1.53

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,11 +148,11 @@ jobs:
         include:
           # MANDATORY CHECKS USING CURRENT DEVELOPMENT COMPILER
           - task: RUST_LOG=libstratis=debug make -f Makefile test-loop
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: RUST_LOG=libstratis=debug make -f Makefile test-loop
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
     runs-on: ubuntu-18.04
@@ -219,7 +219,7 @@ jobs:
               TANG_URL=tang
               RUST_LOG=libstratis=debug
               make -f Makefile test-clevis-loop
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,61 +43,60 @@ jobs:
             toolchain: 1.52.1
             components: clippy
             image: fedora:33
-          # MANDATORY TESTING ON STABLE
           - task: make -f Makefile build
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: make -f Makefile build-min
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: make -f Makefile build-extras
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: make -f Makefile docs-travis
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: make -f Makefile test
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: make -f Makefile release
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: make -f Makefile release-min
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: ubuntu:groovy
           - task: make -f Makefile build
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
           - task: make -f Makefile build-min
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
           - task: make -f Makefile build-extras
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
           - task: make -f Makefile docs-travis
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
           - task: make -f Makefile test
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
           - task: make -f Makefile release
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
           - task: make -f Makefile release-min
-            toolchain: stable
+            toolchain: 1.52.1
             components: cargo
             image: fedora:33
     runs-on: ubuntu-18.04

--- a/src/dbus_api/api/fetch_properties_2_1/methods.rs
+++ b/src/dbus_api/api/fetch_properties_2_1/methods.rs
@@ -20,7 +20,6 @@ use crate::dbus_api::{
 
 const ALL_PROPERTIES: [&str; 2] = [consts::KEY_LIST_PROP, consts::LOCKED_POOL_UUIDS];
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/dbus_api/api/fetch_properties_2_2/methods.rs
+++ b/src/dbus_api/api/fetch_properties_2_2/methods.rs
@@ -24,7 +24,6 @@ const ALL_PROPERTIES: [&str; 3] = [
     consts::LOCKED_POOL_UUIDS,
 ];
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/dbus_api/api/fetch_properties_2_4/methods.rs
+++ b/src/dbus_api/api/fetch_properties_2_4/methods.rs
@@ -86,7 +86,6 @@ pub fn locked_pools_with_devs(
         .collect())
 }
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/dbus_api/blockdev/fetch_properties_2_0/methods.rs
+++ b/src/dbus_api/blockdev/fetch_properties_2_0/methods.rs
@@ -17,7 +17,6 @@ use crate::dbus_api::{
 
 const ALL_PROPERTIES: [&str; 1] = [consts::BLOCKDEV_TOTAL_SIZE_PROP];
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/dbus_api/filesystem/fetch_properties_2_0/methods.rs
+++ b/src/dbus_api/filesystem/fetch_properties_2_0/methods.rs
@@ -17,7 +17,6 @@ use crate::dbus_api::{
 
 const ALL_PROPERTIES: [&str; 1] = [consts::FILESYSTEM_USED_PROP];
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/dbus_api/pool/fetch_properties_2_0/methods.rs
+++ b/src/dbus_api/pool/fetch_properties_2_0/methods.rs
@@ -20,7 +20,6 @@ use crate::dbus_api::{
 
 const ALL_PROPERTIES: [&str; 2] = [consts::POOL_TOTAL_SIZE_PROP, consts::POOL_TOTAL_USED_PROP];
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/dbus_api/pool/fetch_properties_2_1/methods.rs
+++ b/src/dbus_api/pool/fetch_properties_2_1/methods.rs
@@ -27,7 +27,6 @@ const ALL_PROPERTIES: [&str; 4] = [
     consts::POOL_TOTAL_USED_PROP,
 ];
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/dbus_api/pool/fetch_properties_2_3/methods.rs
+++ b/src/dbus_api/pool/fetch_properties_2_3/methods.rs
@@ -29,7 +29,6 @@ const ALL_PROPERTIES: [&str; 5] = [
     consts::POOL_CLEVIS_INFO,
 ];
 
-#[allow(unknown_lints)]
 #[allow(clippy::unnecessary_wraps)]
 fn get_properties_shared(
     m: &MethodInfo<MTSync<TData>, TData>,

--- a/src/engine/strat_engine/liminal/device_info.rs
+++ b/src/engine/strat_engine/liminal/device_info.rs
@@ -259,7 +259,6 @@ impl LInfo {
         // Returns true if the information found via udev for two devices is
         // compatible, otherwise false.
         // Precondition: Stratis identifiers of devices are the same
-        #[allow(unknown_lints)]
         #[allow(clippy::suspicious_operation_groupings)]
         fn luks_luks_compatible(info_1: &LLuksInfo, info_2: &LuksInfo) -> bool {
             assert_eq!(info_1.ids.identifiers, info_2.info.identifiers);


### PR DESCRIPTION
This PR does two separate things:

* removed some old allow unknown lints directives that are no longer necessary
* changes all tests on the stable toolchain in the CI to tests on the current development toolchain. The reasoning here is that since we compile with warnings on, sometimes the upgrade to stable will cause our tests to fail to compile which is inconvenient. The errors do get caught by the clippy task in nightly, which runs on stable.