### PR TITLE
Allow code generated by bindgen for testing struct layouts

### DIFF
--- a/src/systemd/bindings.rs
+++ b/src/systemd/bindings.rs
@@ -5,5 +5,9 @@
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::missing_safety_doc)]
+// This allow should be removed once bindgen finds a way to
+// generate struct alignment tests without triggering errors
+// in the compiler. See https://github.com/rust-lang/rust-bindgen/issues/1651.
+#![allow(deref_nullptr)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Closes #2658 