### PR TITLE
Update CI to use new version of compare_fedora_release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -178,39 +178,3 @@ jobs:
           PYTHONPATH=./src
           make dbus-tests
         working-directory: ./stratis-cli
-
-  checks-with-ci-repo:
-    strategy:
-      matrix:
-        include:
-          - task: ./compare_fedora_versions --manifest-path=../../Cargo.toml
-    continue-on-error: true
-    runs-on: ubuntu-18.04
-    container:
-      image: fedora:33  # CURRENT DEVELOPMENT ENVIRONMENT
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies for Fedora
-        run: >
-          dnf install -y
-          clang
-          curl
-          cryptsetup-devel
-          dbus-devel
-          git
-          libblkid-devel
-          make
-          openssl-devel
-          python-requests
-          python-semantic_version
-          systemd-devel
-      - uses: actions-rs/toolchain@v1
-        with:
-          components: cargo
-          toolchain: 1.53.0  # CURRENT DEVELOPMENT TOOLCHAIN
-          override: true
-      - name: Check out ci repo
-        run: git clone https://github.com/stratis-storage/ci.git
-      - name: ${{ matrix.task }}
-        run: ${{ matrix.task }}
-        working-directory: ./ci/dependency_management

--- a/Makefile
+++ b/Makefile
@@ -335,13 +335,11 @@ verify-dependency-bounds:
 	cargo build --all-targets --all-features
 
 # Check that there are no dependencies missing in Fedora or ones that require
-# versions higher than those available in Fedora. There is no reason to fail
-# if our versions are too low, as we can bump versions at our leisure, so
-# do not check the value of the low key. The jq filter can be updated if we
-# deliberately choose a too high or a missing dependency.
+# versions higher than those available in Fedora.  If any crates have
+# versions that are too low, specify those crates via the --ignore-low
+# command-line option.
 check-fedora-versions:
-	`${COMPARE_FEDORA_VERSIONS} ${MANIFEST_PATH_ARGS} \
-		| jq '[.missing == [], .high == []] | all'`
+	${COMPARE_FEDORA_VERSIONS} ${MANIFEST_PATH_ARGS}
 
 .PHONY:
 	audit


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/307