### PR TITLE
Pass optional size parameter for new filesystem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -344,6 +344,12 @@ jobs:
         run: PROFILEDIR=debug make -f Makefile install
       - name: Check out stratis-cli
         run: git clone https://github.com/stratis-storage/stratis-cli.git
+      - name: Switch to PR branch
+        # yamllint disable rule:line-length
+        run: |
+          git checkout -b mulkieran-issue-project-299 develop-2.4.1
+          git pull https://github.com/mulkieran/stratis-cli.git issue-project-299
+
       - name: Set up for D-Bus
         run: |
           mkdir -p /var/lib/dbus

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -349,7 +349,7 @@ jobs:
         run: |
           git checkout -b mulkieran-issue-project-299 develop-2.4.1
           git pull https://github.com/mulkieran/stratis-cli.git issue-project-299
-
+        working-directory: ./stratis-cli
       - name: Set up for D-Bus
         run: |
           mkdir -p /var/lib/dbus

--- a/src/dbus_api/pool/pool_3_0/api.rs
+++ b/src/dbus_api/pool/pool_3_0/api.rs
@@ -22,7 +22,7 @@ pub fn create_filesystems_method(
     f: &Factory<MTSync<TData>, TData>,
 ) -> Method<MTSync<TData>, TData> {
     f.method("CreateFilesystems", (), create_filesystems)
-        .in_arg(("specs", "as"))
+        .in_arg(("specs", "a(s(bs))"))
         // b: true if filesystems were created
         // a(os): Array of tuples with object paths and names
         //

--- a/src/dbus_api/pool/pool_3_0/methods.rs
+++ b/src/dbus_api/pool/pool_3_0/methods.rs
@@ -93,7 +93,7 @@ pub fn create_filesystems(m: &MethodInfo<MTSync<TData>, TData>) -> MethodResult 
         Some(ref newly_created_filesystems) => {
             let v = newly_created_filesystems
                 .iter()
-                .map(|&(name, uuid)| {
+                .map(|&(name, uuid, _)| {
                     let filesystem = pool
                         .get_filesystem(uuid)
                         .expect("just inserted by create_filesystems")

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -136,7 +136,7 @@ pub trait Pool: Debug {
         &'a mut self,
         pool_name: &str,
         pool_uuid: PoolUuid,
-        specs: &[(&'b str, Option<Sectors>)],
+        specs: &[(&'b str, Option<Bytes>)],
     ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>>;
 
     /// Adds blockdevs specified by paths to pool.

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -137,7 +137,7 @@ pub trait Pool: Debug {
         pool_name: &str,
         pool_uuid: PoolUuid,
         specs: &[(&'b str, Option<Bytes>)],
-    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>>;
+    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid, Sectors)>>;
 
     /// Adds blockdevs specified by paths to pool.
     /// Returns a list of uuids corresponding to devices actually added.

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -13,7 +13,7 @@ use std::{
 use nix::poll::{poll, PollFd, PollFlags};
 use regex::Regex;
 
-use devicemapper::Bytes;
+use devicemapper::{Bytes, Sectors, IEC};
 use libcryptsetup_rs::SafeMemHandle;
 
 use crate::{
@@ -23,6 +23,8 @@ use crate::{
     },
     stratis::{StratisError, StratisResult},
 };
+
+pub const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
 /// Called when the name of a requested pool coincides with the name of an
 /// existing pool. Returns an error if the specifications of the requested

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -29,6 +29,8 @@ const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 #[cfg(test)]
 pub const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
+const MIN_THIN_DEV_SIZE: Sectors = Sectors(64 * IEC::Ki); // 32 MiB
+
 /// Called when the name of a requested pool coincides with the name of an
 /// existing pool. Returns an error if the specifications of the requested
 /// pool differ from the specifications of the existing pool, otherwise
@@ -215,6 +217,11 @@ pub fn validate_filesystem_size_specs<'a>(
                         Err(StratisError::Msg(format!(
                             "Requested size of filesystem {} must be divisble by {}",
                             name, SECTOR_SIZE
+                        )))
+                    } else if size_sectors < MIN_THIN_DEV_SIZE {
+                        Err(StratisError::Msg(format!(
+                            "Requested size of filesystem {} is {} which is less than minimum required: {}",
+                            name, size_sectors, MIN_THIN_DEV_SIZE
                         )))
                     } else {
                         Ok(size_sectors)

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -24,6 +24,9 @@ use crate::{
     stratis::{StratisError, StratisResult},
 };
 
+#[cfg(not(test))]
+const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
+#[cfg(test)]
 pub const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
 /// Called when the name of a requested pool coincides with the name of an

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -29,6 +29,8 @@ const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 #[cfg(test)]
 pub const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
+// Maximum taken from "XFS Algorithms and Data Structured: 3rd edition"
+const MAX_THIN_DEV_SIZE: Sectors = Sectors(16 * IEC::Pi); // 8 EiB
 const MIN_THIN_DEV_SIZE: Sectors = Sectors(64 * IEC::Ki); // 32 MiB
 
 /// Called when the name of a requested pool coincides with the name of an
@@ -222,6 +224,11 @@ pub fn validate_filesystem_size_specs<'a>(
                         Err(StratisError::Msg(format!(
                             "Requested size of filesystem {} is {} which is less than minimum required: {}",
                             name, size_sectors, MIN_THIN_DEV_SIZE
+                        )))
+                    } else if size_sectors > MAX_THIN_DEV_SIZE {
+                        Err(StratisError::Msg(format!(
+                            "Requested size of filesystem {} is {} which is greater than maximum allowed: {}",
+                            name, size_sectors, MAX_THIN_DEV_SIZE
                         )))
                     } else {
                         Ok(size_sectors)

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -5,6 +5,7 @@
 use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
+use serde_json::{Map, Value};
 
 use devicemapper::{Bytes, Sectors};
 
@@ -48,5 +49,21 @@ impl Filesystem for SimFilesystem {
 
     fn used(&self) -> StratisResult<Bytes> {
         Ok((self.size / 2u64).bytes())
+    }
+}
+
+impl<'a> Into<Value> for &'a SimFilesystem {
+    fn into(self) -> Value {
+        let mut json = Map::new();
+        json.insert("size".to_string(), Value::from(self.size().to_string()));
+        json.insert(
+            "used".to_string(),
+            Value::from(
+                self.used()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|_| "Unavailable".to_string()),
+            ),
+        );
+        Value::from(json)
     }
 }

--- a/src/engine/sim_engine/filesystem.rs
+++ b/src/engine/sim_engine/filesystem.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
-use devicemapper::Bytes;
+use devicemapper::{Bytes, Sectors};
 
 use crate::{engine::Filesystem, stratis::StratisResult};
 
@@ -14,14 +14,20 @@ use crate::{engine::Filesystem, stratis::StratisResult};
 pub struct SimFilesystem {
     rand: u32,
     created: DateTime<Utc>,
+    size: Sectors,
 }
 
 impl SimFilesystem {
-    pub fn new() -> SimFilesystem {
+    pub fn new(size: Sectors) -> SimFilesystem {
         SimFilesystem {
             rand: rand::random::<u32>(),
             created: Utc::now(),
+            size,
         }
+    }
+
+    pub fn size(&self) -> Sectors {
+        self.size
     }
 }
 
@@ -41,6 +47,6 @@ impl Filesystem for SimFilesystem {
     }
 
     fn used(&self) -> StratisResult<Bytes> {
-        Ok(Bytes(12_345_678))
+        Ok((self.size / 2u64).bytes())
     }
 }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -240,11 +240,13 @@ impl Pool for SimPool {
 
         let mut result = Vec::new();
         for (name, size) in spec_map {
-            let uuid = FilesystemUuid::new_v4();
-            let new_filesystem = SimFilesystem::new(size);
-            self.filesystems
-                .insert(Name::new((name).to_owned()), uuid, new_filesystem);
-            result.push((name, uuid));
+            if !self.filesystems.contains_name(name) {
+                let uuid = FilesystemUuid::new_v4();
+                let new_filesystem = SimFilesystem::new(size);
+                self.filesystems
+                    .insert(Name::new((name).to_owned()), uuid, new_filesystem);
+                result.push((name, uuid));
+            }
         }
 
         Ok(SetCreateAction::new(result))

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -120,15 +120,23 @@ impl SimPool {
 }
 
 // Precondition: SimDev::into() always returns a value that matches Value::Object(_).
+// Precondition: SimFilesystem::into() always returns a value that matches Value::Object(_).
 impl<'a> Into<Value> for &'a SimPool {
     fn into(self) -> Value {
         json!({
             "filesystems": Value::Array(
                 self.filesystems.iter()
-                    .map(|(name, uuid, _)| json!({
-                        "name": name.to_string(),
-                        "uuid": uuid.to_string(),
-                    }))
+                    .map(|(name, uuid, fs)| {
+                        let mut json = Map::new();
+                        json.insert("name".to_string(), Value::from(name.to_string()));
+                        json.insert("uuid".to_string(), Value::from(uuid.to_string()));
+                        if let Value::Object(map) = fs.into() {
+                            json.extend(map.into_iter());
+                        } else {
+                                panic!("SimFilesystem::into() always returns JSON object")
+                        }
+                        Value::from(json)
+                    })
                     .collect()
             ),
             "blockdevs": {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -215,7 +215,7 @@ impl Pool for SimPool {
         _pool_name: &str,
         _pool_uuid: PoolUuid,
         specs: &[(&'b str, Option<Bytes>)],
-    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>> {
+    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid, Sectors)>> {
         let spec_map = validate_filesystem_size_specs(specs)?;
 
         spec_map.iter().fold(Ok(()), |res, (name, size)| {
@@ -245,7 +245,7 @@ impl Pool for SimPool {
                 let new_filesystem = SimFilesystem::new(size);
                 self.filesystems
                     .insert(Name::new((name).to_owned()), uuid, new_filesystem);
-                result.push((name, uuid));
+                result.push((name, uuid, size));
             }
         }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -398,7 +398,7 @@ mod test {
             name2,
             fs_uuid1
                 .into_iter()
-                .map(|(_, u)| u)
+                .map(|(_, u, _)| u)
                 .collect::<Vec<_>>()
                 .as_slice(),
         )
@@ -407,7 +407,7 @@ mod test {
             name2,
             fs_uuid2
                 .into_iter()
-                .map(|(_, u)| u)
+                .map(|(_, u, _)| u)
                 .collect::<Vec<_>>()
                 .as_slice(),
         )

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,17 +2,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{borrow::Cow, collections::HashMap, path::Path, vec::Vec};
+use std::{borrow::Cow, path::Path, vec::Vec};
 
 use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
 
-use devicemapper::{DmNameBuf, Sectors};
+use devicemapper::{Bytes, DmNameBuf, Sectors};
 
 use crate::{
     engine::{
         engine::{BlockDev, Filesystem, Pool},
-        shared::{init_cache_idempotent_or_err, validate_name, validate_paths},
+        shared::{
+            init_cache_idempotent_or_err, validate_filesystem_size_specs, validate_name,
+            validate_paths,
+        },
         strat_engine::{
             backstore::{Backstore, StratBlockDev},
             metadata::MDADataSize,
@@ -426,17 +429,33 @@ impl Pool for StratPool {
         &'a mut self,
         pool_name: &str,
         pool_uuid: PoolUuid,
-        specs: &[(&'b str, Option<Sectors>)],
+        specs: &[(&'b str, Option<Bytes>)],
     ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>> {
-        let names: HashMap<_, _> = specs.iter().map(|&tup| (tup.0, tup.1)).collect();
+        let spec_map = validate_filesystem_size_specs(specs)?;
 
-        names.iter().fold(Ok(()), |res, (name, _)| {
+        spec_map.iter().fold(Ok(()), |res, (name, size)| {
             res.and_then(|()| validate_name(name))
+                .and_then(|()| {
+                    if let Some((_, fs)) = self.thin_pool.get_filesystem_by_name(name) {
+                        if fs.thindev_size() == *size {
+                            Ok(())
+                        } else {
+                            Err(StratisError::Msg(format!(
+                                "Size {} of filesystem {} to be created conflicts with size {} for existing filesystem",
+                                size,
+                                name,
+                                fs.thindev_size()
+                            )))
+                        }
+                    } else {
+                        Ok(())
+                    }
+                })
         })?;
 
         // TODO: Roll back on filesystem initialization failure.
         let mut result = Vec::new();
-        for (name, size) in names {
+        for (name, size) in spec_map {
             if self.thin_pool.get_mut_filesystem_by_name(name).is_none() {
                 let fs_uuid = self
                     .thin_pool

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -430,7 +430,7 @@ impl Pool for StratPool {
         pool_name: &str,
         pool_uuid: PoolUuid,
         specs: &[(&'b str, Option<Bytes>)],
-    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid)>> {
+    ) -> StratisResult<SetCreateAction<(&'b str, FilesystemUuid, Sectors)>> {
         let spec_map = validate_filesystem_size_specs(specs)?;
 
         spec_map.iter().fold(Ok(()), |res, (name, size)| {
@@ -460,7 +460,7 @@ impl Pool for StratPool {
                 let fs_uuid = self
                     .thin_pool
                     .create_filesystem(pool_name, pool_uuid, name, size)?;
-                result.push((name, fs_uuid));
+                result.push((name, fs_uuid, size));
             }
         }
 
@@ -726,7 +726,7 @@ mod tests {
         let metadata1 = pool.record(name);
         assert_matches!(metadata1.backstore.cache_tier, None);
 
-        let (_, fs_uuid) = pool
+        let (_, fs_uuid, _) = pool
             .create_filesystems(name, uuid, &[("stratis-filesystem", None)])
             .unwrap()
             .changed()
@@ -809,7 +809,7 @@ mod tests {
         invariant(&pool, name);
 
         let fs_name = "stratis_test_filesystem";
-        let (_, fs_uuid) = pool
+        let (_, fs_uuid, _) = pool
             .create_filesystems(name, pool_uuid, &[(fs_name, None)])
             .unwrap()
             .changed()

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use data_encoding::BASE32_NOPAD;
 
 use devicemapper::{
-    Bytes, DmDevice, DmName, DmUuid, Sectors, ThinDev, ThinDevId, ThinPoolDev, ThinStatus, IEC,
+    Bytes, DmDevice, DmName, DmUuid, Sectors, ThinDev, ThinDevId, ThinPoolDev, ThinStatus,
 };
 
 use nix::{
@@ -25,6 +25,7 @@ use nix::{
 use crate::{
     engine::{
         engine::Filesystem,
+        shared::DEFAULT_THIN_DEV_SIZE,
         strat_engine::{
             cmd::{create_fs, set_uuid, udev_settle, xfs_growfs},
             devlinks,
@@ -37,8 +38,6 @@ use crate::{
     },
     stratis::{StratisError, StratisResult},
 };
-
-const DEFAULT_THIN_DEV_SIZE: Sectors = Sectors(2 * IEC::Gi); // 1 TiB
 
 const TEMP_MNT_POINT_PREFIX: &str = "stratis_mp_";
 

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -12,6 +12,7 @@ use std::{
 
 use chrono::{DateTime, TimeZone, Utc};
 use data_encoding::BASE32_NOPAD;
+use serde_json::{Map, Value};
 
 use devicemapper::{
     Bytes, DmDevice, DmName, DmUuid, Sectors, ThinDev, ThinDevId, ThinPoolDev, ThinStatus,
@@ -363,4 +364,23 @@ pub fn fs_usage(mount_point: &Path) -> StratisResult<(Bytes, Bytes)> {
         Bytes::from(block_size * blocks),
         Bytes::from(block_size * (blocks - blocks_free)),
     ))
+}
+
+impl<'a> Into<Value> for &'a StratFilesystem {
+    fn into(self) -> Value {
+        let mut json = Map::new();
+        json.insert(
+            "size".to_string(),
+            Value::from(self.thindev_size().to_string()),
+        );
+        json.insert(
+            "used".to_string(),
+            Value::from(
+                self.used()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|_| "Unavailable".to_string()),
+            ),
+        );
+        Value::from(json)
+    }
 }

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use devicemapper::{
     device_exists, DataBlocks, Device, DmDevice, DmName, DmNameBuf, FlakeyTargetParams, LinearDev,
@@ -1098,10 +1098,17 @@ impl<'a> Into<Value> for &'a ThinPool {
         json!({
             "filesystems": Value::Array(
                 self.filesystems.iter()
-                    .map(|(name, uuid, _)| json!({
-                        "name": name.to_string(),
-                        "uuid": uuid.to_string(),
-                    }))
+                    .map(|(name, uuid, fs)| {
+                        let mut json = Map::new();
+                        json.insert("name".to_string(), Value::from(name.to_string()));
+                        json.insert("uuid".to_string(), Value::from(uuid.to_string()));
+                        if let Value::Object(map) = fs.into() {
+                            json.extend(map.into_iter());
+                        } else {
+                                panic!("SimFilesystem::into() always returns JSON object")
+                        }
+                        Value::from(json)
+                    })
                     .collect()
             )
         })

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -832,7 +832,7 @@ impl ThinPool {
         pool_name: &str,
         pool_uuid: PoolUuid,
         name: &str,
-        size: Option<Sectors>,
+        size: Sectors,
     ) -> StratisResult<FilesystemUuid> {
         let (fs_uuid, mut new_filesystem) =
             StratFilesystem::initialize(pool_uuid, &self.thin_pool, size, self.id_gen.new_id()?)?;
@@ -1207,6 +1207,7 @@ mod tests {
     use devicemapper::{Bytes, SECTOR_SIZE};
 
     use crate::engine::{
+        shared::DEFAULT_THIN_DEV_SIZE,
         strat_engine::{
             cmd,
             metadata::MDADataSize,
@@ -1311,7 +1312,12 @@ mod tests {
         .unwrap();
 
         let fs_uuid = pool
-            .create_filesystem(pool_name, pool_uuid, "stratis_test_filesystem", None)
+            .create_filesystem(
+                pool_name,
+                pool_uuid,
+                "stratis_test_filesystem",
+                DEFAULT_THIN_DEV_SIZE,
+            )
             .unwrap();
 
         check_expected_filesystem_size!(pool);
@@ -1425,7 +1431,7 @@ mod tests {
 
         let filesystem_name = "stratis_test_filesystem";
         let fs_uuid = pool
-            .create_filesystem(pool_name, pool_uuid, filesystem_name, None)
+            .create_filesystem(pool_name, pool_uuid, filesystem_name, DEFAULT_THIN_DEV_SIZE)
             .unwrap();
 
         check_expected_filesystem_size!(pool);
@@ -1555,7 +1561,7 @@ mod tests {
 
         let pool_name = "stratis_test_pool";
         let fs_uuid = pool
-            .create_filesystem(pool_name, pool_uuid, name1, None)
+            .create_filesystem(pool_name, pool_uuid, name1, DEFAULT_THIN_DEV_SIZE)
             .unwrap();
 
         check_expected_filesystem_size!(pool);
@@ -1622,7 +1628,7 @@ mod tests {
         .unwrap();
 
         let fs_uuid = pool
-            .create_filesystem(pool_name, pool_uuid, "fsname", None)
+            .create_filesystem(pool_name, pool_uuid, "fsname", DEFAULT_THIN_DEV_SIZE)
             .unwrap();
 
         check_expected_filesystem_size!(pool);
@@ -1700,7 +1706,7 @@ mod tests {
         let pool_name = "stratis_test_pool";
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool
-            .create_filesystem(pool_name, pool_uuid, fs_name, None)
+            .create_filesystem(pool_name, pool_uuid, fs_name, DEFAULT_THIN_DEV_SIZE)
             .unwrap();
 
         check_expected_filesystem_size!(pool);
@@ -1773,7 +1779,7 @@ mod tests {
 
         let fs_name = "stratis_test_filesystem";
         let fs_uuid = pool
-            .create_filesystem(pool_name, pool_uuid, fs_name, Some(fs_size))
+            .create_filesystem(pool_name, pool_uuid, fs_name, fs_size)
             .unwrap();
 
         let tmp_dir = tempfile::Builder::new()
@@ -1865,8 +1871,13 @@ mod tests {
         )
         .unwrap();
 
-        pool.create_filesystem(pool_name, pool_uuid, "stratis_test_filesystem", None)
-            .unwrap();
+        pool.create_filesystem(
+            pool_name,
+            pool_uuid,
+            "stratis_test_filesystem",
+            DEFAULT_THIN_DEV_SIZE,
+        )
+        .unwrap();
 
         pool.suspend().unwrap();
         pool.suspend().unwrap();
@@ -1917,7 +1928,12 @@ mod tests {
         .unwrap();
 
         let fs_uuid = pool
-            .create_filesystem(pool_name, pool_uuid, "stratis_test_filesystem", None)
+            .create_filesystem(
+                pool_name,
+                pool_uuid,
+                "stratis_test_filesystem",
+                DEFAULT_THIN_DEV_SIZE,
+            )
             .unwrap();
 
         check_expected_filesystem_size!(pool);

--- a/src/engine/types/actions.rs
+++ b/src/engine/types/actions.rs
@@ -10,6 +10,8 @@
 
 use std::fmt::{self, Display};
 
+use devicemapper::Sectors;
+
 use crate::engine::{
     engine::Filesystem,
     types::{DevUuid, FilesystemUuid, PoolUuid},
@@ -305,7 +307,7 @@ impl<T> EngineAction for SetCreateAction<T> {
     }
 }
 
-impl Display for SetCreateAction<(&str, FilesystemUuid)> {
+impl Display for SetCreateAction<(&str, FilesystemUuid, Sectors)> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.changed.is_empty() {
             write!(
@@ -318,7 +320,7 @@ impl Display for SetCreateAction<(&str, FilesystemUuid)> {
                 "The following filesystems {} were successfully created",
                 self.changed
                     .iter()
-                    .map(|(n, u)| format!("name: {}, UUID: {}", n, u))
+                    .map(|(n, u, s)| format!("name: {}, UUID: {}, size: {}", n, u, s))
                     .collect::<Vec<_>>()
                     .join("; ")
             )

--- a/tests/client-dbus/src/stratisd_client_dbus/_introspect.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_introspect.py
@@ -159,7 +159,7 @@ SPECS = {
       <arg name="return_string" type="s" direction="out" />
     </method>
     <method name="CreateFilesystems">
-      <arg name="specs" type="as" direction="in" />
+      <arg name="specs" type="a(s(bs))" direction="in" />
       <arg name="results" type="(ba(os))" direction="out" />
       <arg name="return_code" type="q" direction="out" />
       <arg name="return_string" type="s" direction="out" />


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/299

Changes in this PR:
1. Change the CreateFileystem D-Bus method to accept size parameter.
2. Include more filesystem information, specifically the size, in the JSON report.
3. Set a minimum size of 32 MiB and a maximum of 8 EiB.
4. Log the size of the filesystem on creation.
5. Use an idempotency check that requires that the size and the name of the filesystem be the same. If the filesystem already exists, but the size is different, return an error.