### PR TITLE
Fixes for 1.57.0

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -48,6 +48,7 @@ pub struct StratEngine {
     // kernel keyring.
     // In memory filesystem for passing keys to Clevis.
     // See GitHub issue: https://github.com/stratis-storage/project/issues/212.
+    #[allow(dead_code)]
     key_fs: MemoryFilesystem,
 }
 

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -243,7 +243,7 @@ impl StratFilesystem {
         let mut needs_save = false;
         let original_state = self.cached(|fs| StratFilesystemState {
             size: fs.size(),
-            used: fs.used().ok(),
+            used: fs.used.clone(),
         });
         match self.thin_dev.status(get_dm(), DmOptions::default())? {
             ThinStatus::Working(_) => {


### PR DESCRIPTION
@bgurney-rh These are the two that I needed to tend to. @mulkieran I'm not sure what you want to do about `redundancy` because that is legitimately unused.