### PR TITLE
Add UnownedDevices

### DIFF
--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -100,14 +100,14 @@ impl Engine for SimEngine {
         blockdev_paths: &[&Path],
         encryption_info: Option<&EncryptionInfo>,
     ) -> StratisResult<CreateAction<PoolUuid>> {
-        validate_name(name)?;
-        let name = Name::new(name.to_owned());
-
         if blockdev_paths.is_empty() {
             return Err(StratisError::Msg(
                 "At least one blockdev is required to create a pool.".to_string(),
             ));
         }
+
+        validate_name(name)?;
+        let name = Name::new(name.to_owned());
 
         validate_paths(blockdev_paths)?;
 

--- a/src/engine/sim_engine/engine.rs
+++ b/src/engine/sim_engine/engine.rs
@@ -103,13 +103,13 @@ impl Engine for SimEngine {
         validate_name(name)?;
         let name = Name::new(name.to_owned());
 
-        validate_paths(blockdev_paths)?;
-
         if blockdev_paths.is_empty() {
             return Err(StratisError::Msg(
                 "At least one blockdev is required to create a pool.".to_string(),
             ));
         }
+
+        validate_paths(blockdev_paths)?;
 
         if let Some(key_desc) = encryption_info.and_then(|ei| ei.key_description()) {
             if !self.key_handler.read().await.contains_key(key_desc) {

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -191,17 +191,18 @@ impl Pool for SimPool {
     ) -> StratisResult<SetCreateAction<DevUuid>> {
         validate_paths(blockdevs)?;
 
+        if blockdevs.is_empty() {
+            return Err(StratisError::Msg(
+                "At least one blockdev path is required to initialize a cache.".to_string(),
+            ));
+        }
+
         if self.is_encrypted() {
             return Err(StratisError::Msg(
                 "Use of a cache is not supported with an encrypted pool".to_string(),
             ));
         }
         if !self.has_cache() {
-            if blockdevs.is_empty() {
-                return Err(StratisError::Msg(
-                    "At least one blockdev path is required to initialize a cache.".to_string(),
-                ));
-            }
             let blockdev_pairs: Vec<_> = blockdevs.iter().map(|p| SimDev::new(p, None)).collect();
             let blockdev_uuids: Vec<_> = blockdev_pairs.iter().map(|(uuid, _)| *uuid).collect();
             self.cache_devs.extend(blockdev_pairs);

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -189,13 +189,13 @@ impl Pool for SimPool {
         _pool_name: &str,
         blockdevs: &[&Path],
     ) -> StratisResult<SetCreateAction<DevUuid>> {
-        validate_paths(blockdevs)?;
-
         if blockdevs.is_empty() {
             return Err(StratisError::Msg(
                 "At least one blockdev path is required to initialize a cache.".to_string(),
             ));
         }
+
+        validate_paths(blockdevs)?;
 
         if self.is_encrypted() {
             return Err(StratisError::Msg(
@@ -268,8 +268,6 @@ impl Pool for SimPool {
         paths: &[&Path],
         tier: BlockDevTier,
     ) -> StratisResult<(SetCreateAction<DevUuid>, Option<PoolDiff>)> {
-        validate_paths(paths)?;
-
         if tier == BlockDevTier::Cache && !self.has_cache() {
             return Err(StratisError::Msg(
                     "The cache has not been initialized; you must use init_cache first to initialize the cache.".to_string(),
@@ -280,6 +278,8 @@ impl Pool for SimPool {
             // Treat adding no new blockdev as the empty set.
             return Ok((SetCreateAction::new(vec![]), None));
         }
+
+        validate_paths(paths)?;
 
         let devices: HashSet<_, RandomState> = HashSet::from_iter(paths);
         let encryption_info = pool_enc_to_enc!(self.encryption_info());

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -674,7 +674,7 @@ impl Recordable<BackstoreSave> for Backstore {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, convert::TryFrom, fs::OpenOptions, path::Path};
+    use std::{convert::TryFrom, fs::OpenOptions, path::Path};
 
     use devicemapper::{CacheDevStatus, DataBlocks, DmOptions, IEC};
 
@@ -778,28 +778,16 @@ mod tests {
             CacheDevStatus::Fail => panic!("cache is in a failed state"),
         }
 
-        let data_uuids = backstore
-            .datadevs()
-            .iter()
-            .map(|(u, _)| u)
-            .cloned()
-            .collect::<HashSet<_>>();
         let unowned_devices = ProcessedPathInfos::try_from(datadevpaths)
-            .and_then(|pp| pp.for_add(pool_uuid, &data_uuids))
+            .map(|pp| pp.unpack().1)
             .unwrap();
 
         let data_uuids = backstore.add_datadevs(pool_uuid, unowned_devices).unwrap();
         invariant(&backstore);
         assert_eq!(data_uuids.len(), datadevpaths.len());
 
-        let cache_uuids = backstore
-            .cachedevs()
-            .iter()
-            .map(|(u, _)| u)
-            .cloned()
-            .collect::<HashSet<_>>();
         let unowned_devices = ProcessedPathInfos::try_from(cachedevpaths)
-            .and_then(|pp| pp.for_add(pool_uuid, &cache_uuids))
+            .map(|pp| pp.unpack().1)
             .unwrap();
         let cache_uuids = backstore.add_cachedevs(pool_uuid, unowned_devices).unwrap();
         invariant(&backstore);

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -731,7 +731,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(initdatapaths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -751,7 +751,7 @@ mod tests {
             .init_cache(
                 pool_uuid,
                 ProcessedPathInfos::try_from(initcachepaths)
-                    .and_then(|pp| pp.get_infos_for_create())
+                    .and_then(|pp| pp.for_create())
                     .unwrap(),
             )
             .unwrap();
@@ -854,7 +854,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths1)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -886,7 +886,7 @@ mod tests {
             .init_cache(
                 pool_uuid,
                 ProcessedPathInfos::try_from(paths2)
-                    .and_then(|pp| pp.get_infos_for_create())
+                    .and_then(|pp| pp.for_create())
                     .unwrap(),
             )
             .unwrap();

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -785,7 +785,7 @@ mod tests {
             .cloned()
             .collect::<HashSet<_>>();
         let unowned_devices = ProcessedPathInfos::try_from(datadevpaths)
-            .and_then(|pp| pp.get_infos_for_add(pool_uuid, &data_uuids))
+            .and_then(|pp| pp.for_add(pool_uuid, &data_uuids))
             .unwrap();
 
         let data_uuids = backstore.add_datadevs(pool_uuid, unowned_devices).unwrap();
@@ -799,7 +799,7 @@ mod tests {
             .cloned()
             .collect::<HashSet<_>>();
         let unowned_devices = ProcessedPathInfos::try_from(cachedevpaths)
-            .and_then(|pp| pp.get_infos_for_add(pool_uuid, &cache_uuids))
+            .and_then(|pp| pp.for_add(pool_uuid, &cache_uuids))
             .unwrap();
         let cache_uuids = backstore.add_cachedevs(pool_uuid, unowned_devices).unwrap();
         invariant(&backstore);

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -19,6 +19,7 @@ use crate::{
                 blockdevmgr::{map_to_dm, BlockDevMgr},
                 cache_tier::CacheTier,
                 data_tier::DataTier,
+                devices::UnownedDevices,
                 transaction::RequestTransaction,
             },
             dm::get_dm,
@@ -267,7 +268,7 @@ impl Backstore {
     pub fn add_cachedevs(
         &mut self,
         pool_uuid: PoolUuid,
-        paths: &[&Path],
+        infos: UnownedDevices,
     ) -> StratisResult<Vec<DevUuid>> {
         match self.cache_tier {
             Some(ref mut cache_tier) => {
@@ -275,7 +276,7 @@ impl Backstore {
                     .cache
                     .as_mut()
                     .expect("cache_tier.is_some() <=> self.cache.is_some()");
-                let (uuids, (cache_change, meta_change)) = cache_tier.add(pool_uuid, paths)?;
+                let (uuids, (cache_change, meta_change)) = cache_tier.add(pool_uuid, infos)?;
 
                 if cache_change {
                     let table = map_to_dm(&cache_tier.cache_segments);
@@ -303,9 +304,9 @@ impl Backstore {
     pub fn add_datadevs(
         &mut self,
         pool_uuid: PoolUuid,
-        paths: &[&Path],
+        infos: UnownedDevices,
     ) -> StratisResult<Vec<DevUuid>> {
-        self.data_tier.add(pool_uuid, paths)
+        self.data_tier.add(pool_uuid, infos)
     }
 
     /// Extend the cap device whether it is a cache or not. Create the DM

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -4,7 +4,7 @@
 
 // Code to handle the backing store of a pool.
 
-use std::{cmp, path::Path};
+use std::cmp;
 
 use chrono::{DateTime, Utc};
 use serde_json::Value;
@@ -180,7 +180,7 @@ impl Backstore {
     /// WARNING: metadata changing event
     pub fn initialize(
         pool_uuid: PoolUuid,
-        paths: &[&Path],
+        paths: UnownedDevices,
         mda_data_size: MDADataSize,
         encryption_info: Option<&EncryptionInfo>,
     ) -> StratisResult<Backstore> {
@@ -211,12 +211,12 @@ impl Backstore {
     pub fn init_cache(
         &mut self,
         pool_uuid: PoolUuid,
-        paths: &[&Path],
+        devices: UnownedDevices,
     ) -> StratisResult<Vec<DevUuid>> {
         match self.cache_tier {
             Some(_) => unreachable!("self.cache.is_none()"),
             None => {
-                if paths.is_empty() {
+                if devices.devices.is_empty() {
                     return Err(StratisError::Msg(
                         "Must initialize cache with at least one blockdev.".to_string(),
                     ));
@@ -227,7 +227,8 @@ impl Backstore {
                 // If it is desired to change a cache dev to a data dev, it
                 // should be removed and then re-added in order to ensure
                 // that the MDA region is set to the correct size.
-                let bdm = BlockDevMgr::initialize(pool_uuid, paths, MDADataSize::default(), None)?;
+                let bdm =
+                    BlockDevMgr::initialize(pool_uuid, devices, MDADataSize::default(), None)?;
 
                 let cache_tier = CacheTier::new(bdm)?;
 

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -827,7 +827,7 @@ mod tests {
                 .cloned()
                 .collect::<HashSet<_>>();
             let devices = ProcessedPathInfos::try_from(&paths[2..3])
-                .and_then(|pp| pp.get_infos_for_add(pool_uuid, &dev_uuids))
+                .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
                 .unwrap();
             if bdm.add(pool_uuid, devices).is_err() {
                 Err(Box::new(StratisError::Msg(
@@ -880,7 +880,7 @@ mod tests {
                 .cloned()
                 .collect::<HashSet<_>>();
             let devices = ProcessedPathInfos::try_from(&paths[2..3])
-                .and_then(|pp| pp.get_infos_for_add(pool_uuid, &dev_uuids))
+                .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
                 .unwrap();
             if bdm.add(pool_uuid, devices).is_ok() {
                 Err(Box::new(StratisError::Msg(

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -4,12 +4,7 @@
 
 // Code to handle a collection of block devices.
 
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryFrom,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, convert::TryFrom, fs, path::PathBuf};
 
 use chrono::{DateTime, Duration, Utc};
 use rand::{seq::IteratorRandom, thread_rng};
@@ -28,9 +23,7 @@ use crate::{
                     back_up_luks_header, interpret_clevis_config, restore_luks_header,
                     CryptActivationHandle,
                 },
-                devices::{
-                    initialize_devices, process_and_verify_devices, wipe_blockdevs, UnownedDevices,
-                },
+                devices::{initialize_devices, wipe_blockdevs, UnownedDevices},
                 range_alloc::PerDevSegments,
                 transaction::RequestTransaction,
             },
@@ -146,12 +139,10 @@ impl BlockDevMgr {
     /// Initialize a new StratBlockDevMgr with specified pool and devices.
     pub fn initialize(
         pool_uuid: PoolUuid,
-        paths: &[&Path],
+        devices: UnownedDevices,
         mda_data_size: MDADataSize,
         encryption_info: Option<&EncryptionInfo>,
     ) -> StratisResult<BlockDevMgr> {
-        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths)?;
-
         Ok(BlockDevMgr::new(
             initialize_devices(devices, pool_uuid, mda_data_size, encryption_info)?,
             None,
@@ -211,7 +202,7 @@ impl BlockDevMgr {
         // then the necessary amount must be provided or the data can not be
         // saved.
         let bds = initialize_devices(
-            infos.devices,
+            infos,
             pool_uuid,
             MDADataSize::default(),
             encryption_info.as_ref(),

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -775,7 +775,7 @@ mod tests {
     /// in balance.
     fn test_blockdevmgr_used(paths: &[&Path]) {
         let infos = ProcessedPathInfos::try_from(paths)
-            .and_then(|pp| pp.get_infos_for_create())
+            .and_then(|pp| pp.for_create())
             .unwrap();
         let mut mgr =
             BlockDevMgr::initialize(PoolUuid::new_v4(), infos, MDADataSize::default(), None)
@@ -815,8 +815,7 @@ mod tests {
             let pool_uuid = PoolUuid::new_v4();
             let mut bdm = BlockDevMgr::initialize(
                 pool_uuid,
-                ProcessedPathInfos::try_from(&paths[..2])
-                    .and_then(|pp| pp.get_infos_for_create())?,
+                ProcessedPathInfos::try_from(&paths[..2]).and_then(|pp| pp.for_create())?,
                 MDADataSize::default(),
                 Some(&EncryptionInfo::KeyDesc(key_desc.clone())),
             )?;
@@ -867,8 +866,7 @@ mod tests {
             let pool_uuid = PoolUuid::new_v4();
             let mut bdm = BlockDevMgr::initialize(
                 pool_uuid,
-                ProcessedPathInfos::try_from(&paths[..2])
-                    .and_then(|pp| pp.get_infos_for_create())?,
+                ProcessedPathInfos::try_from(&paths[..2]).and_then(|pp| pp.for_create())?,
                 MDADataSize::default(),
                 Some(&EncryptionInfo::KeyDesc(key_desc.clone())),
             )?;
@@ -915,7 +913,7 @@ mod tests {
     fn test_clevis_initialize(paths: &[&Path]) {
         let _memfs = MemoryFilesystem::new().unwrap();
         let devices = ProcessedPathInfos::try_from(paths)
-            .and_then(|pp| pp.get_infos_for_create())
+            .and_then(|pp| pp.for_create())
             .unwrap();
         let mut mgr = BlockDevMgr::initialize(
             PoolUuid::new_v4(),
@@ -957,8 +955,7 @@ mod tests {
     fn test_clevis_both_initialize(paths: &[&Path]) {
         fn test_both(paths: &[&Path], key_desc: &KeyDescription) -> Result<(), Box<dyn Error>> {
             let _memfs = MemoryFilesystem::new().unwrap();
-            let devices =
-                ProcessedPathInfos::try_from(paths).and_then(|pp| pp.get_infos_for_create())?;
+            let devices = ProcessedPathInfos::try_from(paths).and_then(|pp| pp.for_create())?;
 
             let mut mgr = BlockDevMgr::initialize(
                 PoolUuid::new_v4(),

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -820,14 +820,8 @@ mod tests {
                 Some(&EncryptionInfo::KeyDesc(key_desc.clone())),
             )?;
 
-            let dev_uuids = bdm
-                .blockdevs()
-                .iter()
-                .map(|(u, _)| u)
-                .cloned()
-                .collect::<HashSet<_>>();
             let devices = ProcessedPathInfos::try_from(&paths[2..3])
-                .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
+                .map(|pp| pp.unpack().1)
                 .unwrap();
             if bdm.add(pool_uuid, devices).is_err() {
                 Err(Box::new(StratisError::Msg(
@@ -873,14 +867,8 @@ mod tests {
 
             crypt::change_key(key_desc)?;
 
-            let dev_uuids = bdm
-                .blockdevs()
-                .iter()
-                .map(|(u, _)| u)
-                .cloned()
-                .collect::<HashSet<_>>();
             let devices = ProcessedPathInfos::try_from(&paths[2..3])
-                .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
+                .map(|pp| pp.unpack().1)
                 .unwrap();
             if bdm.add(pool_uuid, devices).is_ok() {
                 Err(Box::new(StratisError::Msg(

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -253,7 +253,7 @@ mod tests {
         let mgr = BlockDevMgr::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths1)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -4,8 +4,6 @@
 
 // Code to handle the backing store of a pool.
 
-use std::path::Path;
-
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
 use crate::{
@@ -14,6 +12,7 @@ use crate::{
             backstore::{
                 blockdev::StratBlockDev,
                 blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                devices::UnownedDevices,
                 shared::{coalesce_blkdevsegs, metadata_to_segment},
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
@@ -98,9 +97,9 @@ impl CacheTier {
     pub fn add(
         &mut self,
         pool_uuid: PoolUuid,
-        paths: &[&Path],
+        infos: UnownedDevices,
     ) -> StratisResult<(Vec<DevUuid>, (bool, bool))> {
-        let uuids = self.block_mgr.add(pool_uuid, paths)?;
+        let uuids = self.block_mgr.add(pool_uuid, infos)?;
 
         let avail_space = self.block_mgr.avail_space();
 
@@ -230,6 +229,8 @@ impl Recordable<CacheTierSave> for CacheTier {
 
 #[cfg(test)]
 mod tests {
+
+    use std::path::Path;
 
     use crate::engine::strat_engine::{
         metadata::MDADataSize,

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -250,7 +250,15 @@ mod tests {
 
         let pool_uuid = PoolUuid::new_v4();
 
-        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MDADataSize::default(), None).unwrap();
+        let mgr = BlockDevMgr::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths1)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
 
         let mut cache_tier = CacheTier::new(mgr).unwrap();
 

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -230,7 +230,7 @@ impl Recordable<CacheTierSave> for CacheTier {
 #[cfg(test)]
 mod tests {
 
-    use std::{collections::HashSet, convert::TryFrom, path::Path};
+    use std::{convert::TryFrom, path::Path};
 
     use crate::engine::strat_engine::{
         backstore::ProcessedPathInfos,
@@ -281,15 +281,8 @@ mod tests {
         assert_eq!(cache_tier.block_mgr.avail_space(), Sectors(0));
         assert_eq!(size - metadata_size, allocated + cache_metadata_size);
 
-        let dev_uuids = cache_tier
-            .block_mgr
-            .blockdevs()
-            .iter()
-            .map(|(u, _)| u)
-            .cloned()
-            .collect::<HashSet<_>>();
         let devices2 = ProcessedPathInfos::try_from(paths2)
-            .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
+            .map(|pp| pp.unpack().1)
             .unwrap();
 
         let (_, (cache, meta)) = cache_tier.add(pool_uuid, devices2).unwrap();

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -289,7 +289,7 @@ mod tests {
             .cloned()
             .collect::<HashSet<_>>();
         let devices2 = ProcessedPathInfos::try_from(paths2)
-            .and_then(|pp| pp.get_infos_for_add(pool_uuid, &dev_uuids))
+            .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
             .unwrap();
 
         let (_, (cache, meta)) = cache_tier.add(pool_uuid, devices2).unwrap();

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -63,7 +63,7 @@ impl DataTier {
         }
     }
 
-    /// Add the given paths to self. Return UUIDs of the new blockdevs
+    /// Add the given devices to self. Return UUIDs of the new blockdevs
     /// corresponding to the specified paths.
     /// WARNING: metadata changing event
     pub fn add(

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -226,7 +226,7 @@ mod tests {
             .cloned()
             .collect::<HashSet<_>>();
         let devices2 = ProcessedPathInfos::try_from(paths2)
-            .and_then(|pp| pp.get_infos_for_add(pool_uuid, &dev_uuids))
+            .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
             .unwrap();
         data_tier.add(pool_uuid, devices2).unwrap();
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -189,7 +189,7 @@ mod tests {
         let mgr = BlockDevMgr::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths1)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -186,7 +186,15 @@ mod tests {
 
         let pool_uuid = PoolUuid::new_v4();
 
-        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MDADataSize::default(), None).unwrap();
+        let mgr = BlockDevMgr::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths1)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
 
         let mut data_tier = DataTier::new(mgr);
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -4,8 +4,6 @@
 
 // Code to handle the backing store of a pool.
 
-use std::path::Path;
-
 use devicemapper::Sectors;
 
 use crate::{
@@ -14,6 +12,7 @@ use crate::{
             backstore::{
                 blockdev::StratBlockDev,
                 blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                devices::UnownedDevices,
                 shared::{coalesce_blkdevsegs, metadata_to_segment},
                 transaction::RequestTransaction,
             },
@@ -67,8 +66,12 @@ impl DataTier {
     /// Add the given paths to self. Return UUIDs of the new blockdevs
     /// corresponding to the specified paths.
     /// WARNING: metadata changing event
-    pub fn add(&mut self, pool_uuid: PoolUuid, paths: &[&Path]) -> StratisResult<Vec<DevUuid>> {
-        self.block_mgr.add(pool_uuid, paths)
+    pub fn add(
+        &mut self,
+        pool_uuid: PoolUuid,
+        infos: UnownedDevices,
+    ) -> StratisResult<Vec<DevUuid>> {
+        self.block_mgr.add(pool_uuid, infos)
     }
 
     /// Allocate a region for all sector size requests from unallocated segments in
@@ -163,6 +166,8 @@ impl Recordable<DataTierSave> for DataTier {
 
 #[cfg(test)]
 mod tests {
+
+    use std::path::Path;
 
     use crate::engine::strat_engine::{
         metadata::MDADataSize,

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -167,7 +167,7 @@ impl Recordable<DataTierSave> for DataTier {
 #[cfg(test)]
 mod tests {
 
-    use std::{collections::HashSet, convert::TryFrom, path::Path};
+    use std::{convert::TryFrom, path::Path};
 
     use crate::engine::strat_engine::{
         backstore::ProcessedPathInfos,
@@ -218,15 +218,8 @@ mod tests {
         assert_eq!(data_tier.size(), size);
         allocated = data_tier.allocated();
 
-        let dev_uuids = data_tier
-            .block_mgr
-            .blockdevs()
-            .iter()
-            .map(|(u, _)| u)
-            .cloned()
-            .collect::<HashSet<_>>();
         let devices2 = ProcessedPathInfos::try_from(paths2)
-            .and_then(|pp| pp.for_add(pool_uuid, &dev_uuids))
+            .map(|pp| pp.unpack().1)
             .unwrap();
         data_tier.add(pool_uuid, devices2).unwrap();
 

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -312,6 +312,8 @@ impl ProcessedPathInfos {
             )));
         }
 
+        // TODO: Might want to check UUIDs instead of using the *idempotent*
+        // methods.
         Ok(this_pool
             .unwrap_or_default()
             .values()

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -238,7 +238,7 @@ impl ProcessedPathInfos {
         mut self,
         pool_uuid: PoolUuid,
         dev_uuids: &HashSet<DevUuid>,
-    ) -> StratisResult<Vec<PathBuf>> {
+    ) -> StratisResult<UnownedDevices> {
         let this_pool = self.stratis_devices.remove(&pool_uuid);
         if !self.stratis_devices.is_empty() {
             return Err(StratisError::Msg(format!(
@@ -265,11 +265,9 @@ impl ProcessedPathInfos {
             )));
         }
 
-        Ok(self
-            .unclaimed_devices
-            .iter()
-            .map(|i| i.devnode.clone())
-            .collect::<Vec<PathBuf>>())
+        Ok(UnownedDevices {
+            devices: self.unclaimed_devices,
+        })
     }
 
     /// If creating a new pool or cache, all devices must be unowned.

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -234,7 +234,7 @@ impl ProcessedPathInfos {
     /// already belong to the tier, return an error if there are any
     /// devices belonging to Stratis that do not belong to the pool,
     /// and return only unclaimed devices for initialization.
-    pub fn get_infos_for_add(
+    pub fn for_add(
         mut self,
         pool_uuid: PoolUuid,
         dev_uuids: &HashSet<DevUuid>,
@@ -289,10 +289,7 @@ impl ProcessedPathInfos {
     /// pools. Return an error if any such found. If none found, return a list
     /// of devnodes, which appear to belong to this pool to pass to
     /// the idempotent create method.
-    pub fn get_paths_for_idempotent_create(
-        mut self,
-        pool_uuid: PoolUuid,
-    ) -> StratisResult<Vec<PathBuf>> {
+    pub fn for_idempotent_create(mut self, pool_uuid: PoolUuid) -> StratisResult<Vec<PathBuf>> {
         if !self.unclaimed_devices.is_empty() {
             return Err(StratisError::Msg(format!(
                 "Pool with UUID {} already exists; can not add uninitialized devices to existing pool or cache with init or create command.",
@@ -813,7 +810,7 @@ mod tests {
                     .collect::<Vec<_>>()
                     .as_slice(),
             )
-            .and_then(|pp| pp.get_infos_for_add(pool_uuid, &initialized_uuids))
+            .and_then(|pp| pp.for_add(pool_uuid, &initialized_uuids))
             .map(|un| un.devices.is_empty())?
             {
                 return Err(Box::new(StratisError::Msg(
@@ -828,7 +825,7 @@ mod tests {
                     .collect::<Vec<_>>()
                     .as_slice(),
             )
-            .and_then(|pp| pp.get_infos_for_add(pool_uuid, &HashSet::new()))
+            .and_then(|pp| pp.for_add(pool_uuid, &HashSet::new()))
             .is_ok()
             {
                 return Err(Box::new(StratisError::Msg(
@@ -846,7 +843,7 @@ mod tests {
                     .collect::<Vec<_>>()
                     .as_slice(),
             )
-            .and_then(|pp| pp.get_infos_for_add(pool_uuid, &initialized_uuids))
+            .and_then(|pp| pp.for_add(pool_uuid, &initialized_uuids))
             {
                 if !infos.devices.is_empty() {
                     return Err(Box::new(StratisError::Msg(
@@ -863,7 +860,7 @@ mod tests {
                 .collect::<Vec<_>>()
                 .as_slice(),
         )
-        .and_then(|pp| pp.get_infos_for_add(PoolUuid::new_v4(), &initialized_uuids))
+        .and_then(|pp| pp.for_add(PoolUuid::new_v4(), &initialized_uuids))
         .is_ok()
         {
             return Err(Box::new(StratisError::Msg(

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -836,7 +836,7 @@ mod tests {
                     .collect::<Vec<_>>()
                     .as_slice(),
             )
-            .map(|pp| !pp.unpack().1.devices.is_empty())?
+            .map(|pp| !pp.unpack().0.partition(pool_uuid).1.is_empty())?
             {
                 return Err(Box::new(StratisError::Msg(
                     "Failed to eliminate devices already initialized for this pool from list of devices to initialize".to_string()

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -317,6 +317,18 @@ impl TryFrom<&[&Path]> for ProcessedPathInfos {
     }
 }
 
+/// A list of device paths that have been determined to be unowned, and thus
+/// can be initialized by stratisd.
+/// Invariants:
+/// * DeviceInfo devnode values are unique.
+/// * DeviceInfo id_wwn values are unique, if present.
+/// * DeviceInfo devno values are unique.
+/// * DeviceInfo.size value meets the required Stratis minimum.
+#[derive(Debug)]
+pub struct UnownedDevices {
+    pub devices: Vec<DeviceInfo>,
+}
+
 // Check coherence of pool and device UUIDs against a set of current UUIDs.
 // If the selection of devices is incompatible with the current
 // state of the set, or simply invalid, return an error.

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -272,7 +272,7 @@ impl ProcessedPathInfos {
 
     /// If creating a new pool or cache, all devices must be unowned.
     /// Return an error if any appear to belong to Stratis.
-    pub fn get_infos_for_create(self) -> StratisResult<UnownedDevices> {
+    pub fn for_create(self) -> StratisResult<UnownedDevices> {
         if self.stratis_devices.is_empty() {
             Ok(UnownedDevices {
                 devices: self.unclaimed_devices,
@@ -743,8 +743,7 @@ mod tests {
         key_description: Option<&KeyDescription>,
     ) -> Result<(), Box<dyn Error>> {
         let pool_uuid = PoolUuid::new_v4();
-        let dev_infos =
-            ProcessedPathInfos::try_from(paths).and_then(|pp| pp.get_infos_for_create())?;
+        let dev_infos = ProcessedPathInfos::try_from(paths).and_then(|pp| pp.for_create())?;
 
         if dev_infos.devices.len() != paths.len() {
             return Err(Box::new(StratisError::Msg(
@@ -985,7 +984,7 @@ mod tests {
             )));
         }
 
-        let mut dev_infos = ProcessedPathInfos::try_from(paths)?.get_infos_for_create()?;
+        let mut dev_infos = ProcessedPathInfos::try_from(paths)?.for_create()?;
         let pool_uuid = PoolUuid::new_v4();
 
         if dev_infos.devices.len() != paths.len() {

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -299,7 +299,7 @@ impl ProcessedPathInfos {
     ) -> StratisResult<Vec<PathBuf>> {
         if !self.unclaimed_devices.is_empty() {
             return Err(StratisError::Msg(format!(
-                "Pool with UUID {} already exists; can not add unclaimed devices to existing pool or cache with init or create command.",
+                "Pool with UUID {} already exists; can not add uninitialized devices to existing pool or cache with init or create command.",
                 pool_uuid
             )));
         }

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -811,7 +811,7 @@ mod tests {
                     .as_slice(),
             )
             .and_then(|pp| pp.for_add(pool_uuid, &initialized_uuids))
-            .map(|un| un.devices.is_empty())?
+            .map(|un| !un.devices.is_empty())?
             {
                 return Err(Box::new(StratisError::Msg(
                     "Failed to eliminate devices already initialized for this pool from list of devices to initialize".to_string()

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -20,5 +20,5 @@ pub use self::{
     backstore::Backstore,
     blockdev::{StratBlockDev, UnderlyingDevice},
     crypt::{CryptActivationHandle, CryptHandle, CryptMetadataHandle, CLEVIS_TANG_TRUST_URL},
-    devices::{initialize_devices, process_and_verify_devices},
+    devices::{initialize_devices, process_and_verify_devices, ProcessedPathInfos},
 };

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -20,5 +20,5 @@ pub use self::{
     backstore::Backstore,
     blockdev::{StratBlockDev, UnderlyingDevice},
     crypt::{CryptActivationHandle, CryptHandle, CryptMetadataHandle, CLEVIS_TANG_TRUST_URL},
-    devices::{initialize_devices, process_and_verify_devices, ProcessedPathInfos},
+    devices::{initialize_devices, ProcessedPathInfos, UnownedDevices},
 };

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -20,5 +20,5 @@ pub use self::{
     backstore::Backstore,
     blockdev::{StratBlockDev, UnderlyingDevice},
     crypt::{CryptActivationHandle, CryptHandle, CryptMetadataHandle, CLEVIS_TANG_TRUST_URL},
-    devices::{initialize_devices, ProcessedPathInfos, UnownedDevices},
+    devices::{initialize_devices, NonEmptyUnownedDevices, ProcessedPathInfos, UnownedDevices},
 };

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -16,9 +16,12 @@ mod transaction;
 
 #[cfg(test)]
 pub use self::crypt::crypt_metadata_size;
+#[cfg(test)]
+pub use self::devices::initialize_devices;
+
 pub use self::{
     backstore::Backstore,
     blockdev::{StratBlockDev, UnderlyingDevice},
     crypt::{CryptActivationHandle, CryptHandle, CryptMetadataHandle, CLEVIS_TANG_TRUST_URL},
-    devices::{initialize_devices, NonEmptyUnownedDevices, ProcessedPathInfos, UnownedDevices},
+    devices::{NonEmptyUnownedDevices, ProcessedPathInfos, UnownedDevices},
 };

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -351,13 +351,13 @@ impl Engine for StratEngine {
         validate_name(name)?;
         let name = Name::new(name.to_owned());
 
-        validate_paths(blockdev_paths)?;
-
         if blockdev_paths.is_empty() {
             return Err(StratisError::Msg(
                 "At least one blockdev is required to create a pool.".to_string(),
             ));
         }
+
+        validate_paths(blockdev_paths)?;
 
         let mut device_infos = ProcessedPathInfos::try_from(blockdev_paths)?;
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -351,14 +351,16 @@ impl Engine for StratEngine {
 
         validate_paths(blockdev_paths)?;
 
+        if blockdev_paths.is_empty() {
+            return Err(StratisError::Msg(
+                "At least one blockdev is required to create a pool.".to_string(),
+            ));
+        }
+
         let maybe_guard = self.pools.read(LockKey::Name(name.clone())).await;
         if let Some(guard) = maybe_guard {
             let (name, _, pool) = guard.as_tuple();
             create_pool_idempotent_or_err(pool, &name, blockdev_paths)
-        } else if blockdev_paths.is_empty() {
-            Err(StratisError::Msg(
-                "At least one blockdev is required to create a pool.".to_string(),
-            ))
         } else {
             let cloned_name = name.clone();
             let cloned_paths = blockdev_paths

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -4,7 +4,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     path::Path,
     sync::Arc,
 };
@@ -377,7 +377,9 @@ impl Engine for StratEngine {
             create_pool_idempotent_or_err(pool, &name, &borrowed_paths)
         } else {
             let cloned_name = name.clone();
-            let device_infos = device_infos.for_create()?;
+            let device_infos = device_infos.for_create()?.try_into().expect(
+                "constructed with at least one path; if Stratis devices, already rejected.",
+            );
             let cloned_enc_info = encryption_info.cloned();
 
             let (pool_uuid, _) = spawn_blocking!({

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -348,14 +348,14 @@ impl Engine for StratEngine {
         blockdev_paths: &[&Path],
         encryption_info: Option<&EncryptionInfo>,
     ) -> StratisResult<CreateAction<PoolUuid>> {
-        validate_name(name)?;
-        let name = Name::new(name.to_owned());
-
         if blockdev_paths.is_empty() {
             return Err(StratisError::Msg(
                 "At least one blockdev is required to create a pool.".to_string(),
             ));
         }
+
+        validate_name(name)?;
+        let name = Name::new(name.to_owned());
 
         validate_paths(blockdev_paths)?;
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -377,7 +377,7 @@ impl Engine for StratEngine {
             create_pool_idempotent_or_err(pool, &name, &borrowed_paths)
         } else {
             let cloned_name = name.clone();
-            let device_infos = device_infos.get_infos_for_create()?;
+            let device_infos = device_infos.for_create()?;
             let cloned_enc_info = encryption_info.cloned();
 
             let (pool_uuid, _) = spawn_blocking!({

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -372,7 +372,7 @@ impl Engine for StratEngine {
         let maybe_guard = self.pools.read(LockKey::Name(name.clone())).await;
         if let Some(guard) = maybe_guard {
             let (name, uuid, pool) = guard.as_tuple();
-            let cloned_paths = device_infos.get_paths_for_idempotent_create(uuid)?;
+            let cloned_paths = device_infos.for_idempotent_create(uuid)?;
             let borrowed_paths = cloned_paths.iter().map(|p| p.as_path()).collect::<Vec<_>>();
             create_pool_idempotent_or_err(pool, &name, &borrowed_paths)
         } else {

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -377,12 +377,11 @@ impl Engine for StratEngine {
             create_pool_idempotent_or_err(pool, &name, &borrowed_paths)
         } else {
             let cloned_name = name.clone();
-            let cloned_paths = device_infos.get_infos_for_create()?;
+            let device_infos = device_infos.get_infos_for_create()?;
             let cloned_enc_info = encryption_info.cloned();
 
             let (pool_uuid, _) = spawn_blocking!({
-                let borrowed_paths = cloned_paths.iter().map(|p| p.as_path()).collect::<Vec<_>>();
-                StratPool::initialize(&cloned_name, &borrowed_paths, cloned_enc_info.as_ref())
+                StratPool::initialize(&cloned_name, device_infos, cloned_enc_info.as_ref())
             })??;
 
             Ok(CreateAction::Created(pool_uuid))

--- a/src/engine/strat_engine/liminal/identify.rs
+++ b/src/engine/strat_engine/liminal/identify.rs
@@ -435,12 +435,12 @@ pub fn find_all() -> libudev::Result<(
 #[cfg(test)]
 mod tests {
 
-    use std::{collections::HashSet, error::Error};
+    use std::{convert::TryFrom, error::Error};
 
     use crate::{
         engine::{
             strat_engine::{
-                backstore::{initialize_devices, process_and_verify_devices},
+                backstore::{initialize_devices, ProcessedPathInfos},
                 cmd::create_fs,
                 metadata::MDADataSize,
                 tests::{crypt, loopbacked, real},
@@ -470,7 +470,7 @@ mod tests {
             let pool_uuid = PoolUuid::new_v4();
 
             let devices = initialize_devices(
-                process_and_verify_devices(pool_uuid, &HashSet::new(), paths)?,
+                ProcessedPathInfos::try_from(paths).and_then(|pp| pp.get_infos_for_create())?,
                 pool_uuid,
                 MDADataSize::default(),
                 Some(&EncryptionInfo::KeyDesc(key_description.clone())),
@@ -584,7 +584,9 @@ mod tests {
         let pool_uuid = PoolUuid::new_v4();
 
         initialize_devices(
-            process_and_verify_devices(pool_uuid, &HashSet::new(), paths).unwrap(),
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
             pool_uuid,
             MDADataSize::default(),
             None,

--- a/src/engine/strat_engine/liminal/identify.rs
+++ b/src/engine/strat_engine/liminal/identify.rs
@@ -470,7 +470,7 @@ mod tests {
             let pool_uuid = PoolUuid::new_v4();
 
             let devices = initialize_devices(
-                ProcessedPathInfos::try_from(paths).and_then(|pp| pp.get_infos_for_create())?,
+                ProcessedPathInfos::try_from(paths).and_then(|pp| pp.for_create())?,
                 pool_uuid,
                 MDADataSize::default(),
                 Some(&EncryptionInfo::KeyDesc(key_description.clone())),
@@ -585,7 +585,7 @@ mod tests {
 
         initialize_devices(
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             pool_uuid,
             MDADataSize::default(),

--- a/src/engine/strat_engine/liminal/identify.rs
+++ b/src/engine/strat_engine/liminal/identify.rs
@@ -435,7 +435,10 @@ pub fn find_all() -> libudev::Result<(
 #[cfg(test)]
 mod tests {
 
-    use std::{convert::TryFrom, error::Error};
+    use std::{
+        convert::{TryFrom, TryInto},
+        error::Error,
+    };
 
     use crate::{
         engine::{
@@ -470,7 +473,9 @@ mod tests {
             let pool_uuid = PoolUuid::new_v4();
 
             let devices = initialize_devices(
-                ProcessedPathInfos::try_from(paths).and_then(|pp| pp.for_create())?,
+                ProcessedPathInfos::try_from(paths)
+                    .and_then(|pp| pp.for_create())
+                    .and_then(|un| un.try_into())?,
                 pool_uuid,
                 MDADataSize::default(),
                 Some(&EncryptionInfo::KeyDesc(key_description.clone())),
@@ -586,6 +591,7 @@ mod tests {
         initialize_devices(
             ProcessedPathInfos::try_from(paths)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             pool_uuid,
             MDADataSize::default(),

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -973,7 +973,13 @@ mod tests {
     fn test_empty_pool(paths: &[&Path]) {
         assert_eq!(paths.len(), 0);
         assert_matches!(
-            StratPool::initialize("stratis_test_pool", paths, None),
+            StratPool::initialize(
+                "stratis_test_pool",
+                ProcessedPathInfos::try_from(paths)
+                    .and_then(|pp| pp.get_infos_for_create())
+                    .unwrap(),
+                None
+            ),
             Err(_)
         );
     }
@@ -997,7 +1003,14 @@ mod tests {
         let (paths1, paths2) = paths.split_at(paths.len() / 2);
 
         let name = "stratis-test-pool";
-        let (uuid, mut pool) = StratPool::initialize(name, paths2, None).unwrap();
+        let (uuid, mut pool) = StratPool::initialize(
+            name,
+            ProcessedPathInfos::try_from(paths2)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            None,
+        )
+        .unwrap();
         invariant(&pool, name);
 
         let metadata1 = pool.record(name);
@@ -1080,7 +1093,14 @@ mod tests {
         let (data_path, data_paths) = data_paths.split_at(1);
 
         let name = "stratis-test-pool";
-        let (uuid, mut pool) = StratPool::initialize(name, data_path, None).unwrap();
+        let (uuid, mut pool) = StratPool::initialize(
+            name,
+            ProcessedPathInfos::try_from(data_path)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            None,
+        )
+        .unwrap();
         invariant(&pool, name);
 
         pool.init_cache(uuid, name, cache_path).unwrap();
@@ -1116,7 +1136,14 @@ mod tests {
         let (paths1, paths2) = paths.split_at(1);
 
         let name = "stratis-test-pool";
-        let (pool_uuid, mut pool) = StratPool::initialize(name, paths1, None).unwrap();
+        let (pool_uuid, mut pool) = StratPool::initialize(
+            name,
+            ProcessedPathInfos::try_from(paths1)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            None,
+        )
+        .unwrap();
         invariant(&pool, name);
 
         let fs_name = "stratis_test_filesystem";
@@ -1188,7 +1215,14 @@ mod tests {
         assert!(paths.len() > 1);
 
         let name = "stratis-test-pool";
-        let (_, mut pool) = StratPool::initialize(name, paths, None).unwrap();
+        let (_, mut pool) = StratPool::initialize(
+            name,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            None,
+        )
+        .unwrap();
         invariant(&pool, name);
 
         assert_eq!(pool.action_avail, ActionAvailability::Full);
@@ -1199,7 +1233,14 @@ mod tests {
         udev_settle().unwrap();
 
         let name = "stratis-test-pool";
-        let (_, mut pool) = StratPool::initialize(name, paths, None).unwrap();
+        let (_, mut pool) = StratPool::initialize(
+            name,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            None,
+        )
+        .unwrap();
         invariant(&pool, name);
 
         assert_eq!(pool.action_avail, ActionAvailability::Full);
@@ -1233,7 +1274,14 @@ mod tests {
         assert!(paths.len() == 1);
 
         let pool_name = "pool";
-        let (pool_uuid, mut pool) = StratPool::initialize(pool_name, paths, None).unwrap();
+        let (pool_uuid, mut pool) = StratPool::initialize(
+            pool_name,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            None,
+        )
+        .unwrap();
 
         let (_, fs_uuid, _) = pool
             .create_filesystems(

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -472,7 +472,7 @@ impl Pool for StratPool {
             self.write_metadata(pool_name)?;
             Ok(SetCreateAction::new(devices))
         } else {
-            let cloned_paths = devices.get_paths_for_idempotent_create(pool_uuid)?;
+            let cloned_paths = devices.for_idempotent_create(pool_uuid)?;
             let borrowed_paths = cloned_paths.iter().map(|p| p.as_path()).collect::<Vec<_>>();
             init_cache_idempotent_or_err(
                 &borrowed_paths,
@@ -628,7 +628,7 @@ impl Pool for StratPool {
 
         let device_infos = ProcessedPathInfos::try_from(paths)?;
         let bdev_info = if tier == BlockDevTier::Cache {
-            let unclaimed = device_infos.get_infos_for_add(
+            let unclaimed = device_infos.for_add(
                 pool_uuid,
                 &self
                     .backstore
@@ -649,7 +649,7 @@ impl Pool for StratPool {
         } else {
             let cached = self.cached();
 
-            let unclaimed = device_infos.get_infos_for_add(
+            let unclaimed = device_infos.for_add(
                 pool_uuid,
                 &self
                     .backstore

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -437,13 +437,13 @@ impl Pool for StratPool {
         pool_name: &str,
         blockdevs: &[&Path],
     ) -> StratisResult<SetCreateAction<DevUuid>> {
-        validate_paths(blockdevs)?;
-
         if blockdevs.is_empty() {
             return Err(StratisError::Msg(
                 "At least one blockdev path is required to initialize a cache.".to_string(),
             ));
         }
+
+        validate_paths(blockdevs)?;
 
         if self.is_encrypted() {
             return Err(StratisError::Msg(
@@ -655,11 +655,11 @@ impl Pool for StratPool {
             ));
         }
 
-        validate_paths(paths)?;
-
         if paths.is_empty() {
             return Ok((SetCreateAction::new(vec![]), None));
         }
+
+        validate_paths(paths)?;
 
         let mut device_infos = ProcessedPathInfos::try_from(paths)?;
         let this_pool = device_infos.stratis_devices.remove(&pool_uuid);

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -454,7 +454,7 @@ impl Pool for StratPool {
         let devices = ProcessedPathInfos::try_from(blockdevs)?;
 
         if !self.has_cache() {
-            let device_infos = devices.get_infos_for_create()?;
+            let device_infos = devices.for_create()?;
             self.thin_pool.suspend()?;
             let devices_result =
                 self.backstore
@@ -976,7 +976,7 @@ mod tests {
             StratPool::initialize(
                 "stratis_test_pool",
                 ProcessedPathInfos::try_from(paths)
-                    .and_then(|pp| pp.get_infos_for_create())
+                    .and_then(|pp| pp.for_create())
                     .unwrap(),
                 None
             ),
@@ -1006,7 +1006,7 @@ mod tests {
         let (uuid, mut pool) = StratPool::initialize(
             name,
             ProcessedPathInfos::try_from(paths2)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             None,
         )
@@ -1096,7 +1096,7 @@ mod tests {
         let (uuid, mut pool) = StratPool::initialize(
             name,
             ProcessedPathInfos::try_from(data_path)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             None,
         )
@@ -1139,7 +1139,7 @@ mod tests {
         let (pool_uuid, mut pool) = StratPool::initialize(
             name,
             ProcessedPathInfos::try_from(paths1)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             None,
         )
@@ -1218,7 +1218,7 @@ mod tests {
         let (_, mut pool) = StratPool::initialize(
             name,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             None,
         )
@@ -1236,7 +1236,7 @@ mod tests {
         let (_, mut pool) = StratPool::initialize(
             name,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             None,
         )
@@ -1277,7 +1277,7 @@ mod tests {
         let (pool_uuid, mut pool) = StratPool::initialize(
             pool_name,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             None,
         )

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1921,7 +1921,7 @@ mod tests {
             .collect::<HashSet<_>>();
         let devices = ProcessedPathInfos::try_from(remaining_paths)
             .unwrap()
-            .get_infos_for_add(pool_uuid, &data_uuids)
+            .for_add(pool_uuid, &data_uuids)
             .unwrap();
 
         // Add block devices to the pool and run check() to extend

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1734,7 +1734,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -1830,7 +1830,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(first_path)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -1972,7 +1972,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2100,7 +2100,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2170,7 +2170,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2249,7 +2249,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2316,7 +2316,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2374,7 +2374,7 @@ mod tests {
         let mut backstore = Backstore::initialize(
             pool_uuid,
             ProcessedPathInfos::try_from(paths2)
-                .and_then(|pp| pp.get_infos_for_create())
+                .and_then(|pp| pp.for_create())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2441,7 +2441,7 @@ mod tests {
             .init_cache(
                 pool_uuid,
                 ProcessedPathInfos::try_from(paths1)
-                    .and_then(|pp| pp.get_infos_for_create())
+                    .and_then(|pp| pp.for_create())
                     .unwrap(),
             )
             .unwrap();

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1731,8 +1731,15 @@ mod tests {
     fn test_lazy_allocation(paths: &[&Path]) {
         let pool_uuid = PoolUuid::new_v4();
 
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
 
         let size = ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap();
         let mut pool = ThinPool::new(pool_uuid, &size, DATA_BLOCK_SIZE, &mut backstore).unwrap();
@@ -1820,8 +1827,15 @@ mod tests {
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
         let (first_path, remaining_paths) = paths.split_at(1);
-        let mut backstore =
-            Backstore::initialize(pool_uuid, first_path, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(first_path)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -1955,8 +1969,15 @@ mod tests {
     fn test_filesystem_snapshot(paths: &[&Path]) {
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(datablocks_to_sectors(DataBlocks(768))).unwrap(),
@@ -2076,8 +2097,15 @@ mod tests {
         let name2 = "name2";
 
         let pool_uuid = PoolUuid::new_v4();
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2139,8 +2167,15 @@ mod tests {
     fn test_pool_setup(paths: &[&Path]) {
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2211,8 +2246,15 @@ mod tests {
     /// same thin id and verifying that it fails.
     fn test_thindev_destroy(paths: &[&Path]) {
         let pool_uuid = PoolUuid::new_v4();
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2271,8 +2313,15 @@ mod tests {
     fn test_suspend_resume(paths: &[&Path]) {
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2322,8 +2371,15 @@ mod tests {
 
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths2, MDADataSize::default(), None).unwrap();
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            ProcessedPathInfos::try_from(paths2)
+                .and_then(|pp| pp.get_infos_for_create())
+                .unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2381,7 +2437,14 @@ mod tests {
         let old_device = backstore
             .device()
             .expect("Space already allocated from backstore, backstore must have device");
-        backstore.init_cache(pool_uuid, paths1).unwrap();
+        backstore
+            .init_cache(
+                pool_uuid,
+                ProcessedPathInfos::try_from(paths1)
+                    .and_then(|pp| pp.get_infos_for_create())
+                    .unwrap(),
+            )
+            .unwrap();
         let new_device = backstore
             .device()
             .expect("Space already allocated from backstore, backstore must have device");

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1673,7 +1673,7 @@ fn attempt_thin_repair(
 #[cfg(test)]
 mod tests {
     use std::{
-        convert::TryFrom,
+        convert::{TryFrom, TryInto},
         fs::OpenOptions,
         io::{BufWriter, Read, Write},
         path::Path,
@@ -1734,6 +1734,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -1830,6 +1831,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(first_path)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -1915,6 +1917,7 @@ mod tests {
 
         let devices = ProcessedPathInfos::try_from(remaining_paths)
             .map(|pp| pp.unpack().1)
+            .and_then(|un| un.try_into())
             .unwrap();
 
         // Add block devices to the pool and run check() to extend
@@ -1966,6 +1969,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2094,6 +2098,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2164,6 +2169,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2243,6 +2249,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2310,6 +2317,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(paths)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2368,6 +2376,7 @@ mod tests {
             pool_uuid,
             ProcessedPathInfos::try_from(paths2)
                 .and_then(|pp| pp.for_create())
+                .and_then(|un| un.try_into())
                 .unwrap(),
             MDADataSize::default(),
             None,
@@ -2435,6 +2444,7 @@ mod tests {
                 pool_uuid,
                 ProcessedPathInfos::try_from(paths1)
                     .and_then(|pp| pp.for_create())
+                    .and_then(|un| un.try_into())
                     .unwrap(),
             )
             .unwrap();

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1673,7 +1673,6 @@ fn attempt_thin_repair(
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashSet,
         convert::TryFrom,
         fs::OpenOptions,
         io::{BufWriter, Read, Write},
@@ -1914,14 +1913,8 @@ mod tests {
             ThinPoolStatus::Fail => panic!("ThinPoolStatus::Fail  Expected working/full."),
         };
 
-        let data_uuids = backstore
-            .datadevs()
-            .iter()
-            .map(|(u, _)| *u)
-            .collect::<HashSet<_>>();
         let devices = ProcessedPathInfos::try_from(remaining_paths)
-            .unwrap()
-            .for_add(pool_uuid, &data_uuids)
+            .map(|pp| pp.unpack().1)
             .unwrap();
 
         // Add block devices to the pool and run check() to extend


### PR DESCRIPTION
Closes: https://github.com/stratis-storage/stratisd/issues/1968

* Does check for an empty list of devices earlier in ```init_cache``` and ```create_pool``` methods. The idea is to treat an empty list as much as possible as simply an invalid argument, even though it is typed correctly.
* In StratEngine uses ```ProcessedPathInfos::try_from``` to process the paths and discover their information in the ```add_blockdevs```, ```init_cache```, and ```create_pool``` methods. Checks for potential errors in the result _before_ invoking the code that will actually initialize the device.
* Retains the use of the ```*idempotent*``` methods for the strat engine, but only invokes them if all the passed paths could conceivably belong to the given pool.

Advantages:
* Raises the inspection of devices up to a higher level, to the pool, or in the case of creating a pool, the engine level. This is the principal goal. The reasons for doing this are to allow stratisd to have a full understanding of the properties of the devices it has been given as an argument at the same time as it can inspect information about all the existing devices in _both_ tiers, in order to decide whether they should be considered compatible or not. Currently, when creating a pool, everything about the devices to be used for the pool are known at the time of creation. But when initializing a cache, only the info about the proposed cache devices is known. And when adding devices to either tier, only the information about that tier is known. It is not known, at all, whether the devices are cache or data devices, at the point where they are inspected. This last could be remedied by passing a Tier argument down to the blockdev manager methods, but the other issues could not be.
* When creating a pool, the lock on the possibly existing pool doesn't need to be taken until after the information on the devices has been read. This is a bit of an improvement, because the lock, which would conflict w/, say a global write lock, is held for a shorter time.
* When initializing or extending the cache, it is necessary to suspend the thinpool. By reading the data from the devices before initializing or extending the cache, the suspend/resume interval is made a bit shorter. Not that much, probably, compared to the time that it takes to initialize the devices, but still an improvement.

NOTES:
* There is a lot of code, now, that is transitively invoked by the initialization methods, that inspects the devices a second time, that I expect to remove in future, if I continue with this. I left it there for now, because it will require a lot of tinkering w/ tests, etc., to clean it up.
* We have a lot of code in the CLI to try to guard against and give good messages in case the user specifies devices that belong to another pool or the same pool but a different tier, when adding, creating, or initializing. We can't really remove this, and handle it in stratisd, because although the inspection of devices is hoisted, it would all have to be hoisted up into the engine to make this doable. We could, however, send out good error messages for when a user specifies devices in one tier, but they belong to the opposite tier. I haven't taken the trouble to implement really complete error messages in this case, as of now, but it is possible.
* I think the ```can_unlock()``` check taken before initializing devices Ishould be retained in the blockdev manager's add method because it is checking whether it is possible to go ahead and actually initialize the devices.

Questions:
* The result of these changes is that in ```StratEngine::CreatePool``` the devices are read and processed, although not initialized, outside the blocking task where this would have previously happened. How should this change be viewed? I don't see any reason why reading the data from the devices need to be in a blocking thread.
* etc.