### PR TITLE
Add metadata size to total allocated size

### DIFF
--- a/src/dbus_api/pool/shared.rs
+++ b/src/dbus_api/pool/shared.rs
@@ -18,7 +18,10 @@ use crate::{
         types::{DbusErrorEnum, TData, OK_STRING},
         util::{engine_to_dbus_err_tuple, get_next_arg},
     },
-    engine::{total_used, BlockDevTier, Diff, Engine, EngineAction, LockKey, Name, Pool, PoolUuid},
+    engine::{
+        total_allocated, total_used, BlockDevTier, Diff, Engine, EngineAction, LockKey, Name, Pool,
+        PoolUuid,
+    },
 };
 
 pub enum BlockDevOp {
@@ -156,8 +159,11 @@ where
                                 assert!(d.pool.metadata_size.is_changed());
                                 dbus_context.push_pool_foreground_change(
                                     pool_path.get_name(),
-                                    total_used(d.thin_pool.used, d.pool.metadata_size),
-                                    d.thin_pool.allocated_size,
+                                    total_used(&d.thin_pool.used, &d.pool.metadata_size),
+                                    total_allocated(
+                                        &d.thin_pool.allocated_size,
+                                        &d.pool.metadata_size,
+                                    ),
                                     Diff::Changed(pool.total_physical_size().bytes()),
                                     d.pool.out_of_alloc_space,
                                 )

--- a/src/dbus_api/types.rs
+++ b/src/dbus_api/types.rs
@@ -28,9 +28,9 @@ use devicemapper::Bytes;
 use crate::{
     dbus_api::{connection::DbusConnectionHandler, tree::DbusTreeHandler, udev::DbusUdevHandler},
     engine::{
-        total_used, ActionAvailability, Diff, Engine, ExclusiveGuard, FilesystemUuid, Lockable,
-        LockedPoolInfo, PoolDiff, PoolEncryptionInfo, PoolUuid, SharedGuard, StratFilesystemDiff,
-        StratPoolDiff, StratisUuid, ThinPoolDiff,
+        total_allocated, total_used, ActionAvailability, Diff, Engine, ExclusiveGuard,
+        FilesystemUuid, Lockable, LockedPoolInfo, PoolDiff, PoolEncryptionInfo, PoolUuid,
+        SharedGuard, StratFilesystemDiff, StratPoolDiff, StratisUuid, ThinPoolDiff,
     },
 };
 
@@ -161,8 +161,8 @@ where
 
                 DbusAction::PoolBackgroundChange(
                     uuid,
-                    SignalChange::from(total_used(used, metadata_size)),
-                    SignalChange::from(allocated_size),
+                    SignalChange::from(total_used(&used, &metadata_size)),
+                    SignalChange::from(total_allocated(&allocated_size, &metadata_size)),
                     SignalChange::from(out_of_alloc_space),
                 )
             })

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -4,7 +4,7 @@
 
 pub use self::{
     engine::{BlockDev, Engine, Filesystem, KeyActions, Pool, Report},
-    shared::total_used,
+    shared::{total_allocated, total_used},
     sim_engine::SimEngine,
     strat_engine::{
         get_dm, get_dm_init, StaticHeader, StaticHeaderResult, StratEngine, StratKeyActions, BDA,

--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -269,16 +269,26 @@ where
 }
 
 /// Calculate the total used diff from a diff of the thin pool usage and metadata size.
-pub fn total_used(used: Diff<Option<Bytes>>, metadata_size: Diff<Bytes>) -> Diff<Option<Bytes>> {
+pub fn total_used(used: &Diff<Option<Bytes>>, metadata_size: &Diff<Bytes>) -> Diff<Option<Bytes>> {
     let changed = matches!(
-        (&used, &metadata_size),
+        (used, metadata_size),
         (Diff::Changed(_), _) | (Diff::Unchanged(Some(_)), Diff::Changed(_))
     );
-    let total_used = used.map(|u| u + *metadata_size);
+    let total_used = used.map(|u| u + **metadata_size);
     if changed {
         Diff::Changed(total_used)
     } else {
         Diff::Unchanged(total_used)
+    }
+}
+
+/// Calculate the allocated diff from a diff of the allocated size and metadata size.
+pub fn total_allocated(allocated: &Diff<Bytes>, metadata_size: &Diff<Bytes>) -> Diff<Bytes> {
+    match (allocated, metadata_size) {
+        (Diff::Unchanged(a), Diff::Unchanged(m)) => Diff::Unchanged(*a + *m),
+        (Diff::Changed(a), Diff::Unchanged(m)) => Diff::Changed(*a + *m),
+        (Diff::Unchanged(a), Diff::Changed(m)) => Diff::Changed(*a + *m),
+        (Diff::Changed(a), Diff::Changed(m)) => Diff::Changed(*a + *m),
     }
 }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -731,7 +731,7 @@ impl Pool for StratPool {
     }
 
     fn total_allocated_size(&self) -> Sectors {
-        self.backstore.datatier_allocated_size()
+        self.backstore.datatier_allocated_size() + self.metadata_size
     }
 
     fn total_physical_used(&self) -> Option<Sectors> {


### PR DESCRIPTION
Closes stratis-storage/project#434

@mulkieran One note about this is that the allocated and total sizes will not always be equal. There are cases in the allocation algorithm where the metadata and data devices may have sizes that leave some space not consumable by either though the difference should be not be much more than 1MiB (our thin pool allocation block size).