### PR TITLE
Make stratis-min 'filesystem' UUID formatting consistent with 'pool'

### DIFF
--- a/src/jsonrpc/client/filesystem.rs
+++ b/src/jsonrpc/client/filesystem.rs
@@ -21,10 +21,7 @@ pub fn filesystem_list() -> StratisResult<()> {
         })
         .collect();
     let devices_formatted: Vec<_> = paths.into_iter().map(|p| p.display().to_string()).collect();
-    let uuids_formatted: Vec<_> = uuids
-        .into_iter()
-        .map(|u| u.as_simple().to_string())
-        .collect();
+    let uuids_formatted: Vec<_> = uuids.into_iter().map(|u| u.to_string()).collect();
     print_table!(
         "Pool Name", pool_names, "<";
         "Name", fs_names, "<";


### PR DESCRIPTION
stratis-min currently formats filesystem UUIDs without hyphens:

```
Pool Name   Name   Used         Created                Device       UUID
p2          fs1    546.00 MiB   2022-05-04T14:17:31Z   /dev/dm-5    7e74950afda84ff5b89cbc879d2d29a8
p1          fs1    546.00 MiB   2022-05-04T14:17:26Z   /dev/dm-11   0a9813fa1c884dc790792abc4e2efe79
```

Format these in the same way as the 'pool list' subcommand.

```
Pool Name   Name   Used         Created                Device       UUID
p1          fs1    546.00 MiB   2022-05-04T14:17:26Z   /dev/dm-11   0a9813fa-1c88-4dc7-9079-2abc4e2efe79
p2          fs1    546.00 MiB   2022-05-04T14:17:31Z   /dev/dm-5    7e74950a-fda8-4ff5-b89c-bc879d2d29a8
```