### PR TITLE
Build stratisd with the udev sync devicemapper-rs branch

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -39,6 +39,7 @@ jobs:
           curl
           cryptsetup-devel
           dbus-devel
+          device-mapper-devel
           git
           libblkid-devel
           make

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Run comparisons of version specs with available Fedora packages
         # yamllint disable rule:line-length
         run: |
-          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=rawhide IGNORE_ARGS="--ignore-category low --ignore-high=stratisd_proc_macros --ignore-high=libblkid-rs" make -f Makefile_dependencies check-fedora-versions
-          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f37 IGNORE_ARGS="--ignore-category low --ignore-high=stratisd_proc_macros --ignore-high=libblkid-rs" make -f Makefile_dependencies check-fedora-versions
-          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f36 IGNORE_ARGS="--ignore-category low --ignore-high=stratisd_proc_macros --ignore-high=libblkid-rs" make -f Makefile_dependencies check-fedora-versions
+          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=rawhide IGNORE_ARGS="--ignore-category low --ignore-high=stratisd_proc_macros --ignore-high=libblkid-rs --ignore-high=devicemapper" make -f Makefile_dependencies check-fedora-versions
+          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f37 IGNORE_ARGS="--ignore-category low --ignore-high=stratisd_proc_macros --ignore-high=libblkid-rs --ignore-high=devicemapper" make -f Makefile_dependencies check-fedora-versions
+          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f36 IGNORE_ARGS="--ignore-category low --ignore-high=stratisd_proc_macros --ignore-high=libblkid-rs --ignore-high=devicemapper" make -f Makefile_dependencies check-fedora-versions

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -76,6 +76,7 @@ jobs:
           cryptsetup-devel
           dbus-devel
           device-mapper-persistent-data
+          device-mapper-devel
           libblkid-devel
           make
           ncurses
@@ -109,9 +110,10 @@ jobs:
           clang
           cryptsetup-devel
           curl
-          device-mapper-persistent-data
           dbus-devel
           glibc-static
+          device-mapper-devel
+          device-mapper-persistent-data
           libblkid-devel
           make
           ncurses

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
           curl
           cryptsetup-devel
           dbus-devel
+          device-mapper-devel
           libblkid-devel
           make
           ncurses
@@ -100,8 +101,9 @@ jobs:
           clevis-luks
           cracklib-dicts
           curl
-          device-mapper-persistent-data
           dbus-devel
+          device-mapper-devel
+          device-mapper-persistent-data
           libblkid-devel
           make
           ncurses
@@ -132,6 +134,7 @@ jobs:
           dbus-daemon
           dbus-tools
           dbus-devel
+          device-mapper-devel
           libblkid-devel
           git
           glibc-static
@@ -200,6 +203,7 @@ jobs:
           curl
           cryptsetup-devel
           dbus-devel
+          device-mapper-devel
           git
           libblkid-devel
           make
@@ -234,6 +238,7 @@ jobs:
           clang
           cryptsetup-devel
           dbus-devel
+          device-mapper-devel
           libblkid-devel
           make
           ncurses
@@ -256,6 +261,8 @@ jobs:
           cryptsetup-devel
           curl
           dbus-devel
+          dbus-tools
+          device-mapper-devel
           device-mapper-persistent-data
           glibc-static
           libblkid-devel

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,7 @@ jobs:
           curl
           cryptsetup-devel
           dbus-devel
+          device-mapper-devel
           libblkid-devel
           make
           ncurses
@@ -124,6 +125,7 @@ jobs:
           curl
           cryptsetup-devel
           dbus-devel
+          device-mapper-devel
           git
           libblkid-devel
           make
@@ -177,6 +179,7 @@ jobs:
           clang
           cryptsetup-devel
           dbus-devel
+          device-mapper-devel
           libblkid-devel
           git
           glibc-static

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,6 +51,7 @@ jobs:
           libblkid-dev
           libcryptsetup-dev
           libdbus-1-dev
+          libdevmapper-dev
           libsystemd-dev
           libudev-dev
           make
@@ -115,6 +116,8 @@ jobs:
           cracklib-dicts
           curl
           dbus-devel
+          dbus-tools
+          device-mapper-devel
           device-mapper-persistent-data
           glibc-static
           libblkid-devel

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -74,6 +74,7 @@ jobs:
           libblkid-dev
           libcryptsetup-dev
           libdbus-1-dev
+          libdevmapper-dev
           libsystemd-dev
           libudev-dev
           make
@@ -112,6 +113,7 @@ jobs:
           libblkid-dev
           libcryptsetup-dev
           libdbus-1-dev
+          libdevmapper-dev
           libsystemd-dev
           libudev-dev
           make

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,26 +333,30 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.32.3"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da7c273a50833e1fbbff5b71b06fd1f3f00356b0fa1d392a21ee8b4aabb2a1e"
+checksum = "e645b7ca36b156ce45a2fdb51f86cd26c549f6034ee25233830054006789f7aa"
 dependencies = [
  "bitflags",
  "devicemapper-sys",
+ "env_logger",
  "lazy_static",
- "nix 0.24.3",
+ "log",
+ "nix 0.26.2",
+ "rand",
+ "retry",
  "semver",
  "serde",
 ]
 
 [[package]]
 name = "devicemapper-sys"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2aad5bae6bc8a217f8c398c5737122966cbd35f19dd223433606225ec48285"
+checksum = "f0b0f9d16560f830ae6e90b769017333c4561d2c84f39e7aa7d935d2e7bcbc4c"
 dependencies = [
- "bindgen 0.59.2",
- "nix 0.24.3",
+ "bindgen 0.63.0",
+ "nix 0.26.2",
 ]
 
 [[package]]
@@ -801,15 +805,6 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -850,18 +845,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -869,7 +852,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset 0.7.1",
+ "memoffset",
  "pin-utils",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ version = "2.3.0"
 optional = true
 
 [dependencies.devicemapper]
-version = "0.32.3"
+version = "0.33.1"
 optional = true
 
 [dependencies.dbus]

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -930,6 +930,7 @@ mod test {
 
         test_async!(engine.start_pool(PoolIdentifier::Uuid(uuid), Some(unlock_method)))?;
         test_async!(engine.destroy_pool(uuid))?;
+        cmd::udev_settle()?;
         engine.teardown()?;
 
         Ok(())

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -1410,6 +1410,7 @@ mod tests {
                 _ => panic!("thin pool status should be back to working"),
             }
         }
+        udev_settle().unwrap();
     }
 
     #[test]

--- a/src/engine/strat_engine/tests/real.rs
+++ b/src/engine/strat_engine/tests/real.rs
@@ -19,6 +19,7 @@ use devicemapper::{
 };
 
 use crate::engine::strat_engine::{
+    cmd::udev_settle,
     device::blkdev_size,
     dm::get_dm,
     tests::{logger::init_logger, util::clean_up},
@@ -51,6 +52,7 @@ impl RealTestDev {
     /// Teardown a real test dev
     fn teardown(self) {
         wipe_sectors(self.as_path(), Sectors(0), Bytes::from(IEC::Mi).sectors()).unwrap();
+        udev_settle().unwrap();
         if let Some(mut ld) = self.dev.right() {
             ld.teardown(get_dm()).unwrap();
         }

--- a/src/engine/strat_engine/tests/util.rs
+++ b/src/engine/strat_engine/tests/util.rs
@@ -97,7 +97,10 @@ pub fn dm_stratis_devices_remove() -> Result<()> {
             .iter()
             .map(|d| &d.0)
             .filter_map(|n| {
-                if !n.to_string().starts_with("stratis-1") {
+                if !n.to_string().starts_with("stratis-1")
+                    && !n.to_string().starts_with("stratis_fail_device")
+                    && !n.to_string().starts_with("stratis_test_device")
+                {
                     None
                 } else {
                     match get_dm().device_remove(&DevId::Name(n), DmOptions::default()) {


### PR DESCRIPTION
Update the build dependencies for devicemapper-rs to reference the bmr-udev-sync branch and include `ilbdevmapper.h` in the dependencies for CI environments.