### PR TITLE
Bug fix for device removal on pool stop

### DIFF
--- a/src/engine/strat_engine/liminal/liminal.rs
+++ b/src/engine/strat_engine/liminal/liminal.rs
@@ -239,6 +239,22 @@ impl LiminalDevices {
         pool: &mut StratPool,
     ) -> StratisResult<()> {
         let devices = pool.stop(pool_name)?;
+        for (_, device) in devices.iter() {
+            match device {
+                LInfo::Luks(l) => {
+                    self.uuid_lookup.insert(
+                        l.ids.devnode.clone(),
+                        (l.ids.identifiers.pool_uuid, l.ids.identifiers.device_uuid),
+                    );
+                }
+                LInfo::Stratis(s) => {
+                    self.uuid_lookup.insert(
+                        s.ids.devnode.clone(),
+                        (s.ids.identifiers.pool_uuid, s.ids.identifiers.device_uuid),
+                    );
+                }
+            }
+        }
         self.stopped_pools.insert(pool_uuid, devices);
         Ok(())
     }


### PR DESCRIPTION
Related to #2949 

It appears that the UUID lookup data structure is not populated properly when pools are stopped. This leads to stratisd ignoring remove events for devices from pools that were stopped only. Device records that were added to liminal device data structures by a udev add event will appropriately react to remove events.