### PR TITLE
Process device paths at the top level

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -180,11 +180,10 @@ impl Backstore {
     /// WARNING: metadata changing event
     pub fn initialize(
         pool_uuid: PoolUuid,
-        paths: &[&Path],
+        devices: UnownedDevices,
         mda_data_size: MDADataSize,
         encryption_info: Option<&EncryptionInfo>,
     ) -> StratisResult<Backstore> {
-        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths)?;
         let data_tier = DataTier::new(BlockDevMgr::initialize(
             pool_uuid,
             devices,
@@ -736,8 +735,11 @@ mod tests {
         let cachedevs =
             process_and_verify_devices(pool_uuid, &HashSet::new(), cachedevpaths).unwrap();
 
+        let initdatadevs =
+            process_and_verify_devices(pool_uuid, &HashSet::new(), initdatapaths).unwrap();
+
         let mut backstore =
-            Backstore::initialize(pool_uuid, initdatapaths, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, initdatadevs, MDADataSize::default(), None).unwrap();
 
         invariant(&backstore);
 
@@ -826,8 +828,10 @@ mod tests {
 
         let pool_uuid = PoolUuid::new_v4();
 
+        let devices1 = process_and_verify_devices(pool_uuid, &HashSet::new(), paths1).unwrap();
+
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths1, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices1, MDADataSize::default(), None).unwrap();
 
         for path in paths1 {
             assert_eq!(

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -309,7 +309,15 @@ impl Backstore {
         pool_uuid: PoolUuid,
         paths: &[&Path],
     ) -> StratisResult<Vec<DevUuid>> {
-        self.data_tier.add(pool_uuid, paths)
+        let current_uuids = self
+            .datadevs()
+            .iter()
+            .map(|(uuid, _)| *uuid)
+            .collect::<HashSet<_>>();
+
+        let devices = process_and_verify_devices(pool_uuid, &current_uuids, paths)?;
+
+        self.data_tier.add(pool_uuid, devices)
     }
 
     /// Extend the cap device whether it is a cache or not. Create the DM

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -674,7 +674,7 @@ mod tests {
     use devicemapper::{CacheDevStatus, DataBlocks, DmOptions, IEC};
 
     use crate::engine::strat_engine::{
-        backstore::process_and_verify_devices,
+        backstore::devices::process_and_verify_devices,
         metadata::device_identifiers,
         tests::{loopbacked, real},
     };

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -231,7 +231,10 @@ impl Recordable<CacheTierSave> for CacheTier {
 #[cfg(test)]
 mod tests {
 
+    use std::collections::HashSet;
+
     use crate::engine::strat_engine::{
+        backstore::devices::process_and_verify_devices,
         metadata::MDADataSize,
         tests::{loopbacked, real},
     };
@@ -248,7 +251,13 @@ mod tests {
 
         let pool_uuid = PoolUuid::new_v4();
 
-        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MDADataSize::default(), None).unwrap();
+        let mgr = BlockDevMgr::initialize(
+            pool_uuid,
+            process_and_verify_devices(pool_uuid, &HashSet::new(), paths1).unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
 
         let mut cache_tier = CacheTier::new(mgr).unwrap();
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -168,7 +168,10 @@ impl Recordable<DataTierSave> for DataTier {
 #[cfg(test)]
 mod tests {
 
+    use std::collections::HashSet;
+
     use crate::engine::strat_engine::{
+        backstore::devices::process_and_verify_devices,
         metadata::MDADataSize,
         tests::{loopbacked, real},
     };
@@ -184,7 +187,13 @@ mod tests {
 
         let pool_uuid = PoolUuid::new_v4();
 
-        let mgr = BlockDevMgr::initialize(pool_uuid, paths1, MDADataSize::default(), None).unwrap();
+        let mgr = BlockDevMgr::initialize(
+            pool_uuid,
+            process_and_verify_devices(pool_uuid, &HashSet::new(), paths1).unwrap(),
+            MDADataSize::default(),
+            None,
+        )
+        .unwrap();
 
         let mut data_tier = DataTier::new(mgr);
 

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -436,7 +436,7 @@ impl TryFrom<&[&Path]> for ProcessedPathInfos {
 /// * DeviceInfo.size value meets the required Stratis minimum.
 #[derive(Debug)]
 pub struct UnownedDevices {
-    inner: Vec<DeviceInfo>,
+    pub(super) inner: Vec<DeviceInfo>,
 }
 
 // Check coherence of pool and device UUIDs against a set of current UUIDs.

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -436,6 +436,12 @@ pub struct UnownedDevices {
     pub(super) inner: Vec<DeviceInfo>,
 }
 
+impl UnownedDevices {
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
 // Check coherence of pool and device UUIDs against a set of current UUIDs.
 // If the selection of devices is incompatible with the current
 // state of the set, or simply invalid, return an error.

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -273,14 +273,14 @@ pub struct StratisDevices {
 impl StratisDevices {
     // Given a pool UUID partition the devices into two divisions;
     // those that belong to the pool and those that do not.
-    fn partition(mut self, uuid: PoolUuid) -> (HashMap<DevUuid, DeviceInfo>, StratisDevices) {
+    pub fn partition(mut self, uuid: PoolUuid) -> (HashMap<DevUuid, DeviceInfo>, StratisDevices) {
         let this_pool = self.inner.remove(&uuid).unwrap_or_default();
         (this_pool, StratisDevices { inner: self.inner })
     }
 
     // Return an error message on the assumption that these devices have
     // been identified as belonging to another pool.
-    fn error_on_not_empty(&self) -> StratisResult<()> {
+    pub fn error_on_not_empty(&self) -> StratisResult<()> {
         let errors = self
             .inner
             .iter()
@@ -322,7 +322,7 @@ pub struct ProcessedPathInfos {
 impl ProcessedPathInfos {
     /// Unpack ProcessedPathInfos into devices owned by Stratis and
     /// into unowned devices.
-    fn unpack(self) -> (StratisDevices, UnownedDevices) {
+    pub fn unpack(self) -> (StratisDevices, UnownedDevices) {
         (
             StratisDevices {
                 inner: self.stratis_devices,

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -440,6 +440,10 @@ impl UnownedDevices {
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
+
+    pub fn unpack(self) -> Vec<DeviceInfo> {
+        self.inner
+    }
 }
 
 // Check coherence of pool and device UUIDs against a set of current UUIDs.
@@ -465,6 +469,7 @@ impl UnownedDevices {
 // Note that this method _should_ be somewhat temporary. We hope that in
 // another step the functionality contained will be hoisted up closer to
 // the D-Bus/engine interface, as it computes some idempotency information.
+#[cfg(test)]
 fn check_device_ids(
     pool_uuid: PoolUuid,
     current_uuids: &HashSet<DevUuid>,
@@ -521,6 +526,7 @@ fn check_device_ids(
 /// Combine the functionality of process_devices and check_device_ids.
 /// It is useful to guarantee that check_device_ids is called only with
 /// the result of invoking process_devices.
+#[cfg(test)]
 pub fn process_and_verify_devices(
     pool_uuid: PoolUuid,
     current_uuids: &HashSet<DevUuid>,

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -24,5 +24,5 @@ pub use self::{
         crypt_metadata_size, set_up_crypt_logging, CryptActivationHandle, CryptHandle,
         CryptMetadataHandle, CLEVIS_TANG_TRUST_URL,
     },
-    devices::{find_stratis_devs_by_uuid, initialize_devices, ProcessedPathInfos},
+    devices::{find_stratis_devs_by_uuid, initialize_devices, ProcessedPathInfos, UnownedDevices},
 };

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -14,6 +14,9 @@ mod range_alloc;
 mod shared;
 mod transaction;
 
+#[cfg(test)]
+pub use self::devices::process_and_verify_devices;
+
 pub use self::{
     backstore::Backstore,
     blockdev::{StratBlockDev, UnderlyingDevice},
@@ -21,8 +24,5 @@ pub use self::{
         crypt_metadata_size, set_up_crypt_logging, CryptActivationHandle, CryptHandle,
         CryptMetadataHandle, CLEVIS_TANG_TRUST_URL,
     },
-    devices::{
-        find_stratis_devs_by_uuid, initialize_devices, process_and_verify_devices,
-        ProcessedPathInfos,
-    },
+    devices::{find_stratis_devs_by_uuid, initialize_devices, ProcessedPathInfos},
 };

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -14,9 +14,6 @@ mod range_alloc;
 mod shared;
 mod transaction;
 
-#[cfg(test)]
-pub use self::devices::process_and_verify_devices;
-
 pub use self::{
     backstore::Backstore,
     blockdev::{StratBlockDev, UnderlyingDevice},

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -21,5 +21,8 @@ pub use self::{
         crypt_metadata_size, set_up_crypt_logging, CryptActivationHandle, CryptHandle,
         CryptMetadataHandle, CLEVIS_TANG_TRUST_URL,
     },
-    devices::{find_stratis_devs_by_uuid, initialize_devices, process_and_verify_devices},
+    devices::{
+        find_stratis_devs_by_uuid, initialize_devices, process_and_verify_devices,
+        ProcessedPathInfos,
+    },
 };

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -690,6 +690,11 @@ impl Pool for StratPool {
                     );
                     return Err(StratisError::Msg(error_message));
                 };
+
+                if unowned_devices.is_empty() {
+                    return Ok((SetCreateAction::new(vec![]), None));
+                }
+
                 self.thin_pool.suspend()?;
                 let bdev_info_res = self.backstore.add_cachedevs(pool_uuid, unowned_devices);
                 self.thin_pool.resume()?;
@@ -708,6 +713,10 @@ impl Pool for StratPool {
                     );
                     return Err(StratisError::Msg(error_message));
                 };
+
+                if unowned_devices.is_empty() {
+                    return Ok((SetCreateAction::new(vec![]), None));
+                }
 
                 let cached = self.cached();
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -18,7 +18,7 @@ use crate::{
             validate_paths,
         },
         strat_engine::{
-            backstore::{Backstore, StratBlockDev},
+            backstore::{Backstore, ProcessedPathInfos, StratBlockDev},
             liminal::{DeviceInfo, DeviceSet, LInfo},
             metadata::MDADataSize,
             serde_structs::{FlexDevsSave, PoolSave, Recordable},
@@ -641,42 +641,99 @@ impl Pool for StratPool {
                     pool_name
                 )
             ));
-        } else if paths.is_empty() {
-            //TODO: Substitute is_empty check with process_and_verify_devices
-            return Ok((SetCreateAction::new(vec![]), None));
-        } else if tier == BlockDevTier::Cache {
-            // If adding cache devices, must suspend the pool; the cache
-            // must be augmented with the new devices.
-            self.thin_pool.suspend()?;
-            let bdev_info_res = self.backstore.add_cachedevs(pool_uuid, paths);
-            self.thin_pool.resume()?;
-            let bdev_info = bdev_info_res?;
-            Ok((SetCreateAction::new(bdev_info), None))
         } else {
-            let cached = self.cached();
+            let devices = ProcessedPathInfos::try_from(paths)?;
+            let (stratis_devices, unowned_devices) = devices.unpack();
+            let (this_pool, other_pools) = stratis_devices.partition(pool_uuid);
 
-            // If just adding data devices, no need to suspend the pool.
-            // No action will be taken on the DM devices.
-            let bdev_info = self.backstore.add_datadevs(pool_uuid, paths)?;
-            self.thin_pool.set_queue_mode();
+            other_pools.error_on_not_empty()?;
 
-            // Adding data devices does not change the state of the thin
-            // pool at all. However, if the thin pool is in a state
-            // where it would request an allocation from the backstore the
-            // addition of the new data devs may have changed its context
-            // so that it can satisfy the allocation request where
-            // previously it could not. Run check() in case that is true.
-            let check = match self.thin_pool.check(pool_uuid, &mut self.backstore) {
-                Ok((_, thin_pool)) => {
-                    let pool = cached.diff(&self.dump(()));
-                    Some(PoolDiff { thin_pool, pool })
-                }
-                Err(e) => {
-                    warn!("Failed to check the thin pool for status changes; some information may not be able to reported to the IPC layer: {}", e);
-                    None
-                }
+            let (in_pool, out_pool): (Vec<_>, Vec<_>) = this_pool
+                .iter()
+                .map(|(dev_uuid, _)| {
+                    self.backstore
+                        .get_blockdev_by_uuid(*dev_uuid)
+                        .map(|(tier, _)| (*dev_uuid, tier))
+                })
+                .partition(|v| v.is_some());
+
+            if !out_pool.is_empty() {
+                let error_message = format!(
+                    "Devices ({}) appear to be already in use by this pool which has UUID {} but this pool has no record of them",
+                    out_pool
+                    .iter()
+                    .map(|opt| this_pool.get(&opt.expect("was looked up").0).expect("partitioned from this_pool").devnode.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                    pool_uuid
+                );
+                return Err(StratisError::Msg(error_message));
             };
-            Ok((SetCreateAction::new(bdev_info), check))
+
+            let (datadevs, cachedevs): (Vec<_>, Vec<_>) = in_pool
+                .iter()
+                .map(|opt| opt.expect("in_pool devices are Some"))
+                .partition(|(_, tier)| *tier == BlockDevTier::Data);
+
+            if tier == BlockDevTier::Cache {
+                // If adding cache devices, must suspend the pool; the cache
+                // must be augmented with the new devices.
+                if !datadevs.is_empty() {
+                    let error_message = format!(
+                        "Devices ({}) appear to be already in use by this pool which has UUID {}, but in the data tier not the cache tier",
+                        datadevs
+                        .iter()
+                        .map(|(uuid, _)| this_pool.get(uuid).expect("partitioned from this_pool").devnode.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                        pool_uuid
+                    );
+                    return Err(StratisError::Msg(error_message));
+                };
+                self.thin_pool.suspend()?;
+                let bdev_info_res = self.backstore.add_cachedevs(pool_uuid, unowned_devices);
+                self.thin_pool.resume()?;
+                let bdev_info = bdev_info_res?;
+                Ok((SetCreateAction::new(bdev_info), None))
+            } else {
+                if !cachedevs.is_empty() {
+                    let error_message = format!(
+                        "Devices ({}) appear to be already in use by this pool which has UUID {}, but in the cache tier not the data tier",
+                        cachedevs
+                        .iter()
+                        .map(|(uuid, _)| this_pool.get(uuid).expect("partitioned from this_pool").devnode.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                        pool_uuid
+                    );
+                    return Err(StratisError::Msg(error_message));
+                };
+
+                let cached = self.cached();
+
+                // If just adding data devices, no need to suspend the pool.
+                // No action will be taken on the DM devices.
+                let bdev_info = self.backstore.add_datadevs(pool_uuid, unowned_devices)?;
+                self.thin_pool.set_queue_mode();
+
+                // Adding data devices does not change the state of the thin
+                // pool at all. However, if the thin pool is in a state
+                // where it would request an allocation from the backstore the
+                // addition of the new data devs may have changed its context
+                // so that it can satisfy the allocation request where
+                // previously it could not. Run check() in case that is true.
+                let check = match self.thin_pool.check(pool_uuid, &mut self.backstore) {
+                    Ok((_, thin_pool)) => {
+                        let pool = cached.diff(&self.dump(()));
+                        Some(PoolDiff { thin_pool, pool })
+                    }
+                    Err(e) => {
+                        warn!("Failed to check the thin pool for status changes; some information may not be able to reported to the IPC layer: {}", e);
+                        None
+                    }
+                };
+                Ok((SetCreateAction::new(bdev_info), check))
+            }
         };
         self.write_metadata(pool_name)?;
         bdev_info

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -155,11 +155,20 @@ impl StratPool {
     ) -> StratisResult<(PoolUuid, StratPool)> {
         let pool_uuid = PoolUuid::new_v4();
 
+        let devices = ProcessedPathInfos::try_from(paths)?;
+        let (stratis_devices, unowned_devices) = devices.unpack();
+
+        stratis_devices.error_on_not_empty()?;
+
         // FIXME: Initializing with the minimum MDA size is not necessarily
         // enough. If there are enough devices specified, more space will be
         // required.
-        let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), encryption_info)?;
+        let mut backstore = Backstore::initialize(
+            pool_uuid,
+            unowned_devices,
+            MDADataSize::default(),
+            encryption_info,
+        )?;
 
         let thinpool = ThinPool::new(
             pool_uuid,

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -1663,8 +1663,10 @@ mod tests {
     fn test_lazy_allocation(paths: &[&Path]) {
         let pool_uuid = PoolUuid::new_v4();
 
+        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths).unwrap();
+
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices, MDADataSize::default(), None).unwrap();
         let size = ThinPoolSizeParams::new(backstore.datatier_usable_size()).unwrap();
         let mut pool = ThinPool::new(pool_uuid, &size, DATA_BLOCK_SIZE, &mut backstore).unwrap();
 
@@ -1750,11 +1752,13 @@ mod tests {
         let pool_uuid = PoolUuid::new_v4();
         let (first_path, remaining_paths) = paths.split_at(1);
 
+        let first_devices =
+            process_and_verify_devices(pool_uuid, &HashSet::new(), first_path).unwrap();
         let remaining_devices =
             process_and_verify_devices(pool_uuid, &HashSet::new(), remaining_paths).unwrap();
 
         let mut backstore =
-            Backstore::initialize(pool_uuid, first_path, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, first_devices, MDADataSize::default(), None).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -1878,8 +1882,11 @@ mod tests {
     fn test_filesystem_snapshot(paths: &[&Path]) {
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
+
+        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths).unwrap();
+
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices, MDADataSize::default(), None).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -1989,8 +1996,9 @@ mod tests {
         let name2 = "name2";
 
         let pool_uuid = PoolUuid::new_v4();
+        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths).unwrap();
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices, MDADataSize::default(), None).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2050,8 +2058,9 @@ mod tests {
     fn test_pool_setup(paths: &[&Path]) {
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
+        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths).unwrap();
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices, MDADataSize::default(), None).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2120,8 +2129,9 @@ mod tests {
     /// same thin id and verifying that it fails.
     fn test_thindev_destroy(paths: &[&Path]) {
         let pool_uuid = PoolUuid::new_v4();
+        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths).unwrap();
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices, MDADataSize::default(), None).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2178,8 +2188,9 @@ mod tests {
     fn test_suspend_resume(paths: &[&Path]) {
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
+        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths).unwrap();
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices, MDADataSize::default(), None).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),
@@ -2229,8 +2240,10 @@ mod tests {
 
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
+        let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths2).unwrap();
+
         let mut backstore =
-            Backstore::initialize(pool_uuid, paths2, MDADataSize::default(), None).unwrap();
+            Backstore::initialize(pool_uuid, devices, MDADataSize::default(), None).unwrap();
         let mut pool = ThinPool::new(
             pool_uuid,
             &ThinPoolSizeParams::new(backstore.available_in_backstore()).unwrap(),

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -2240,6 +2240,7 @@ mod tests {
 
         let pool_name = "pool";
         let pool_uuid = PoolUuid::new_v4();
+        let devices1 = process_and_verify_devices(pool_uuid, &HashSet::new(), paths1).unwrap();
         let devices = process_and_verify_devices(pool_uuid, &HashSet::new(), paths2).unwrap();
 
         let mut backstore =
@@ -2299,7 +2300,7 @@ mod tests {
         let old_device = backstore
             .device()
             .expect("Space already allocated from backstore, backstore must have device");
-        backstore.init_cache(pool_uuid, paths1).unwrap();
+        backstore.init_cache(pool_uuid, devices1).unwrap();
         let new_device = backstore
             .device()
             .expect("Space already allocated from backstore, backstore must have device");


### PR DESCRIPTION
Supercedes #2948
Closes #1968 
Related #2880 

* Defines or extends some structs and methods for obtaining and processing sets of device information in the backstore/devices.rs file.
* Uses these methods to check for an empty set of to-be-initialized devices in ```init_cache``` and ```create_pool``` at the top level. This ensure a correct evaluation of emptiness, requiring little reasoning about the intervening reading steps. Also checks for emptiness when adding devices, to return early and omit expensive processing if no devices are to be added.
* Retains the use of the ```*idempotent*``` methods for the strat engine. Unpacks some device sets to obtain paths to pass to the methods, but only those device sets that wouldn't already have caused an error. This decision is motivated by the fact that the ```idempotent*``` methods are shared by the sim engine and the strat engine.
* Removes the process_and_verify_devices() and the check_device_ids() method entirely. Substitutes use of structs and their related impls in tests throughout the code.

Advantages:
* Raises the inspection of devices up to a higher level, to the pool, or in the case of creating a pool, the engine level. This is the principal goal. The reasons for doing this are to allow stratisd to have a full understanding of the properties of the devices it has been given as an argument at the same time as it can inspect information about all the existing devices in _both_ tiers, in order to decide whether they should be considered compatible or not. Currently, when creating a pool, everything about the devices to be used for the pool are known at the time of creation. But when initializing a cache, only the info about the proposed cache devices is known. And when adding devices to either tier, only the information about that tier is known. It is not known, at all, whether the devices are cache or data devices, at the point where they are inspected. This last could be remedied by passing a Tier argument down to the blockdev manager methods, but the other issues could not be.
* When initializing or extending the cache, it is necessary to suspend the thinpool. By reading the data from the devices before initializing or extending the cache, the suspend/resume interval is made a bit shorter. Not that much, probably, compared to the time that it takes to initialize the devices, but still an improvement.
* We have a lot of code in the CLI to try to guard against and give detailed messages in case the user specifies devices that belong to another pool or the same pool but a different tier, when adding, creating, or initializing. We can't really remove this, and achieve all that precision in stratisd, because although the inspection of devices is hoisted higher, it would all have to be hoisted up into the engine to make the level of detail in error messages comparable to that in the CLI. We do, however, send out precise error messages for when a user specifies devices in one tier, but they belong to the opposite tier, which is an improvement over the previous situation.

NOTES:
* This is an improvement over the previous iteration, which had convoluted and not generally useful abstractions in some of the impls in devices.rs. It drops the NonEmptyUnownedDevices, which turned out to be unhelpful in enforcing non-emptiness requirements.
* It keeps calls to ```validate_paths()``` before other processing, because ```validate_paths()``` verifies that the paths are absolute and emptiness checks now occur after the paths have been processed and information has been read from their corresponding devices.
