### PR TITLE
Prohibit certain block size combinations when creating a new pool or adding devices to an existing pool (prior)

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -16,8 +16,7 @@ use crate::{
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev, blockdevmgr::BlockDevMgr, cache_tier::CacheTier,
-                data_tier::DataTier, devices::UnownedDevices, shared::map_to_dm,
-                transaction::RequestTransaction,
+                data_tier::DataTier, devices::UnownedDevices, transaction::RequestTransaction,
             },
             dm::get_dm,
             metadata::MDADataSize,
@@ -49,7 +48,7 @@ fn make_cache(
         get_dm(),
         &dm_name,
         Some(&dm_uuid),
-        map_to_dm(&cache_tier.meta_segments),
+        cache_tier.meta_segments.map_to_dm(),
     )?;
 
     if new {
@@ -66,7 +65,7 @@ fn make_cache(
         get_dm(),
         &dm_name,
         Some(&dm_uuid),
-        map_to_dm(&cache_tier.cache_segments),
+        cache_tier.cache_segments.map_to_dm(),
     )?;
 
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
@@ -136,7 +135,7 @@ impl Backstore {
             get_dm(),
             &dm_name,
             Some(&dm_uuid),
-            map_to_dm(&data_tier.segments),
+            data_tier.segments.map_to_dm(),
         )?;
 
         let (cache_tier, cache, origin) = if !cachedevs.is_empty() {
@@ -271,7 +270,7 @@ impl Backstore {
                 let (uuids, (cache_change, meta_change)) = cache_tier.add(pool_uuid, devices)?;
 
                 if cache_change {
-                    let table = map_to_dm(&cache_tier.cache_segments);
+                    let table = cache_tier.cache_segments.map_to_dm();
                     cache_device.set_cache_table(get_dm(), table)?;
                     cache_device.resume(get_dm())?;
                 }
@@ -280,7 +279,7 @@ impl Backstore {
                 // meta segments. That means that this code is dead. But,
                 // when CacheTier::add() is fixed, this code will become live.
                 if meta_change {
-                    let table = map_to_dm(&cache_tier.meta_segments);
+                    let table = cache_tier.meta_segments.map_to_dm();
                     cache_device.set_meta_table(get_dm(), table)?;
                     cache_device.resume(get_dm())?;
                 }
@@ -308,13 +307,13 @@ impl Backstore {
         let create = match (self.cache.as_mut(), self.linear.as_mut()) {
             (None, None) => true,
             (Some(cache), None) => {
-                let table = map_to_dm(&self.data_tier.segments);
+                let table = self.data_tier.segments.map_to_dm();
                 cache.set_origin_table(get_dm(), table)?;
                 cache.resume(get_dm())?;
                 false
             }
             (None, Some(linear)) => {
-                let table = map_to_dm(&self.data_tier.segments);
+                let table = self.data_tier.segments.map_to_dm();
                 linear.set_table(get_dm(), table)?;
                 linear.resume(get_dm())?;
                 false
@@ -323,7 +322,7 @@ impl Backstore {
         };
 
         if create {
-            let table = map_to_dm(&self.data_tier.segments);
+            let table = self.data_tier.segments.map_to_dm();
             let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
             let origin = LinearDev::setup(get_dm(), &dm_name, Some(&dm_uuid), table)?;
             self.linear = Some(origin);

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -15,11 +15,8 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
-                blockdev::StratBlockDev,
-                blockdevmgr::{map_to_dm, BlockDevMgr},
-                cache_tier::CacheTier,
-                data_tier::DataTier,
-                devices::UnownedDevices,
+                blockdev::StratBlockDev, blockdevmgr::BlockDevMgr, cache_tier::CacheTier,
+                data_tier::DataTier, devices::UnownedDevices, shared::map_to_dm,
                 transaction::RequestTransaction,
             },
             dm::get_dm,

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -16,7 +16,8 @@ use crate::{
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev, blockdevmgr::BlockDevMgr, cache_tier::CacheTier,
-                data_tier::DataTier, devices::UnownedDevices, transaction::RequestTransaction,
+                data_tier::DataTier, devices::UnownedDevices, shared::BlockSizeSummary,
+                transaction::RequestTransaction,
             },
             dm::get_dm,
             metadata::MDADataSize,
@@ -25,7 +26,8 @@ use crate::{
             writing::wipe_sectors,
         },
         types::{
-            BlockDevTier, DevUuid, EncryptionInfo, KeyDescription, PoolEncryptionInfo, PoolUuid,
+            ActionAvailability, BlockDevTier, DevUuid, EncryptionInfo, KeyDescription,
+            PoolEncryptionInfo, PoolUuid,
         },
     },
     stratis::{StratisError, StratisResult},
@@ -629,6 +631,35 @@ impl Backstore {
 
     pub fn grow(&mut self, dev: DevUuid) -> StratisResult<bool> {
         self.data_tier.grow(dev)
+    }
+
+    /// A summary of block sizes
+    pub fn block_size_summary(&self, tier: BlockDevTier) -> Option<BlockSizeSummary> {
+        match tier {
+            BlockDevTier::Data => Some(self.data_tier.partition_by_use().into()),
+            BlockDevTier::Cache => self
+                .cache_tier
+                .as_ref()
+                .map(|ct| ct.partition_cache_by_use().into()),
+        }
+    }
+
+    /// What the pool's action availability should be
+    pub fn action_availability(&self) -> ActionAvailability {
+        let data_tier_bs_summary = self
+            .block_size_summary(BlockDevTier::Data)
+            .expect("always exists");
+        let cache_tier_bs_summary: Option<BlockSizeSummary> =
+            self.block_size_summary(BlockDevTier::Cache);
+        if let Err(err) = data_tier_bs_summary.validate() {
+            warn!("Disabling pool changes for this pool: {}", err);
+            ActionAvailability::NoPoolChanges
+        } else if let Some(Err(err)) = cache_tier_bs_summary.map(|ct| ct.validate()) {
+            warn!("Disabling pool changes for this pool: {}", err);
+            ActionAvailability::NoPoolChanges
+        } else {
+            ActionAvailability::Full
+        }
     }
 }
 

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -701,7 +701,13 @@ mod tests {
                 _ => panic!("impossible; see first assertion"),
             }
         );
-        assert!(backstore.next <= backstore.size())
+        assert!(backstore.next <= backstore.size());
+
+        backstore.data_tier.invariant();
+
+        if let Some(cache_tier) = &backstore.cache_tier {
+            cache_tier.invariant()
+        }
     }
 
     fn get_devices(paths: &[&Path]) -> StratisResult<UnownedDevices> {

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -22,6 +22,7 @@ use crate::{
         strat_engine::{
             backstore::{
                 crypt::CryptHandle,
+                devices::BlockSizes,
                 range_alloc::{PerDevSegments, RangeAllocator},
                 transaction::RequestTransaction,
             },
@@ -85,6 +86,7 @@ pub struct StratBlockDev {
     hardware_info: Option<String>,
     underlying_device: UnderlyingDevice,
     new_size: Option<Sectors>,
+    blksizes: BlockSizes,
 }
 
 impl StratBlockDev {
@@ -116,6 +118,7 @@ impl StratBlockDev {
         user_info: Option<String>,
         hardware_info: Option<String>,
         underlying_device: UnderlyingDevice,
+        blksizes: BlockSizes,
     ) -> StratisResult<StratBlockDev> {
         let mut segments = vec![(Sectors(0), bda.extended_size().sectors())];
         segments.extend(other_segments);
@@ -130,6 +133,7 @@ impl StratBlockDev {
             hardware_info,
             underlying_device,
             new_size: None,
+            blksizes,
         })
     }
 
@@ -260,6 +264,11 @@ impl StratBlockDev {
         self.underlying_device
             .crypt_handle()
             .map(|ch| ch.encryption_info())
+    }
+
+    /// Block size information
+    pub fn blksizes(&self) -> BlockSizes {
+        self.blksizes
     }
 
     /// Bind encrypted device using the given clevis configuration.

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -233,6 +233,12 @@ impl StratBlockDev {
         self.bda.max_data_size()
     }
 
+    /// Whether or not the blockdev is in use by upper layers. It is if the
+    /// sum of the blocks used exceeds the Stratis metadata size.
+    pub fn in_use(&self) -> bool {
+        self.used.used() > self.metadata_size().sectors()
+    }
+
     /// Set the user info on this blockdev.
     /// The user_info may be None, which unsets user info.
     /// Returns true if the user info was changed, otherwise false.

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -496,6 +496,10 @@ impl<'a> Into<Value> for &'a StratBlockDev {
         if let Some(new_size) = self.new_size {
             map.insert("new_size".to_string(), Value::from(new_size.to_string()));
         }
+        map.insert(
+            "blksizes".to_string(),
+            Value::from(self.blksizes.to_string()),
+        );
         json
     }
 }

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -14,7 +14,7 @@ use rand::{seq::IteratorRandom, thread_rng};
 use serde_json::Value;
 use tempfile::TempDir;
 
-use devicemapper::{Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine};
+use devicemapper::{Bytes, Device, Sectors};
 
 use crate::{
     engine::{
@@ -28,10 +28,11 @@ use crate::{
                 },
                 devices::{initialize_devices, wipe_blockdevs, UnownedDevices},
                 range_alloc::PerDevSegments,
+                shared::{BlkDevSegment, Segment},
                 transaction::RequestTransaction,
             },
             metadata::MDADataSize,
-            serde_structs::{BaseBlockDevSave, BaseDevSave, Recordable},
+            serde_structs::{BaseBlockDevSave, Recordable},
         },
         types::{
             ActionAvailability, DevUuid, EncryptionInfo, KeyDescription, PoolEncryptionInfo,
@@ -42,81 +43,6 @@ use crate::{
 };
 
 const MAX_NUM_TO_WRITE: usize = 10;
-
-/// struct to represent a continuous set of sectors on a disk
-#[derive(Debug, Clone)]
-pub struct Segment {
-    /// The offset into the device where this segment starts.
-    pub(super) start: Sectors,
-    /// The length of the segment.
-    pub(super) length: Sectors,
-    /// The device the segment is within.
-    pub(super) device: Device,
-}
-
-impl Segment {
-    /// Create a new Segment with given attributes
-    pub fn new(device: Device, start: Sectors, length: Sectors) -> Segment {
-        Segment {
-            start,
-            length,
-            device,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct BlkDevSegment {
-    pub(super) uuid: DevUuid,
-    pub(super) segment: Segment,
-}
-
-impl BlkDevSegment {
-    pub fn new(uuid: DevUuid, segment: Segment) -> BlkDevSegment {
-        BlkDevSegment { uuid, segment }
-    }
-
-    pub fn to_segment(&self) -> Segment {
-        self.segment.clone()
-    }
-}
-
-impl Recordable<Vec<BaseDevSave>> for Vec<BlkDevSegment> {
-    fn record(&self) -> Vec<BaseDevSave> {
-        self.iter()
-            .map(|bseg| BaseDevSave {
-                parent: bseg.uuid,
-                start: bseg.segment.start,
-                length: bseg.segment.length,
-            })
-            .collect::<Vec<_>>()
-    }
-}
-
-/// Build a linear dev target table from BlkDevSegments. This is useful for
-/// calls to the devicemapper library.
-pub fn map_to_dm(bsegs: &[BlkDevSegment]) -> Vec<TargetLine<LinearDevTargetParams>> {
-    let mut table = Vec::new();
-    let mut logical_start_offset = Sectors(0);
-
-    let segments = bsegs
-        .iter()
-        .map(|bseg| bseg.to_segment())
-        .collect::<Vec<_>>();
-    for segment in segments {
-        let (physical_start_offset, length) = (segment.start, segment.length);
-        let params = LinearTargetParams::new(segment.device, physical_start_offset);
-        let line = TargetLine::new(
-            logical_start_offset,
-            length,
-            LinearDevTargetParams::Linear(params),
-        );
-        table.push(line);
-        logical_start_offset += length;
-    }
-
-    table
-}
 
 #[derive(Debug)]
 pub struct BlockDevMgr {

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -11,9 +11,9 @@ use crate::{
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,
-                blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{coalesce_blkdevsegs, metadata_to_segment},
+                shared::{coalesce_blkdevsegs, metadata_to_segment, BlkDevSegment},
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
         },

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -13,7 +13,7 @@ use crate::{
                 blockdev::StratBlockDev,
                 blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{coalesce_blkdevsegs, metadata_to_segment, BlkDevSegment},
+                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment},
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
         },
@@ -37,10 +37,10 @@ pub struct CacheTier {
     pub block_mgr: BlockDevMgr,
     /// The list of segments granted by block_mgr and used by the cache
     /// device.
-    pub cache_segments: Vec<BlkDevSegment>,
+    pub cache_segments: AllocatedAbove,
     /// The list of segments granted by block_mgr and used by the metadata
     /// device.
-    pub meta_segments: Vec<BlkDevSegment>,
+    pub meta_segments: AllocatedAbove,
 }
 
 impl CacheTier {
@@ -63,15 +63,19 @@ impl CacheTier {
             metadata_to_segment(&uuid_to_devno, ld)
         };
 
-        let meta_segments = cache_tier_save.blockdev.allocs[1]
-            .iter()
-            .map(&mapper)
-            .collect::<StratisResult<Vec<_>>>()?;
+        let meta_segments = AllocatedAbove {
+            inner: cache_tier_save.blockdev.allocs[1]
+                .iter()
+                .map(&mapper)
+                .collect::<StratisResult<Vec<_>>>()?,
+        };
 
-        let cache_segments = cache_tier_save.blockdev.allocs[0]
-            .iter()
-            .map(&mapper)
-            .collect::<StratisResult<Vec<_>>>()?;
+        let cache_segments = AllocatedAbove {
+            inner: cache_tier_save.blockdev.allocs[0]
+                .iter()
+                .map(&mapper)
+                .collect::<StratisResult<Vec<_>>>()?,
+        };
 
         Ok(CacheTier {
             block_mgr,
@@ -105,14 +109,7 @@ impl CacheTier {
 
         // FIXME: This check will become unnecessary when cache metadata device
         // can be increased dynamically.
-        if avail_space
-            + self
-                .cache_segments
-                .iter()
-                .map(|x| x.segment.length)
-                .sum::<Sectors>()
-            > MAX_CACHE_SIZE
-        {
+        if avail_space + self.cache_segments.size() > MAX_CACHE_SIZE {
             self.block_mgr.remove_blockdevs(&uuids)?;
             return Err(StratisError::Msg(format!(
                 "The size of the cache sub-device may not exceed {}",
@@ -132,7 +129,7 @@ impl CacheTier {
                 e
             )));
         }
-        self.cache_segments = coalesce_blkdevsegs(&self.cache_segments, &segments);
+        self.cache_segments.coalesce_blkdevsegs(&segments);
 
         Ok((uuids, (true, false)))
     }
@@ -167,8 +164,12 @@ impl CacheTier {
         let trans = block_mgr
             .request_space(&[meta_space, avail_space - meta_space])?
             .expect("asked for exactly the space available, must get");
-        let meta_segments = trans.get_segs_for_req(0).expect("segments.len() == 2");
-        let cache_segments = trans.get_segs_for_req(1).expect("segments.len() == 2");
+        let meta_segments = AllocatedAbove {
+            inner: trans.get_segs_for_req(0).expect("segments.len() == 2"),
+        };
+        let cache_segments = AllocatedAbove {
+            inner: trans.get_segs_for_req(1).expect("segments.len() == 2"),
+        };
         if let Err(e) = block_mgr.commit_space(trans) {
             block_mgr.destroy_all()?;
             return Err(StratisError::Msg(format!(
@@ -269,19 +270,11 @@ mod tests {
 
         // A cache tier w/ some devices and everything promptly allocated to
         // the tier.
-        let cache_metadata_size = cache_tier
-            .meta_segments
-            .iter()
-            .map(|x| x.segment.length)
-            .sum::<Sectors>();
+        let cache_metadata_size = cache_tier.meta_segments.size();
 
         let mut metadata_size = cache_tier.block_mgr.metadata_size();
         let mut size = cache_tier.block_mgr.size();
-        let mut allocated = cache_tier
-            .cache_segments
-            .iter()
-            .map(|x| x.segment.length)
-            .sum::<Sectors>();
+        let mut allocated = cache_tier.cache_segments.size();
 
         assert_eq!(cache_tier.block_mgr.avail_space(), Sectors(0));
         assert_eq!(size - metadata_size, allocated + cache_metadata_size);
@@ -297,11 +290,7 @@ mod tests {
 
         metadata_size = cache_tier.block_mgr.metadata_size();
         size = cache_tier.block_mgr.size();
-        allocated = cache_tier
-            .cache_segments
-            .iter()
-            .map(|x| x.segment.length)
-            .sum::<Sectors>();
+        allocated = cache_tier.cache_segments.size();
         assert_eq!(size - metadata_size, allocated + cache_metadata_size);
 
         cache_tier.destroy().unwrap();

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -16,7 +16,7 @@ use crate::{
                 blockdev::StratBlockDev,
                 blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment},
+                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment, BlockDevPartition},
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
         },
@@ -217,6 +217,14 @@ impl CacheTier {
         self.block_mgr
             .get_mut_blockdev_by_uuid(uuid)
             .map(|bd| (BlockDevTier::Cache, bd))
+    }
+
+    /// Return the partition of the block devs that are in use and those that
+    /// are not.
+    pub fn partition_cache_by_use(&self) -> BlockDevPartition<'_> {
+        let blockdevs = self.block_mgr.blockdevs();
+        let (used, unused) = blockdevs.iter().partition(|(_, bd)| bd.in_use());
+        BlockDevPartition { used, unused }
     }
 
     #[cfg(test)]

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -34,13 +34,13 @@ const MAX_CACHE_SIZE: Sectors = Sectors(32 * IEC::Ti / SECTOR_SIZE as u64);
 #[derive(Debug)]
 pub struct CacheTier {
     /// Manages the individual block devices
-    pub block_mgr: BlockDevMgr,
+    pub(super) block_mgr: BlockDevMgr,
     /// The list of segments granted by block_mgr and used by the cache
     /// device.
-    pub cache_segments: AllocatedAbove,
+    pub(super) cache_segments: AllocatedAbove,
     /// The list of segments granted by block_mgr and used by the metadata
     /// device.
-    pub meta_segments: AllocatedAbove,
+    pub(super) meta_segments: AllocatedAbove,
 }
 
 impl CacheTier {

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -235,6 +235,15 @@ impl CacheTier {
             .map(|(u, _)| *u)
             .collect::<HashSet<_>>();
         assert_eq!(allocated_uuids, in_use_uuids);
+
+        let uuids = self
+            .block_mgr
+            .blockdevs()
+            .iter()
+            .map(|(u, _)| *u)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(uuids, in_use_uuids);
     }
 }
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -16,7 +16,7 @@ use crate::{
                 blockdev::StratBlockDev,
                 blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment},
+                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment, BlockDevPartition},
                 transaction::RequestTransaction,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},
@@ -156,6 +156,14 @@ impl DataTier {
 
     pub fn grow(&mut self, dev: DevUuid) -> StratisResult<bool> {
         self.block_mgr.grow(dev)
+    }
+
+    /// Return the partition of the block devs that are in use and those
+    /// that are not.
+    pub fn partition_by_use(&self) -> BlockDevPartition<'_> {
+        let blockdevs = self.block_mgr.blockdevs();
+        let (used, unused) = blockdevs.iter().partition(|(_, bd)| bd.in_use());
+        BlockDevPartition { used, unused }
     }
 
     #[cfg(test)]

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -27,9 +27,9 @@ use crate::{
 #[derive(Debug)]
 pub struct DataTier {
     /// Manages the individual block devices
-    pub block_mgr: BlockDevMgr,
+    pub(super) block_mgr: BlockDevMgr,
     /// The list of segments granted by block_mgr and used by dm_device
-    pub segments: AllocatedAbove,
+    pub(super) segments: AllocatedAbove,
 }
 
 impl DataTier {

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -11,9 +11,9 @@ use crate::{
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,
-                blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{coalesce_blkdevsegs, metadata_to_segment},
+                shared::{coalesce_blkdevsegs, metadata_to_segment, BlkDevSegment},
                 transaction::RequestTransaction,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -13,7 +13,7 @@ use crate::{
                 blockdev::StratBlockDev,
                 blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{coalesce_blkdevsegs, metadata_to_segment, BlkDevSegment},
+                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment},
                 transaction::RequestTransaction,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},
@@ -29,7 +29,7 @@ pub struct DataTier {
     /// Manages the individual block devices
     pub block_mgr: BlockDevMgr,
     /// The list of segments granted by block_mgr and used by dm_device
-    pub segments: Vec<BlkDevSegment>,
+    pub segments: AllocatedAbove,
 }
 
 impl DataTier {
@@ -40,10 +40,12 @@ impl DataTier {
         let mapper = |ld: &BaseDevSave| -> StratisResult<BlkDevSegment> {
             metadata_to_segment(&uuid_to_devno, ld)
         };
-        let segments = data_tier_save.blockdev.allocs[0]
-            .iter()
-            .map(&mapper)
-            .collect::<StratisResult<Vec<_>>>()?;
+        let segments = AllocatedAbove {
+            inner: data_tier_save.blockdev.allocs[0]
+                .iter()
+                .map(&mapper)
+                .collect::<StratisResult<Vec<_>>>()?,
+        };
 
         Ok(DataTier {
             block_mgr,
@@ -59,7 +61,7 @@ impl DataTier {
     pub fn new(block_mgr: BlockDevMgr) -> DataTier {
         DataTier {
             block_mgr,
-            segments: vec![],
+            segments: AllocatedAbove { inner: vec![] },
         }
     }
 
@@ -86,7 +88,7 @@ impl DataTier {
     pub fn alloc_commit(&mut self, transaction: RequestTransaction) -> StratisResult<()> {
         let segments = transaction.get_blockdevmgr();
         self.block_mgr.commit_space(transaction)?;
-        self.segments = coalesce_blkdevsegs(&self.segments, &segments);
+        self.segments.coalesce_blkdevsegs(&segments);
 
         Ok(())
     }
@@ -94,10 +96,7 @@ impl DataTier {
     /// The sum of the lengths of all the sectors that have been mapped to an
     /// upper device.
     pub fn allocated(&self) -> Sectors {
-        self.segments
-            .iter()
-            .map(|x| x.segment.length)
-            .sum::<Sectors>()
+        self.segments.size()
     }
 
     /// The total size of all the blockdevs combined

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -252,7 +252,6 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BlockSizes {
-    #[allow(dead_code)]
     pub(super) physical_sector_size: Bytes,
     pub(super) logical_sector_size: Bytes,
 }
@@ -465,6 +464,18 @@ impl UnownedDevices {
 
     pub fn unpack(self) -> Vec<DeviceInfo> {
         self.inner
+    }
+
+    /// Return a map of block sizes to device infos
+    pub fn blocksizes(&self) -> HashMap<BlockSizes, Vec<&DeviceInfo>> {
+        let mut block_size_groups = HashMap::new();
+        for info in self.inner.iter() {
+            block_size_groups
+                .entry(info.blksizes)
+                .or_insert_with(Vec::new)
+                .push(info);
+        }
+        block_size_groups
     }
 }
 

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     fs::{File, OpenOptions},
     path::{Path, PathBuf},
     sync::Mutex,
@@ -264,6 +265,16 @@ impl BlockSizes {
             physical_sector_size,
             logical_sector_size,
         })
+    }
+}
+
+impl fmt::Display for BlockSizes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "BLKSSSZGET: {}, BLKPBSZGET: {}",
+            self.logical_sector_size, self.physical_sector_size
+        )
     }
 }
 

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::OpenOptions,
+    fs::{File, OpenOptions},
     path::{Path, PathBuf},
     sync::Mutex,
 };
@@ -25,7 +25,7 @@ use crate::{
                 blockdev::{StratBlockDev, UnderlyingDevice},
                 crypt::{CryptHandle, CryptInitializer},
             },
-            device::blkdev_size,
+            device::{blkdev_logical_sector_size, blkdev_physical_sector_size, blkdev_size},
             metadata::{
                 device_identifiers, disown_device, BlockdevSize, MDADataSize, StratisIdentifiers,
                 BDA,
@@ -201,6 +201,7 @@ fn dev_info(devnode: &DevicePath) -> StratisResult<(DeviceInfo, Option<StratisId
 
             let mut f = OpenOptions::new().read(true).write(true).open(&**devnode)?;
             let dev_size = blkdev_size(&f)?;
+            let blksizes = BlockSizes::read(&f)?;
 
             let stratis_identifiers = device_identifiers(&mut f).map_err(|err| {
                 let error_message = format!(
@@ -225,6 +226,7 @@ fn dev_info(devnode: &DevicePath) -> StratisResult<(DeviceInfo, Option<StratisId
                     devnode: devnode.to_path_buf(),
                     id_wwn: hw_id,
                     size: dev_size,
+                    blksizes,
                 },
                 stratis_identifiers,
             ))
@@ -248,6 +250,25 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct BlockSizes {
+    #[allow(dead_code)]
+    physical_sector_size: Bytes,
+    #[allow(dead_code)]
+    logical_sector_size: Bytes,
+}
+
+impl BlockSizes {
+    pub fn read(f: &File) -> StratisResult<BlockSizes> {
+        let physical_sector_size = blkdev_physical_sector_size(f)?;
+        let logical_sector_size = blkdev_logical_sector_size(f)?;
+        Ok(BlockSizes {
+            physical_sector_size,
+            logical_sector_size,
+        })
+    }
+}
+
 /// A miscellaneous grab bag of useful information required to decide whether
 /// a device should be allowed to be initialized by Stratis or to be used
 /// when initializing a device.
@@ -262,6 +283,8 @@ pub struct DeviceInfo {
     pub id_wwn: Option<StratisResult<String>>,
     /// The total size of the device
     pub size: Bytes,
+    /// Block size information
+    pub blksizes: BlockSizes,
 }
 
 /// Devices that have all been identified as Stratis devices.
@@ -512,6 +535,7 @@ pub fn initialize_devices(
         dev_uuid: DevUuid,
         sizes: (MDADataSize, BlockdevSize),
         id_wwn: &Option<StratisResult<String>>,
+        blksizes: BlockSizes,
     ) -> StratisResult<StratBlockDev> {
         let (mda_data_size, data_size) = sizes;
         let mut f = OpenOptions::new()
@@ -542,7 +566,7 @@ pub fn initialize_devices(
 
         bda.initialize(&mut f)?;
 
-        StratBlockDev::new(devno, bda, &[], None, hw_id, underlying_device)
+        StratBlockDev::new(devno, bda, &[], None, hw_id, underlying_device, blksizes)
     }
 
     /// Clean up an encrypted device after initialization failure.
@@ -648,6 +672,7 @@ pub fn initialize_devices(
                     dev_uuid,
                     (mda_data_size, BlockdevSize::new(blockdev_size)),
                     &dev_info.id_wwn,
+                    dev_info.blksizes,
                 );
                 if let Err(err) = blockdev {
                     Err(clean_up_encrypted(&mut handle_clone, err))
@@ -663,6 +688,7 @@ pub fn initialize_devices(
                     dev_uuid,
                     (mda_data_size, BlockdevSize::new(blockdev_size)),
                     &dev_info.id_wwn,
+                    dev_info.blksizes,
                 );
                 if let Err(err) = blockdev {
                     Err(clean_up_unencrypted(physical_path, err))
@@ -1028,6 +1054,7 @@ mod tests {
                 devno: old_info.devno,
                 id_wwn: None,
                 size: old_info.size,
+                blksizes: old_info.blksizes,
             };
 
             dev_infos.push(new_info);

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -252,8 +252,8 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BlockSizes {
-    pub(super) physical_sector_size: Bytes,
-    pub(super) logical_sector_size: Bytes,
+    pub physical_sector_size: Bytes,
+    pub logical_sector_size: Bytes,
 }
 
 impl BlockSizes {

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -250,12 +250,11 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BlockSizes {
     #[allow(dead_code)]
-    physical_sector_size: Bytes,
-    #[allow(dead_code)]
-    logical_sector_size: Bytes,
+    pub(super) physical_sector_size: Bytes,
+    pub(super) logical_sector_size: Bytes,
 }
 
 impl BlockSizes {

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -21,5 +21,8 @@ pub use self::{
         crypt_metadata_size, set_up_crypt_logging, CryptActivationHandle, CryptHandle,
         CryptMetadataHandle, CLEVIS_TANG_TRUST_URL,
     },
-    devices::{find_stratis_devs_by_uuid, initialize_devices, ProcessedPathInfos, UnownedDevices},
+    devices::{
+        find_stratis_devs_by_uuid, initialize_devices, BlockSizes, ProcessedPathInfos,
+        UnownedDevices,
+    },
 };

--- a/src/engine/strat_engine/backstore/shared.rs
+++ b/src/engine/strat_engine/backstore/shared.rs
@@ -4,6 +4,9 @@
 
 // Methods that are shared by the cache tier and the data tier.
 
+#[cfg(test)]
+use std::collections::HashSet;
+
 use std::collections::HashMap;
 
 use devicemapper::{Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine};
@@ -130,6 +133,15 @@ impl AllocatedAbove {
                 collect
             },
         );
+    }
+
+    /// A set of UUIDs of every device that is allocated from.
+    #[cfg(test)]
+    pub fn uuids(&self) -> HashSet<DevUuid> {
+        self.inner
+            .iter()
+            .map(|seg| seg.uuid)
+            .collect::<HashSet<DevUuid>>()
     }
 }
 

--- a/src/engine/strat_engine/backstore/shared.rs
+++ b/src/engine/strat_engine/backstore/shared.rs
@@ -4,16 +4,16 @@
 
 // Methods that are shared by the cache tier and the data tier.
 
-#[cfg(test)]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use std::collections::HashMap;
-
-use devicemapper::{Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine};
+use devicemapper::{Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine};
 
 use crate::{
     engine::{
-        strat_engine::serde_structs::{BaseDevSave, Recordable},
+        strat_engine::{
+            backstore::{blockdev::StratBlockDev, devices::BlockSizes},
+            serde_structs::{BaseDevSave, Recordable},
+        },
         types::DevUuid,
     },
     stratis::{StratisError, StratisResult},
@@ -142,6 +142,90 @@ impl AllocatedAbove {
             .iter()
             .map(|seg| seg.uuid)
             .collect::<HashSet<DevUuid>>()
+    }
+}
+
+/// A partition of blockdevs in a BlockDevMgr between those in use by
+/// upper layers and those that are not.
+pub struct BlockDevPartition<'a> {
+    pub(super) used: Vec<(DevUuid, &'a StratBlockDev)>,
+    pub(super) unused: Vec<(DevUuid, &'a StratBlockDev)>,
+}
+
+/// A summary of block sizes for a BlockDevMgr, distinguishing between used
+/// and unused.
+pub struct BlockSizeSummary {
+    pub(super) used: HashMap<BlockSizes, HashSet<DevUuid>>,
+    pub(super) unused: HashMap<BlockSizes, HashSet<DevUuid>>,
+}
+
+impl<'a> From<BlockDevPartition<'a>> for BlockSizeSummary {
+    fn from(pair: BlockDevPartition<'a>) -> BlockSizeSummary {
+        let mut used = HashMap::new();
+        for (u, bd) in pair.used {
+            used.entry(bd.blksizes())
+                .or_insert_with(HashSet::default)
+                .insert(u);
+        }
+
+        let mut unused: HashMap<BlockSizes, _> = HashMap::new();
+        for (u, bd) in pair.unused {
+            unused
+                .entry(bd.blksizes())
+                .or_insert_with(HashSet::default)
+                .insert(u);
+        }
+
+        BlockSizeSummary { used, unused }
+    }
+}
+
+impl BlockSizeSummary {
+    /// Check that, as far as is known, the current arrangement of device
+    /// block sizes will not cause untoward behavior during the lifetime of
+    /// the pool.
+    /// Returns the logical block size that will alway be used by the cap
+    /// device if this size exists.
+    pub fn validate(&self) -> StratisResult<Bytes> {
+        // It is not practically possible that all the data devices in the data
+        // tier or all the the cache devices in the cache tier will be
+        // completely unused during stratisd's normal execution. This condition
+        // is here for logical completeness and in case an unused data or cache
+        // tier is made for testing.
+        if self.used.is_empty() {
+            return if self.unused.len() > 1 {
+                let error_str = "The devices in this pool have inconsistent block sizes. This is an unpredictable situation, and could lead to umnountable file systems if the pool is extended. Consider remaking the pool using devices with consistent block sizes.".to_string();
+                Err(StratisError::Msg(error_str))
+            } else {
+                let logical_size = self
+                    .unused
+                    .keys()
+                    .map(|x| x.logical_sector_size)
+                    .next()
+                    .expect("returned early if unused was empty");
+
+                Ok(logical_size)
+            };
+        }
+
+        let largest_logical_used = self
+            .used
+            .keys()
+            .map(|x| x.logical_sector_size)
+            .max()
+            .expect("returned early if used was empty");
+
+        if self
+            .unused
+            .keys()
+            .map(|x| x.logical_sector_size)
+            .any(|s| s > largest_logical_used)
+        {
+            let error_str = format!("Some unused block devices in the pool have a logical sector size that is larger than the largest logical sector size ({}) of any of the devices that are in use. This could lead to unmountable filesystems if the pool is extended. Consider moving your data to another pool.", largest_logical_used);
+            Err(StratisError::Msg(error_str))
+        } else {
+            Ok(largest_logical_used)
+        }
     }
 }
 

--- a/src/engine/strat_engine/backstore/transaction.rs
+++ b/src/engine/strat_engine/backstore/transaction.rs
@@ -9,7 +9,7 @@ use std::{
 
 use devicemapper::Sectors;
 
-use crate::engine::strat_engine::backstore::blockdevmgr::BlkDevSegment;
+use crate::engine::strat_engine::backstore::shared::BlkDevSegment;
 
 /// This transaction data structure keeps a list of segments associated with block
 /// devices, segments from the cap device, and a map associating each cap device

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -4,13 +4,25 @@
 
 // Functions for dealing with devices.
 
-use std::fs::File;
+use std::{fs::File, os::unix::prelude::AsRawFd};
 
 use iocuddle::{Group, Ioctl, Read};
+use libc::c_int;
 
 use devicemapper::Bytes;
 
-use crate::stratis::StratisResult;
+use crate::stratis::{StratisError, StratisResult};
+
+// BLKSSZGET is actually a Read ioctl which was accidentally defined
+// using _IO. So, we must use the special _bad macro defined in nix.
+// See: https://github.com/nix-rust/nix/issues/1006
+// We have already tried and failed to use the available iocuddle functionality.
+// The same holds true for BLKPBSZGET.
+// If a new version of iocuddle were released, we could probably use the lie()
+// function to get the correct functionality. See:
+// https://github.com/stratis-storage/project/issues/533
+ioctl_read_bad!(blksszget, 0x1268, c_int);
+ioctl_read_bad!(blkpbszget, 0x127b, c_int);
 
 const BLK: Group = Group::new(0x12);
 
@@ -21,4 +33,30 @@ pub fn blkdev_size(file: &File) -> StratisResult<Bytes> {
         .ioctl(file)
         .map(|(_, res)| Bytes::from(res))
         .map_err(|e| e.into())
+}
+
+pub fn blkdev_logical_sector_size(file: &File) -> StratisResult<Bytes> {
+    let mut val = 0i32 as c_int; // util-linux uses int* as out-arg for ioctl
+    unsafe { blksszget(file.as_raw_fd(), &mut val) }.map_err(|e| {
+        StratisError::Msg(format!(
+            "Error reading logical sector size (BLKSSZGET): {}",
+            e
+        ))
+    })?;
+    // Allowed because the size should be less than u16::MAX
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(Bytes::from(val as u16))
+}
+
+pub fn blkdev_physical_sector_size(file: &File) -> StratisResult<Bytes> {
+    let mut val = 0i32 as c_int; // util-linux uses int* as out-arg for ioctl
+    unsafe { blkpbszget(file.as_raw_fd(), &mut val) }.map_err(|e| {
+        StratisError::Msg(format!(
+            "Error reading physical sector size (BLKPBSZGET): {}",
+            e
+        ))
+    })?;
+    // Allowed because the size should be less than u16::MAX
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(Bytes::from(val as u16))
 }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -418,6 +418,12 @@ impl Engine for StratEngine {
                 ));
             }
 
+            let block_size_summary = unowned_devices.blocksizes();
+            if block_size_summary.len() > 1 {
+                let err_str = "The devices specified for initializing the pool do not have uniform physcal and logical block sizes.".into();
+                return Err(StratisError::Msg(err_str));
+            }
+
             let cloned_name = name.clone();
             let cloned_enc_info = encryption_info.cloned();
 

--- a/src/engine/strat_engine/liminal/liminal.rs
+++ b/src/engine/strat_engine/liminal/liminal.rs
@@ -22,7 +22,7 @@ use crate::{
             liminal::{
                 device_info::{DeviceSet, LInfo, LLuksInfo, LStratisInfo},
                 identify::{identify_block_device, DeviceInfo, LuksInfo, StratisInfo},
-                setup::{get_bdas, get_blockdevs, get_metadata, get_pool_state},
+                setup::{get_bdas, get_blockdevs, get_metadata},
             },
             metadata::{StratisIdentifiers, BDA},
             pool::StratPool,
@@ -790,8 +790,15 @@ fn setup_pool(
         }
     };
 
-    let state = get_pool_state(encryption_info);
-    StratPool::setup(pool_uuid, datadevs, cachedevs, timestamp, &metadata, state).map_err(|err| {
+    StratPool::setup(
+        pool_uuid,
+        datadevs,
+        cachedevs,
+        timestamp,
+        &metadata,
+        encryption_info,
+    )
+    .map_err(|err| {
         StratisError::Chained(
             format!(
                 "An attempt to set up pool with UUID {} from the assembled devices failed",

--- a/src/engine/strat_engine/liminal/setup.rs
+++ b/src/engine/strat_engine/liminal/setup.rs
@@ -17,7 +17,7 @@ use devicemapper::Sectors;
 use crate::{
     engine::{
         strat_engine::{
-            backstore::{CryptHandle, StratBlockDev, UnderlyingDevice},
+            backstore::{BlockSizes, CryptHandle, StratBlockDev, UnderlyingDevice},
             device::blkdev_size,
             liminal::device_info::LStratisInfo,
             metadata::{StaticHeader, BDA},
@@ -218,6 +218,8 @@ pub fn get_blockdevs(
             },
         )?;
 
+        let blksizes = BlockSizes::read(&OpenOptions::new().read(true).open(&info.ids.devnode)?)?;
+
         let dev_uuid = bda.dev_uuid();
 
         // Locate the device in the metadata using its uuid. Return the device
@@ -261,6 +263,7 @@ pub fn get_blockdevs(
                     Some(handle) => UnderlyingDevice::Encrypted(handle),
                     None => UnderlyingDevice::Unencrypted(DevicePath::new(physical_path)?),
                 },
+                blksizes,
             )?,
         ))
     }

--- a/src/engine/strat_engine/liminal/setup.rs
+++ b/src/engine/strat_engine/liminal/setup.rs
@@ -23,7 +23,7 @@ use crate::{
             metadata::{StaticHeader, BDA},
             serde_structs::{BackstoreSave, BaseBlockDevSave, PoolSave},
         },
-        types::{ActionAvailability, BlockDevTier, DevUuid, DevicePath, PoolEncryptionInfo},
+        types::{BlockDevTier, DevUuid, DevicePath},
     },
     stratis::{StratisError, StratisResult},
 };
@@ -341,19 +341,4 @@ pub fn get_blockdevs(
     })?;
 
     Ok((datadevs, cachedevs))
-}
-
-/// Takes a set of information determined about the pool in liminal devices and
-/// determines what the state of the pool should be when it is set up.
-pub fn get_pool_state(info: Option<PoolEncryptionInfo>) -> ActionAvailability {
-    if let Some(i) = info {
-        if i.is_inconsistent() {
-            warn!("Metadata for encryption inconsistent across devices in pool; disabling mutating IPC requests for this pool");
-            ActionAvailability::NoRequests
-        } else {
-            ActionAvailability::Full
-        }
-    } else {
-        ActionAvailability::Full
-    }
 }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{collections::HashMap, path::Path, vec::Vec};
+use std::{cmp::max, collections::HashMap, path::Path, vec::Vec};
 
 use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
@@ -218,6 +218,8 @@ impl StratPool {
 
         let mut backstore =
             Backstore::setup(uuid, &metadata.backstore, datadevs, cachedevs, timestamp)?;
+        let action_avail = max(action_avail, backstore.action_availability());
+
         let pool_name = &metadata.name;
 
         let mut thinpool = ThinPool::setup(

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -857,6 +857,22 @@ impl Pool for StratPool {
                     return Err(StratisError::Msg(err_str));
                 }
 
+                let current_logical_sector_size = self
+                    .backstore
+                    .block_size_summary(BlockDevTier::Data)
+                    .expect("always exists")
+                    .validate()
+                    .expect("All operations prevented if validate() function on data tier block size sumary returns an error");
+                let data_block_size = block_size_summary
+                    .keys()
+                    .next()
+                    .expect("unowned devices is not empty")
+                    .logical_sector_size;
+                if data_block_size != current_logical_sector_size {
+                    let err_str = format!("The logical block size of the devices proposed for extending the data tier, {}, does not match the logical block size of the existing data devices, {}", data_block_size, current_logical_sector_size);
+                    return Err(StratisError::Msg(err_str));
+                }
+
                 let cached = self.cached();
 
                 // If just adding data devices, no need to suspend the pool.

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -558,6 +558,22 @@ impl Pool for StratPool {
                 return Err(StratisError::Msg(err_str));
             }
 
+            let current_logical_sector_size = self
+                .backstore
+                .block_size_summary(BlockDevTier::Data)
+                .expect("always exists for data tier")
+                .validate()
+                .expect("All operations prevented if validate() function returns an error");
+            let data_block_size = block_size_summary
+                .keys()
+                .next()
+                .expect("unowned_devices is not empty")
+                .logical_sector_size;
+            if data_block_size != current_logical_sector_size {
+                let err_str = format!("The logical block size of the devices proposed for the cache tier, {}, does not match the logical block size of the data tier, {}", data_block_size, current_logical_sector_size);
+                return Err(StratisError::Msg(err_str));
+            }
+
             self.thin_pool.suspend()?;
             let devices_result = self
                 .backstore

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -812,6 +812,22 @@ impl Pool for StratPool {
                     return Err(StratisError::Msg(err_str));
                 }
 
+                let current_logical_sector_size = self
+                    .backstore
+                    .block_size_summary(BlockDevTier::Cache)
+                    .expect("already returned if no cache tier")
+                    .validate()
+                    .expect("All devices of the cache tier must be in use, so there can only be one representative logical sector size.");
+                let cache_block_size = block_size_summary
+                    .keys()
+                    .next()
+                    .expect("unowned devices is not empty")
+                    .logical_sector_size;
+                if cache_block_size != current_logical_sector_size {
+                    let err_str = format!("The logical block size of the devices proposed for extending the cache tier, {}, does not match the logical block size of the existing cache devices, {}", cache_block_size, current_logical_sector_size);
+                    return Err(StratisError::Msg(err_str));
+                }
+
                 self.thin_pool.suspend()?;
                 let bdev_info_res = self.backstore.add_cachedevs(pool_uuid, unowned_devices);
                 self.thin_pool.resume()?;

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -552,6 +552,12 @@ impl Pool for StratPool {
                 ));
             }
 
+            let block_size_summary = unowned_devices.blocksizes();
+            if block_size_summary.len() > 1 {
+                let err_str = "The devices specified for the cache tier do not have uniform physcal and logical block sizes.".into();
+                return Err(StratisError::Msg(err_str));
+            }
+
             self.thin_pool.suspend()?;
             let devices_result = self
                 .backstore
@@ -784,6 +790,12 @@ impl Pool for StratPool {
                     return Ok((SetCreateAction::new(vec![]), None));
                 }
 
+                let block_size_summary = unowned_devices.blocksizes();
+                if block_size_summary.len() > 1 {
+                    let err_str = "The devices specified to be added to the cache tier do not have uniform physcal and logical block sizes.".into();
+                    return Err(StratisError::Msg(err_str));
+                }
+
                 self.thin_pool.suspend()?;
                 let bdev_info_res = self.backstore.add_cachedevs(pool_uuid, unowned_devices);
                 self.thin_pool.resume()?;
@@ -805,6 +817,12 @@ impl Pool for StratPool {
 
                 if unowned_devices.is_empty() {
                     return Ok((SetCreateAction::new(vec![]), None));
+                }
+
+                let block_size_summary = unowned_devices.blocksizes();
+                if block_size_summary.len() > 1 {
+                    let err_str = "The devices specified to be added to the data tier do not have uniform physcal and logical block sizes.".into();
+                    return Err(StratisError::Msg(err_str));
                 }
 
                 let cached = self.cached();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "min")]
-#[cfg_attr(feature = "dbus_enabled", allow(dead_code))]
 #[macro_use]
 extern crate nix;
 


### PR DESCRIPTION
Related #2880

* Add in_use detection to individual block devices. (1)A block devices is considered in use if the space that is allocated from it exceeds that allocated for Stratis metadata.
* Add an AllocatedAbove struct to tidy up management of segments allocated to the data tier or cache tier from their block devices.
* Assert an invariant that blockdev is considered to be in use by criterion (1) exactly when it is considered in use because it is included in the AllocatedAbove data structure.
* Read BLKSSZGET and BLKPBSZGET ioctls along with other device information when examining devices.
* Calculate whether an existing pool should have reduced ActionAvailability. If the data cap device could be extended so that its logical block size could change, then ActionAvailability is set to no actions. There is no check on the cache tier; if the pool has a cache tier and it is working, then the situation has to be assumed to be correct.
* Require identical block sizes for devices being newly added to either the cache or the data tier.
* Do not allow initializing a cache where the logical block size of the resulting cache would differ from that of the data tier.
* Require the logical block size of the devices to be added to the cache or data tier to match the current logical block size.
* When creating a new pool, require block sizes to match.