### PR TITLE
Fix double-box error

### DIFF
--- a/src/engine/strat_engine/backstore/crypt/mod.rs
+++ b/src/engine/strat_engine/backstore/crypt/mod.rs
@@ -208,7 +208,7 @@ mod tests {
 
             const WINDOW_SIZE: usize = 1024 * 1024;
             let mut devicenode = OpenOptions::new().write(true).open(logical_path)?;
-            let mut random_buffer = Box::new(vec![0; WINDOW_SIZE].into_boxed_slice());
+            let mut random_buffer = vec![0; WINDOW_SIZE].into_boxed_slice();
             File::open("/dev/urandom")?.read_exact(&mut random_buffer)?;
             devicenode.write_all(&random_buffer)?;
             std::mem::drop(devicenode);


### PR DESCRIPTION
Related to #3157

Looks like this got introduced with the most recent round of clippy revisions. Because it's in the test code, type checks didn't catch this.