### PR TITLE
Use timestamp_opt instead of soon to be deprecated timestamp method

### DIFF
--- a/src/engine/sim_engine/blockdev.rs
+++ b/src/engine/sim_engine/blockdev.rs
@@ -4,13 +4,14 @@
 
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
 
 use devicemapper::{Bytes, Sectors, IEC};
 
 use crate::engine::{
     engine::BlockDev,
+    shared::now_to_timestamp,
     types::{DevUuid, EncryptionInfo, KeyDescription},
 };
 
@@ -20,7 +21,7 @@ pub struct SimDev {
     devnode: PathBuf,
     user_info: Option<String>,
     hardware_info: Option<String>,
-    initialization_time: u64,
+    initialization_time: DateTime<Utc>,
     encryption_info: Option<EncryptionInfo>,
 }
 
@@ -49,7 +50,7 @@ impl BlockDev for SimDev {
     }
 
     fn initialization_time(&self) -> DateTime<Utc> {
-        Utc.timestamp(self.initialization_time as i64, 0)
+        self.initialization_time
     }
 
     fn size(&self) -> Sectors {
@@ -74,7 +75,7 @@ impl SimDev {
                 devnode: devnode.to_owned(),
                 user_info: None,
                 hardware_info: None,
-                initialization_time: Utc::now().timestamp() as u64,
+                initialization_time: now_to_timestamp(),
                 encryption_info: encryption_info.cloned(),
             },
         )

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -10,7 +10,7 @@ use std::{
     path::Path,
 };
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 
 use devicemapper::{Device, Sectors};
@@ -508,9 +508,7 @@ impl BlockDev for StratBlockDev {
     }
 
     fn initialization_time(&self) -> DateTime<Utc> {
-        // This cast will result in an incorrect, negative value starting in
-        // the year 292,277,026,596. :-)
-        Utc.timestamp(self.bda.initialization_time() as i64, 0)
+        self.bda.initialization_time()
     }
 
     fn size(&self) -> Sectors {

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -529,7 +529,7 @@ pub fn initialize_devices(
             StratisIdentifiers::new(pool_uuid, dev_uuid),
             mda_data_size,
             data_size,
-            Utc::now().timestamp() as u64,
+            Utc::now(),
         );
 
         bda.initialize(&mut f)?;

--- a/src/engine/strat_engine/metadata/bda.rs
+++ b/src/engine/strat_engine/metadata/bda.rs
@@ -33,7 +33,7 @@ impl Default for BDA {
             StratisIdentifiers::new(PoolUuid::nil(), DevUuid::nil()),
             MDADataSize::default(),
             BlockdevSize::default(),
-            0,
+            DateTime::default(),
         )
     }
 }
@@ -43,7 +43,7 @@ impl BDA {
         identifiers: StratisIdentifiers,
         mda_data_size: MDADataSize,
         blkdev_size: BlockdevSize,
-        initialization_time: u64,
+        initialization_time: DateTime<Utc>,
     ) -> BDA {
         let header =
             StaticHeader::new(identifiers, mda_data_size, blkdev_size, initialization_time);
@@ -140,7 +140,7 @@ impl BDA {
     }
 
     /// Timestamp when the device was initialized.
-    pub fn initialization_time(&self) -> u64 {
+    pub fn initialization_time(&self) -> DateTime<Utc> {
         self.header.initialization_time
     }
 }
@@ -170,7 +170,7 @@ mod tests {
                 sh.identifiers,
                 sh.mda_size.region_size().data_size(),
                 sh.blkdev_size,
-                Utc::now().timestamp() as u64,
+                Utc::now(),
             );
             bda.initialize(&mut buf).unwrap();
             let read_results = StaticHeader::read_sigblocks(&mut buf);
@@ -201,7 +201,7 @@ mod tests {
             sh.identifiers,
             sh.mda_size.region_size().data_size(),
             sh.blkdev_size,
-            Utc::now().timestamp() as u64,
+            Utc::now(),
         );
         bda.initialize(&mut buf).unwrap();
 
@@ -251,7 +251,7 @@ mod tests {
                 sh.identifiers,
                 sh.mda_size.region_size().data_size(),
                 sh.blkdev_size,
-                Utc::now().timestamp() as u64,
+                Utc::now(),
             );
             bda.initialize(&mut buf).unwrap();
             let current_time = Utc::now();

--- a/src/engine/strat_engine/metadata/mda.rs
+++ b/src/engine/strat_engine/metadata/mda.rs
@@ -325,15 +325,13 @@ impl MDAHeader {
         match LittleEndian::read_u64(&buf[8..16]) {
             0 => None,
             used => {
-                let secs = LittleEndian::read_u64(&buf[16..24]);
-
-                // Signed cast is safe, highest order bit of each value
-                // read is guaranteed to be 0.
-                assert!(secs <= std::i64::MAX as u64);
+                let secs: i64 = LittleEndian::read_u64(&buf[16..24])
+                    .try_into()
+                    .expect("highest order bit guaranteed 0");
 
                 Some(MDAHeader {
                     used: MetaDataSize::new(Bytes::from(used)),
-                    last_updated: Utc.timestamp(secs as i64, LittleEndian::read_u32(&buf[24..28])),
+                    last_updated: Utc.timestamp(secs, LittleEndian::read_u32(&buf[24..28])),
                     data_crc: LittleEndian::read_u32(&buf[4..8]),
                 })
             }

--- a/src/engine/strat_engine/metadata/mda.rs
+++ b/src/engine/strat_engine/metadata/mda.rs
@@ -8,15 +8,18 @@ use std::{
 };
 
 use byteorder::{ByteOrder, LittleEndian};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use crc::{Crc, CRC_32_ISCSI};
 
 use devicemapper::Bytes;
 
 use crate::{
-    engine::strat_engine::{
-        metadata::sizes::{mda_size, MDADataSize, MDARegionSize, MDASize},
-        writing::SyncAll,
+    engine::{
+        shared::unsigned_to_timestamp,
+        strat_engine::{
+            metadata::sizes::{mda_size, MDADataSize, MDARegionSize, MDASize},
+            writing::SyncAll,
+        },
     },
     stratis::{StratisError, StratisResult},
 };
@@ -310,7 +313,7 @@ pub struct MDAHeader {
 impl Default for MDAHeader {
     fn default() -> MDAHeader {
         MDAHeader {
-            last_updated: Utc.timestamp(0, 0),
+            last_updated: DateTime::default(),
             used: MetaDataSize::new(Bytes(0)),
             data_crc: 0,
         }
@@ -321,20 +324,20 @@ impl MDAHeader {
     /// Parse a valid MDAHeader from buf.
     /// If the amount used by the variable length metadata is 0, return None,
     /// as this means that no variable length metadata has been written.
-    fn parse_buf(buf: &[u8; mda_size::_MDA_REGION_HDR_SIZE]) -> Option<MDAHeader> {
+    fn parse_buf(buf: &[u8; mda_size::_MDA_REGION_HDR_SIZE]) -> Option<StratisResult<MDAHeader>> {
         match LittleEndian::read_u64(&buf[8..16]) {
             0 => None,
-            used => {
-                let secs: i64 = LittleEndian::read_u64(&buf[16..24])
-                    .try_into()
-                    .expect("highest order bit guaranteed 0");
-
-                Some(MDAHeader {
+            used => Some(
+                unsigned_to_timestamp(
+                    LittleEndian::read_u64(&buf[16..24]),
+                    LittleEndian::read_u32(&buf[24..28]),
+                )
+                .map(|last_updated| MDAHeader {
                     used: MetaDataSize::new(Bytes::from(used)),
-                    last_updated: Utc.timestamp(secs, LittleEndian::read_u32(&buf[24..28])),
+                    last_updated,
                     data_crc: LittleEndian::read_u32(&buf[4..8]),
-                })
-            }
+                }),
+            ),
         }
     }
 
@@ -365,7 +368,7 @@ impl MDAHeader {
             )));
         }
 
-        Ok(MDAHeader::parse_buf(buf))
+        MDAHeader::parse_buf(buf).transpose()
     }
 
     fn to_buf(&self) -> [u8; mda_size::_MDA_REGION_HDR_SIZE] {
@@ -414,7 +417,7 @@ impl MDAHeader {
 mod tests {
     use std::io::Cursor;
 
-    use chrono::Utc;
+    use chrono::{TimeZone, Utc};
     use proptest::{collection, num};
 
     use super::*;
@@ -472,7 +475,8 @@ mod tests {
                       nsec in 0..UTC_TIMESTAMP_NSECS_BOUND) {
 
             let header = MDAHeader {
-                last_updated: Utc.timestamp(sec, nsec),
+                // Argument values are correct by construction
+                last_updated: Utc.timestamp_opt(sec, nsec).unwrap(),
                 used: MetaDataSize::new(Bytes::from(data.len())),
                 data_crc: CASTAGNOLI.checksum(data),
             };

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -9,7 +9,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use data_encoding::BASE32_NOPAD;
 use retry::{delay::Fixed, retry_with_index};
 use serde_json::{Map, Value};
@@ -27,6 +27,7 @@ use nix::{
 use crate::{
     engine::{
         engine::{DumpState, Filesystem, StateDiff},
+        shared::unsigned_to_timestamp,
         strat_engine::{
             cmd::{create_fs, set_uuid, xfs_growfs},
             devlinks,
@@ -113,6 +114,8 @@ impl StratFilesystem {
         fssave: &FilesystemSave,
     ) -> StratisResult<StratFilesystem> {
         let (dm_name, dm_uuid) = format_thin_ids(pool_uuid, ThinRole::Filesystem(fssave.uuid));
+        let created = unsigned_to_timestamp(fssave.created, 0)?;
+
         let thin_dev = ThinDev::setup(
             get_dm(),
             &dm_name,
@@ -124,7 +127,7 @@ impl StratFilesystem {
         Ok(StratFilesystem {
             used: init_used(&thin_dev),
             thin_dev,
-            created: Utc.timestamp(fssave.created as i64, 0),
+            created,
         })
     }
 


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/538

Use timestamp_opt() instead of timestamp() to construct new timestamps from component parts. timestamp() is deprecated in chrono 0.4.23 which we expect to begin depending on when we make our upcoming release. timestamp() just panicked when it was unable to construct a timestamp from the arguments. timestamp_opt() returns a non-standard error result in a principled way; that error result is now handled by the calling code. Also, store the initialization time as a DateTime in the StaticHeader struct.