### PR TITLE
Prohibit certain block size combinations when creating a new pool or adding devices to an existing pool 

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -15,11 +15,8 @@ use crate::{
     engine::{
         strat_engine::{
             backstore::{
-                blockdev::StratBlockDev,
-                blockdevmgr::{map_to_dm, BlockDevMgr},
-                cache_tier::CacheTier,
-                data_tier::DataTier,
-                devices::UnownedDevices,
+                blockdev::StratBlockDev, blockdevmgr::BlockDevMgr, cache_tier::CacheTier,
+                data_tier::DataTier, devices::UnownedDevices, shared::map_to_dm,
                 transaction::RequestTransaction,
             },
             dm::get_dm,

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -736,6 +736,12 @@ impl Backstore {
             warn!("Disabling pool changes for this pool: {}", err);
             ActionAvailability::NoPoolChanges
         } else if let Some(Err(err)) = cache_tier_bs_summary.map(|ct| ct.validate()) {
+            // NOTE: This condition should be impossible. Since the cache is
+            // always expanded to include all its devices, and an attempt to add
+            // more devices than the cache can use causes the devices to be
+            // rejected, there should be no unused devices in a cache. If, for
+            // some reason this condition fails, though, NoPoolChanges would
+            // be the correct state to put the pool in.
             warn!("Disabling pool changes for this pool: {}", err);
             ActionAvailability::NoPoolChanges
         } else {

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -783,7 +783,13 @@ mod tests {
                 _ => panic!("impossible; see first assertion"),
             }
         );
-        assert!(backstore.next <= backstore.size())
+        assert!(backstore.next <= backstore.size());
+
+        backstore.data_tier.invariant();
+
+        if let Some(cache_tier) = &backstore.cache_tier {
+            cache_tier.invariant()
+        }
     }
 
     fn get_devices(paths: &[&Path]) -> StratisResult<UnownedDevices> {

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -529,6 +529,10 @@ impl<'a> Into<Value> for &'a StratBlockDev {
         if let Some(new_size) = self.new_size {
             map.insert("new_size".to_string(), Value::from(new_size.to_string()));
         }
+        map.insert(
+            "blksizes".to_string(),
+            Value::from(self.blksizes.to_string()),
+        );
         json
     }
 }

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -533,6 +533,7 @@ impl<'a> Into<Value> for &'a StratBlockDev {
             "blksizes".to_string(),
             Value::from(self.blksizes.to_string()),
         );
+        map.insert("in_use".to_string(), Value::from(self.in_use()));
         json
     }
 }

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -22,6 +22,7 @@ use crate::{
         strat_engine::{
             backstore::{
                 crypt::CryptHandle,
+                devices::BlockSizes,
                 range_alloc::{PerDevSegments, RangeAllocator},
                 transaction::RequestTransaction,
             },
@@ -86,6 +87,7 @@ pub struct StratBlockDev {
     hardware_info: Option<String>,
     underlying_device: UnderlyingDevice,
     new_size: Option<Sectors>,
+    blksizes: BlockSizes,
 }
 
 impl StratBlockDev {
@@ -117,6 +119,7 @@ impl StratBlockDev {
         user_info: Option<String>,
         hardware_info: Option<String>,
         underlying_device: UnderlyingDevice,
+        blksizes: BlockSizes,
     ) -> BDAResult<StratBlockDev> {
         let mut segments = vec![(Sectors(0), bda.extended_size().sectors())];
         segments.extend(other_segments);
@@ -134,6 +137,7 @@ impl StratBlockDev {
             hardware_info,
             underlying_device,
             new_size: None,
+            blksizes,
         })
     }
 
@@ -285,6 +289,11 @@ impl StratBlockDev {
         self.underlying_device
             .crypt_handle()
             .map(|ch| ch.pool_name())
+    }
+
+    /// Block size information
+    pub fn blksizes(&self) -> BlockSizes {
+        self.blksizes
     }
 
     /// Bind encrypted device using the given clevis configuration.

--- a/src/engine/strat_engine/backstore/blockdev.rs
+++ b/src/engine/strat_engine/backstore/blockdev.rs
@@ -247,6 +247,12 @@ impl StratBlockDev {
         self.bda.max_data_size()
     }
 
+    /// Whether or not the blockdev is in use by upper layers. It is if the
+    /// sum of the blocks used exceeds the Stratis metadata size.
+    pub fn in_use(&self) -> bool {
+        self.used.used() > self.metadata_size().sectors()
+    }
+
     /// Set the user info on this blockdev.
     /// The user_info may be None, which unsets user info.
     /// Returns true if the user info was changed, otherwise false.

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -16,7 +16,7 @@ use crate::{
                 blockdev::StratBlockDev,
                 blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment},
+                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment, BlockDevPartition},
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
             types::BDARecordResult,
@@ -223,6 +223,14 @@ impl CacheTier {
         self.block_mgr
             .get_mut_blockdev_by_uuid(uuid)
             .map(|bd| (BlockDevTier::Cache, bd))
+    }
+
+    /// Return the partition of the block devs that are in use and those that
+    /// are not.
+    pub fn partition_cache_by_use(&self) -> BlockDevPartition<'_> {
+        let blockdevs = self.block_mgr.blockdevs();
+        let (used, unused) = blockdevs.iter().partition(|(_, bd)| bd.in_use());
+        BlockDevPartition { used, unused }
     }
 
     #[cfg(test)]

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -11,9 +11,9 @@ use crate::{
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,
-                blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{coalesce_blkdevsegs, metadata_to_segment},
+                shared::{coalesce_blkdevsegs, metadata_to_segment, BlkDevSegment},
             },
             serde_structs::{BaseDevSave, BlockDevSave, CacheTierSave, Recordable},
             types::BDARecordResult,

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -35,13 +35,13 @@ const MAX_CACHE_SIZE: Sectors = Sectors(32 * IEC::Ti / SECTOR_SIZE as u64);
 #[derive(Debug)]
 pub struct CacheTier {
     /// Manages the individual block devices
-    pub block_mgr: BlockDevMgr,
+    pub(super) block_mgr: BlockDevMgr,
     /// The list of segments granted by block_mgr and used by the cache
     /// device.
-    pub cache_segments: AllocatedAbove,
+    pub(super) cache_segments: AllocatedAbove,
     /// The list of segments granted by block_mgr and used by the metadata
     /// device.
-    pub meta_segments: AllocatedAbove,
+    pub(super) meta_segments: AllocatedAbove,
 }
 
 impl CacheTier {

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -4,6 +4,9 @@
 
 // Code to handle the backing store of a pool.
 
+#[cfg(test)]
+use std::collections::HashSet;
+
 use devicemapper::{Sectors, IEC, SECTOR_SIZE};
 
 use crate::{
@@ -221,6 +224,24 @@ impl CacheTier {
             .get_mut_blockdev_by_uuid(uuid)
             .map(|bd| (BlockDevTier::Cache, bd))
     }
+
+    #[cfg(test)]
+    pub fn invariant(&self) {
+        let allocated_uuids = self
+            .cache_segments
+            .uuids()
+            .union(&self.meta_segments.uuids())
+            .cloned()
+            .collect::<HashSet<_>>();
+        let in_use_uuids = self
+            .block_mgr
+            .blockdevs()
+            .iter()
+            .filter(|(_, bd)| bd.in_use())
+            .map(|(u, _)| *u)
+            .collect::<HashSet<_>>();
+        assert_eq!(allocated_uuids, in_use_uuids);
+    }
 }
 
 impl Recordable<CacheTierSave> for CacheTier {
@@ -280,6 +301,7 @@ mod tests {
         .unwrap();
 
         let mut cache_tier = CacheTier::new(mgr).unwrap();
+        cache_tier.invariant();
 
         // A cache tier w/ some devices and everything promptly allocated to
         // the tier.
@@ -293,6 +315,7 @@ mod tests {
         assert_eq!(size - metadata_size, allocated + cache_metadata_size);
 
         let (_, (cache, meta)) = cache_tier.add(pool_name, pool_uuid, devices2).unwrap();
+        cache_tier.invariant();
         // TODO: Ultimately, it should be the case that meta can be true.
         assert!(cache);
         assert!(!meta);

--- a/src/engine/strat_engine/backstore/cache_tier.rs
+++ b/src/engine/strat_engine/backstore/cache_tier.rs
@@ -241,6 +241,15 @@ impl CacheTier {
             .map(|(u, _)| *u)
             .collect::<HashSet<_>>();
         assert_eq!(allocated_uuids, in_use_uuids);
+
+        let uuids = self
+            .block_mgr
+            .blockdevs()
+            .iter()
+            .map(|(u, _)| *u)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(uuids, in_use_uuids);
     }
 }
 

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -11,9 +11,9 @@ use crate::{
         strat_engine::{
             backstore::{
                 blockdev::StratBlockDev,
-                blockdevmgr::{BlkDevSegment, BlockDevMgr},
+                blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{coalesce_blkdevsegs, metadata_to_segment},
+                shared::{coalesce_blkdevsegs, metadata_to_segment, BlkDevSegment},
                 transaction::RequestTransaction,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -4,6 +4,9 @@
 
 // Code to handle the backing store of a pool.
 
+#[cfg(test)]
+use std::collections::HashSet;
+
 use devicemapper::Sectors;
 
 use crate::{
@@ -161,6 +164,19 @@ impl DataTier {
     pub fn grow(&mut self, dev: DevUuid) -> StratisResult<bool> {
         self.block_mgr.grow(dev)
     }
+
+    #[cfg(test)]
+    pub fn invariant(&self) {
+        let allocated_uuids = self.segments.uuids();
+        let in_use_uuids = self
+            .block_mgr
+            .blockdevs()
+            .iter()
+            .filter(|(_, bd)| bd.in_use())
+            .map(|(u, _)| *u)
+            .collect::<HashSet<_>>();
+        assert_eq!(allocated_uuids, in_use_uuids);
+    }
 }
 
 impl Recordable<DataTierSave> for DataTier {
@@ -220,6 +236,7 @@ mod tests {
         .unwrap();
 
         let mut data_tier = DataTier::new(mgr);
+        data_tier.invariant();
 
         // A data_tier w/ some devices but nothing allocated
         let mut size = data_tier.size();
@@ -234,6 +251,7 @@ mod tests {
 
         let transaction = data_tier.alloc_request(&[request_amount]).unwrap().unwrap();
         data_tier.alloc_commit(transaction).unwrap();
+        data_tier.invariant();
 
         // A data tier w/ some amount allocated
         assert!(data_tier.allocated() >= request_amount);
@@ -241,6 +259,7 @@ mod tests {
         allocated = data_tier.allocated();
 
         data_tier.add(pool_name, pool_uuid, devices2).unwrap();
+        data_tier.invariant();
 
         // A data tier w/ additional blockdevs added
         assert!(data_tier.size() > size);
@@ -254,6 +273,7 @@ mod tests {
             .unwrap()
             .unwrap();
         data_tier.alloc_commit(transaction).unwrap();
+        data_tier.invariant();
 
         assert!(data_tier.allocated() >= request_amount + last_request_amount);
         assert_eq!(data_tier.size(), size);

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -16,7 +16,7 @@ use crate::{
                 blockdev::StratBlockDev,
                 blockdevmgr::BlockDevMgr,
                 devices::UnownedDevices,
-                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment},
+                shared::{metadata_to_segment, AllocatedAbove, BlkDevSegment, BlockDevPartition},
                 transaction::RequestTransaction,
             },
             serde_structs::{BaseDevSave, BlockDevSave, DataTierSave, Recordable},
@@ -163,6 +163,14 @@ impl DataTier {
 
     pub fn grow(&mut self, dev: DevUuid) -> StratisResult<bool> {
         self.block_mgr.grow(dev)
+    }
+
+    /// Return the partition of the block devs that are in use and those
+    /// that are not.
+    pub fn partition_by_use(&self) -> BlockDevPartition<'_> {
+        let blockdevs = self.block_mgr.blockdevs();
+        let (used, unused) = blockdevs.iter().partition(|(_, bd)| bd.in_use());
+        BlockDevPartition { used, unused }
     }
 
     #[cfg(test)]

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -28,9 +28,9 @@ use crate::{
 #[derive(Debug)]
 pub struct DataTier {
     /// Manages the individual block devices
-    pub block_mgr: BlockDevMgr,
+    pub(super) block_mgr: BlockDevMgr,
     /// The list of segments granted by block_mgr and used by dm_device
-    pub segments: AllocatedAbove,
+    pub(super) segments: AllocatedAbove,
 }
 
 impl DataTier {

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::OpenOptions,
+    fs::{File, OpenOptions},
     path::{Path, PathBuf},
     sync::Mutex,
 };
@@ -25,7 +25,7 @@ use crate::{
                 blockdev::{StratBlockDev, UnderlyingDevice},
                 crypt::{CryptHandle, CryptInitializer},
             },
-            device::blkdev_size,
+            device::{blkdev_logical_sector_size, blkdev_physical_sector_size, blkdev_size},
             metadata::{
                 device_identifiers, disown_device, BlockdevSize, MDADataSize, StratisIdentifiers,
                 BDA,
@@ -201,6 +201,7 @@ fn dev_info(devnode: &DevicePath) -> StratisResult<(DeviceInfo, Option<StratisId
 
             let mut f = OpenOptions::new().read(true).write(true).open(&**devnode)?;
             let dev_size = blkdev_size(&f)?;
+            let blksizes = BlockSizes::read(&f)?;
 
             let stratis_identifiers = device_identifiers(&mut f).map_err(|err| {
                 let error_message = format!(
@@ -225,6 +226,7 @@ fn dev_info(devnode: &DevicePath) -> StratisResult<(DeviceInfo, Option<StratisId
                     devnode: devnode.to_path_buf(),
                     id_wwn: hw_id,
                     size: dev_size,
+                    blksizes,
                 },
                 stratis_identifiers,
             ))
@@ -248,6 +250,25 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct BlockSizes {
+    #[allow(dead_code)]
+    physical_sector_size: Bytes,
+    #[allow(dead_code)]
+    logical_sector_size: Bytes,
+}
+
+impl BlockSizes {
+    pub fn read(f: &File) -> StratisResult<BlockSizes> {
+        let physical_sector_size = blkdev_physical_sector_size(f)?;
+        let logical_sector_size = blkdev_logical_sector_size(f)?;
+        Ok(BlockSizes {
+            physical_sector_size,
+            logical_sector_size,
+        })
+    }
+}
+
 /// A miscellaneous grab bag of useful information required to decide whether
 /// a device should be allowed to be initialized by Stratis or to be used
 /// when initializing a device.
@@ -262,6 +283,8 @@ pub struct DeviceInfo {
     pub id_wwn: Option<StratisResult<String>>,
     /// The total size of the device
     pub size: Bytes,
+    /// Block size information
+    pub blksizes: BlockSizes,
 }
 
 /// Devices that have all been identified as Stratis devices.
@@ -506,6 +529,7 @@ pub fn initialize_devices(
         dev_uuid: DevUuid,
         sizes: (MDADataSize, BlockdevSize),
         id_wwn: &Option<StratisResult<String>>,
+        blksizes: BlockSizes,
     ) -> StratisResult<StratBlockDev> {
         let (mda_data_size, data_size) = sizes;
         let mut f = OpenOptions::new()
@@ -536,7 +560,8 @@ pub fn initialize_devices(
 
         bda.initialize(&mut f)?;
 
-        StratBlockDev::new(devno, bda, &[], None, hw_id, underlying_device).map_err(|(e, _)| e)
+        StratBlockDev::new(devno, bda, &[], None, hw_id, underlying_device, blksizes)
+            .map_err(|(e, _)| e)
     }
 
     /// Clean up an encrypted device after initialization failure.
@@ -644,6 +669,7 @@ pub fn initialize_devices(
                     dev_uuid,
                     (mda_data_size, BlockdevSize::new(blockdev_size)),
                     &dev_info.id_wwn,
+                    dev_info.blksizes,
                 );
                 if let Err(err) = blockdev {
                     Err(clean_up_encrypted(&mut handle_clone, err))
@@ -659,6 +685,7 @@ pub fn initialize_devices(
                     dev_uuid,
                     (mda_data_size, BlockdevSize::new(blockdev_size)),
                     &dev_info.id_wwn,
+                    dev_info.blksizes,
                 );
                 if let Err(err) = blockdev {
                     Err(clean_up_unencrypted(physical_path, err))
@@ -1040,6 +1067,7 @@ mod tests {
                 devno: old_info.devno,
                 id_wwn: None,
                 size: old_info.size,
+                blksizes: old_info.blksizes,
             };
 
             dev_infos.push(new_info);

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -252,7 +252,6 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BlockSizes {
-    #[allow(dead_code)]
     pub(super) physical_sector_size: Bytes,
     pub(super) logical_sector_size: Bytes,
 }
@@ -465,6 +464,18 @@ impl UnownedDevices {
 
     pub fn unpack(self) -> Vec<DeviceInfo> {
         self.inner
+    }
+
+    /// Return a map of block sizes to device infos
+    pub fn blocksizes(&self) -> HashMap<BlockSizes, Vec<&DeviceInfo>> {
+        let mut block_size_groups = HashMap::new();
+        for info in self.inner.iter() {
+            block_size_groups
+                .entry(info.blksizes)
+                .or_insert_with(Vec::new)
+                .push(info);
+        }
+        block_size_groups
     }
 }
 

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     fs::{File, OpenOptions},
     path::{Path, PathBuf},
     sync::Mutex,
@@ -264,6 +265,16 @@ impl BlockSizes {
             physical_sector_size,
             logical_sector_size,
         })
+    }
+}
+
+impl fmt::Display for BlockSizes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "BLKSSSZGET: {}, BLKPBSZGET: {}",
+            self.logical_sector_size, self.physical_sector_size
+        )
     }
 }
 

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -252,8 +252,8 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BlockSizes {
-    pub(super) physical_sector_size: Bytes,
-    pub(super) logical_sector_size: Bytes,
+    pub physical_sector_size: Bytes,
+    pub logical_sector_size: Bytes,
 }
 
 impl BlockSizes {

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -250,12 +250,11 @@ fn check_dev(device_info: &DeviceInfo) -> StratisResult<()> {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BlockSizes {
     #[allow(dead_code)]
-    physical_sector_size: Bytes,
-    #[allow(dead_code)]
-    logical_sector_size: Bytes,
+    pub(super) physical_sector_size: Bytes,
+    pub(super) logical_sector_size: Bytes,
 }
 
 impl BlockSizes {

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -21,5 +21,8 @@ pub use self::{
         crypt_metadata_size, set_up_crypt_logging, CryptActivationHandle, CryptHandle,
         CryptMetadataHandle, CLEVIS_TANG_TRUST_URL,
     },
-    devices::{find_stratis_devs_by_uuid, initialize_devices, ProcessedPathInfos, UnownedDevices},
+    devices::{
+        find_stratis_devs_by_uuid, initialize_devices, BlockSizes, ProcessedPathInfos,
+        UnownedDevices,
+    },
 };

--- a/src/engine/strat_engine/backstore/shared.rs
+++ b/src/engine/strat_engine/backstore/shared.rs
@@ -4,6 +4,9 @@
 
 // Methods that are shared by the cache tier and the data tier.
 
+#[cfg(test)]
+use std::collections::HashSet;
+
 use std::collections::HashMap;
 
 use devicemapper::{Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine};
@@ -130,6 +133,15 @@ impl AllocatedAbove {
                 collect
             },
         );
+    }
+
+    /// A set of UUIDs of every device that is allocated from.
+    #[cfg(test)]
+    pub fn uuids(&self) -> HashSet<DevUuid> {
+        self.inner
+            .iter()
+            .map(|seg| seg.uuid)
+            .collect::<HashSet<DevUuid>>()
     }
 }
 

--- a/src/engine/strat_engine/backstore/shared.rs
+++ b/src/engine/strat_engine/backstore/shared.rs
@@ -4,16 +4,16 @@
 
 // Methods that are shared by the cache tier and the data tier.
 
-#[cfg(test)]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use std::collections::HashMap;
-
-use devicemapper::{Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine};
+use devicemapper::{Bytes, Device, LinearDevTargetParams, LinearTargetParams, Sectors, TargetLine};
 
 use crate::{
     engine::{
-        strat_engine::serde_structs::{BaseDevSave, Recordable},
+        strat_engine::{
+            backstore::{blockdev::StratBlockDev, devices::BlockSizes},
+            serde_structs::{BaseDevSave, Recordable},
+        },
         types::DevUuid,
     },
     stratis::{StratisError, StratisResult},
@@ -142,6 +142,90 @@ impl AllocatedAbove {
             .iter()
             .map(|seg| seg.uuid)
             .collect::<HashSet<DevUuid>>()
+    }
+}
+
+/// A partition of blockdevs in a BlockDevMgr between those in use by
+/// upper layers and those that are not.
+pub struct BlockDevPartition<'a> {
+    pub(super) used: Vec<(DevUuid, &'a StratBlockDev)>,
+    pub(super) unused: Vec<(DevUuid, &'a StratBlockDev)>,
+}
+
+/// A summary of block sizes for a BlockDevMgr, distinguishing between used
+/// and unused.
+pub struct BlockSizeSummary {
+    pub(super) used: HashMap<BlockSizes, HashSet<DevUuid>>,
+    pub(super) unused: HashMap<BlockSizes, HashSet<DevUuid>>,
+}
+
+impl<'a> From<BlockDevPartition<'a>> for BlockSizeSummary {
+    fn from(pair: BlockDevPartition<'a>) -> BlockSizeSummary {
+        let mut used = HashMap::new();
+        for (u, bd) in pair.used {
+            used.entry(bd.blksizes())
+                .or_insert_with(HashSet::default)
+                .insert(u);
+        }
+
+        let mut unused: HashMap<BlockSizes, _> = HashMap::new();
+        for (u, bd) in pair.unused {
+            unused
+                .entry(bd.blksizes())
+                .or_insert_with(HashSet::default)
+                .insert(u);
+        }
+
+        BlockSizeSummary { used, unused }
+    }
+}
+
+impl BlockSizeSummary {
+    /// Check that, as far as is known, the current arrangement of device
+    /// block sizes will not cause untoward behavior during the lifetime of
+    /// the pool.
+    /// Returns the logical block size that will alway be used by the cap
+    /// device if this size exists.
+    pub fn validate(&self) -> StratisResult<Bytes> {
+        // It is not practically possible that all the data devices in the data
+        // tier or all the the cache devices in the cache tier will be
+        // completely unused during stratisd's normal execution. This condition
+        // is here for logical completeness and in case an unused data or cache
+        // tier is made for testing.
+        if self.used.is_empty() {
+            return if self.unused.len() > 1 {
+                let error_str = "The devices in this pool have inconsistent block sizes. This is an unpredictable situation, and could lead to umnountable file systems if the pool is extended. Consider remaking the pool using devices with consistent block sizes.".to_string();
+                Err(StratisError::Msg(error_str))
+            } else {
+                let logical_size = self
+                    .unused
+                    .keys()
+                    .map(|x| x.logical_sector_size)
+                    .next()
+                    .expect("returned early if unused was empty");
+
+                Ok(logical_size)
+            };
+        }
+
+        let largest_logical_used = self
+            .used
+            .keys()
+            .map(|x| x.logical_sector_size)
+            .max()
+            .expect("returned early if used was empty");
+
+        if self
+            .unused
+            .keys()
+            .map(|x| x.logical_sector_size)
+            .any(|s| s > largest_logical_used)
+        {
+            let error_str = format!("Some unused block devices in the pool have a logical sector size that is larger than the largest logical sector size ({}) of any of the devices that are in use. This could lead to unmountable filesystems if the pool is extended. Consider moving your data to another pool.", largest_logical_used);
+            Err(StratisError::Msg(error_str))
+        } else {
+            Ok(largest_logical_used)
+        }
     }
 }
 

--- a/src/engine/strat_engine/backstore/transaction.rs
+++ b/src/engine/strat_engine/backstore/transaction.rs
@@ -9,7 +9,7 @@ use std::{
 
 use devicemapper::Sectors;
 
-use crate::engine::strat_engine::backstore::blockdevmgr::BlkDevSegment;
+use crate::engine::strat_engine::backstore::shared::BlkDevSegment;
 
 /// This transaction data structure keeps a list of segments associated with block
 /// devices, segments from the cap device, and a map associating each cap device

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -4,13 +4,25 @@
 
 // Functions for dealing with devices.
 
-use std::fs::File;
+use std::{fs::File, os::unix::prelude::AsRawFd};
 
 use iocuddle::{Group, Ioctl, Read};
+use libc::c_int;
 
 use devicemapper::Bytes;
 
-use crate::stratis::StratisResult;
+use crate::stratis::{StratisError, StratisResult};
+
+// BLKSSZGET is actually a Read ioctl which was accidentally defined
+// using _IO. So, we must use the special _bad macro defined in nix.
+// See: https://github.com/nix-rust/nix/issues/1006
+// We have already tried and failed to use the available iocuddle functionality.
+// The same holds true for BLKPBSZGET.
+// If a new version of iocuddle were released, we could probably use the lie()
+// function to get the correct functionality. See:
+// https://github.com/stratis-storage/project/issues/533
+ioctl_read_bad!(blksszget, 0x1268, c_int);
+ioctl_read_bad!(blkpbszget, 0x127b, c_int);
 
 const BLK: Group = Group::new(0x12);
 
@@ -21,4 +33,30 @@ pub fn blkdev_size(file: &File) -> StratisResult<Bytes> {
         .ioctl(file)
         .map(|(_, res)| Bytes::from(res))
         .map_err(|e| e.into())
+}
+
+pub fn blkdev_logical_sector_size(file: &File) -> StratisResult<Bytes> {
+    let mut val = 0i32 as c_int; // util-linux uses int* as out-arg for ioctl
+    unsafe { blksszget(file.as_raw_fd(), &mut val) }.map_err(|e| {
+        StratisError::Msg(format!(
+            "Error reading logical sector size (BLKSSZGET): {}",
+            e
+        ))
+    })?;
+    // Allowed because the size should be less than u16::MAX
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(Bytes::from(val as u16))
+}
+
+pub fn blkdev_physical_sector_size(file: &File) -> StratisResult<Bytes> {
+    let mut val = 0i32 as c_int; // util-linux uses int* as out-arg for ioctl
+    unsafe { blkpbszget(file.as_raw_fd(), &mut val) }.map_err(|e| {
+        StratisError::Msg(format!(
+            "Error reading physical sector size (BLKPBSZGET): {}",
+            e
+        ))
+    })?;
+    // Allowed because the size should be less than u16::MAX
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(Bytes::from(val as u16))
 }

--- a/src/engine/strat_engine/device.rs
+++ b/src/engine/strat_engine/device.rs
@@ -43,9 +43,7 @@ pub fn blkdev_logical_sector_size(file: &File) -> StratisResult<Bytes> {
             e
         ))
     })?;
-    // Allowed because the size should be less than u16::MAX
-    #[allow(clippy::cast_possible_truncation)]
-    Ok(Bytes::from(val as u16))
+    Ok(Bytes::from(convert_int!(val, c_int, u16)?))
 }
 
 pub fn blkdev_physical_sector_size(file: &File) -> StratisResult<Bytes> {
@@ -56,7 +54,5 @@ pub fn blkdev_physical_sector_size(file: &File) -> StratisResult<Bytes> {
             e
         ))
     })?;
-    // Allowed because the size should be less than u16::MAX
-    #[allow(clippy::cast_possible_truncation)]
-    Ok(Bytes::from(val as u16))
+    Ok(Bytes::from(convert_int!(val, c_int, u16)?))
 }

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -420,7 +420,7 @@ impl Engine for StratEngine {
 
             let block_size_summary = unowned_devices.blocksizes();
             if block_size_summary.len() > 1 {
-                let err_str = "The devices specified for initializing the pool do not have uniform physical and logical sector sizes.".into();
+                let err_str = "The devices specified for initializing the pool do do not all have the same physical sector size or do not all have the same logical sector size.".into();
                 return Err(StratisError::Msg(err_str));
             }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -420,7 +420,7 @@ impl Engine for StratEngine {
 
             let block_size_summary = unowned_devices.blocksizes();
             if block_size_summary.len() > 1 {
-                let err_str = "The devices specified for initializing the pool do not have uniform physcal and logical block sizes.".into();
+                let err_str = "The devices specified for initializing the pool do not have uniform physical and logical sector sizes.".into();
                 return Err(StratisError::Msg(err_str));
             }
 

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -418,6 +418,12 @@ impl Engine for StratEngine {
                 ));
             }
 
+            let block_size_summary = unowned_devices.blocksizes();
+            if block_size_summary.len() > 1 {
+                let err_str = "The devices specified for initializing the pool do not have uniform physcal and logical block sizes.".into();
+                return Err(StratisError::Msg(err_str));
+            }
+
             let cloned_name = name.clone();
             let cloned_enc_info = encryption_info.cloned();
 

--- a/src/engine/strat_engine/liminal/liminal.rs
+++ b/src/engine/strat_engine/liminal/liminal.rs
@@ -29,7 +29,7 @@ use crate::{
                     bda_wrapper, identify_block_device, DeviceInfo, LuksInfo, StratisDevInfo,
                     StratisInfo,
                 },
-                setup::{get_blockdevs, get_metadata, get_pool_state},
+                setup::{get_blockdevs, get_metadata},
             },
             metadata::{StratisIdentifiers, BDA},
             pool::StratPool,
@@ -1000,8 +1000,7 @@ fn setup_pool(
         }
     };
 
-    let state = get_pool_state(pool_einfo);
-    StratPool::setup(pool_uuid, datadevs, cachedevs, timestamp, &metadata, state)
+    StratPool::setup(pool_uuid, datadevs, cachedevs, timestamp, &metadata, pool_einfo)
         .map(|(name, mut pool)| {
             if matches!(pool_name, MaybeInconsistent::Yes | MaybeInconsistent::No(None)) || MaybeInconsistent::No(Some(&name)) != pool_name.as_ref() {
                 if let Err(e) = pool.rename_pool(&name) {

--- a/src/engine/strat_engine/liminal/setup.rs
+++ b/src/engine/strat_engine/liminal/setup.rs
@@ -26,7 +26,7 @@ use crate::{
             shared::{bds_to_bdas, tiers_to_bdas},
             types::{BDARecordResult, BDAResult},
         },
-        types::{ActionAvailability, BlockDevTier, DevUuid, DevicePath, Name, PoolEncryptionInfo},
+        types::{BlockDevTier, DevUuid, DevicePath, Name},
     },
     stratis::{StratisError, StratisResult},
 };
@@ -362,19 +362,4 @@ pub fn get_blockdevs(
     };
 
     Ok((datadevs, cachedevs))
-}
-
-/// Takes a set of information determined about the pool in liminal devices and
-/// determines what the state of the pool should be when it is set up.
-pub fn get_pool_state(info: Option<PoolEncryptionInfo>) -> ActionAvailability {
-    if let Some(i) = info {
-        if i.is_inconsistent() {
-            warn!("Metadata for encryption inconsistent across devices in pool; disabling mutating IPC requests for this pool");
-            ActionAvailability::NoRequests
-        } else {
-            ActionAvailability::Full
-        }
-    } else {
-        ActionAvailability::Full
-    }
 }

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -271,10 +271,12 @@ impl StratPool {
         let mut needs_save = metadata.thinpool_dev.fs_limit.is_none()
             || metadata.thinpool_dev.feature_args.is_none();
 
-        needs_save |= match thinpool.check(uuid, &mut backstore) {
-            Ok(check) => check.0,
-            Err(e) => return Err((e, backstore.into_bdas())),
-        };
+        if action_avail != ActionAvailability::NoPoolChanges {
+            needs_save |= match thinpool.check(uuid, &mut backstore) {
+                Ok(check) => check.0,
+                Err(e) => return Err((e, backstore.into_bdas())),
+            };
+        }
 
         let metadata_size = backstore.datatier_metadata_size();
         let mut pool = StratPool {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -579,7 +579,7 @@ impl Pool for StratPool {
 
             let block_size_summary = unowned_devices.blocksizes();
             if block_size_summary.len() > 1 {
-                let err_str = "The devices specified for the cache tier do not have uniform physcal and logical block sizes.".into();
+                let err_str = "The devices specified for the cache tier do not have uniform physcal and logical sector sizes.".into();
                 return Err(StratisError::Msg(err_str));
             }
 
@@ -596,7 +596,7 @@ impl Pool for StratPool {
                 .expect("unowned_devices is not empty")
                 .logical_sector_size;
             if cache_logical_sector_size != current_data_logical_sector_size {
-                let err_str = format!("The logical block size of the devices proposed for the cache tier, {}, does not match the logical block size of the data tier, {}", cache_logical_sector_size, current_data_logical_sector_size);
+                let err_str = format!("The logical sector size of the devices proposed for the cache tier, {}, does not match the effective logical sector size of the data tier, {}", cache_logical_sector_size, current_data_logical_sector_size);
                 return Err(StratisError::Msg(err_str));
             }
 
@@ -834,7 +834,7 @@ impl Pool for StratPool {
 
                 let block_size_summary = unowned_devices.blocksizes();
                 if block_size_summary.len() > 1 {
-                    let err_str = "The devices specified to be added to the cache tier do not have uniform physcal and logical block sizes.".into();
+                    let err_str = "The devices specified to be added to the cache tier do not have uniform physical and logical sector sizes.".into();
                     return Err(StratisError::Msg(err_str));
                 }
 
@@ -849,7 +849,7 @@ impl Pool for StratPool {
                     .next()
                     .expect("unowned devices is not empty");
                 if added_sector_sizes != &current_sector_sizes {
-                    let err_str = format!("The block sizes of the devices proposed for extending the cache tier, {}, do not match the block size of the existing cache devices, {}", added_sector_sizes, current_sector_sizes);
+                    let err_str = format!("The sector sizes of the devices proposed for extending the cache tier, {}, do not match the effective sector sizes of the existing cache devices, {}", added_sector_sizes, current_sector_sizes);
                     return Err(StratisError::Msg(err_str));
                 }
 
@@ -882,7 +882,7 @@ impl Pool for StratPool {
 
                 let block_size_summary = unowned_devices.blocksizes();
                 if block_size_summary.len() > 1 {
-                    let err_str = "The devices specified to be added to the data tier do not have uniform physcal and logical block sizes.".into();
+                    let err_str = "The devices specified to be added to the data tier do not have uniform physcal and logical sector sizes.".into();
                     return Err(StratisError::Msg(err_str));
                 }
 
@@ -897,7 +897,7 @@ impl Pool for StratPool {
                     .next()
                     .expect("unowned devices is not empty");
                 if added_sector_sizes != &current_sector_sizes {
-                    let err_str = format!("The sector sizes of the devices proposed for extending the data tier, {}, do not match the sector sizes of the existing data devices, {}", added_sector_sizes, current_sector_sizes);
+                    let err_str = format!("The sector sizes of the devices proposed for extending the data tier, {}, do not match the effective sector sizes of the existing data devices, {}", added_sector_sizes, current_sector_sizes);
                     return Err(StratisError::Msg(err_str));
                 }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -577,7 +577,7 @@ impl Pool for StratPool {
 
             let block_size_summary = unowned_devices.blocksizes();
             if block_size_summary.len() > 1 {
-                let err_str = "The devices specified for the cache tier do not have uniform physcal and logical sector sizes.".into();
+                let err_str = "The devices specified for the cache tier do not all have the same physical sector size or do not all have the same logical sector size.".into();
                 return Err(StratisError::Msg(err_str));
             }
 
@@ -832,7 +832,7 @@ impl Pool for StratPool {
 
                 let block_size_summary = unowned_devices.blocksizes();
                 if block_size_summary.len() > 1 {
-                    let err_str = "The devices specified to be added to the cache tier do not have uniform physical and logical sector sizes.".into();
+                    let err_str = "The devices specified to be added to the cache tier do not all have the same physical sector size or do not all have the same logical sector size.".into();
                     return Err(StratisError::Msg(err_str));
                 }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -882,6 +882,22 @@ impl Pool for StratPool {
                     return Err(StratisError::Msg(err_str));
                 }
 
+                let current_logical_sector_size = self
+                    .backstore
+                    .block_size_summary(BlockDevTier::Data)
+                    .expect("always exists")
+                    .validate()
+                    .expect("All operations prevented if validate() function on data tier block size sumary returns an error");
+                let data_block_size = block_size_summary
+                    .keys()
+                    .next()
+                    .expect("unowned devices is not empty")
+                    .logical_sector_size;
+                if data_block_size != current_logical_sector_size {
+                    let err_str = format!("The logical block size of the devices proposed for extending the data tier, {}, does not match the logical block size of the existing data devices, {}", data_block_size, current_logical_sector_size);
+                    return Err(StratisError::Msg(err_str));
+                }
+
                 let cached = self.cached();
 
                 // If just adding data devices, no need to suspend the pool.

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -579,6 +579,22 @@ impl Pool for StratPool {
                 return Err(StratisError::Msg(err_str));
             }
 
+            let current_logical_sector_size = self
+                .backstore
+                .block_size_summary(BlockDevTier::Data)
+                .expect("always exists for data tier")
+                .validate()
+                .expect("All operations prevented if validate() function returns an error");
+            let data_block_size = block_size_summary
+                .keys()
+                .next()
+                .expect("unowned_devices is not empty")
+                .logical_sector_size;
+            if data_block_size != current_logical_sector_size {
+                let err_str = format!("The logical block size of the devices proposed for the cache tier, {}, does not match the logical block size of the data tier, {}", data_block_size, current_logical_sector_size);
+                return Err(StratisError::Msg(err_str));
+            }
+
             self.thin_pool.suspend()?;
             let devices_result = self
                 .backstore

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -573,6 +573,12 @@ impl Pool for StratPool {
                 ));
             }
 
+            let block_size_summary = unowned_devices.blocksizes();
+            if block_size_summary.len() > 1 {
+                let err_str = "The devices specified for the cache tier do not have uniform physcal and logical block sizes.".into();
+                return Err(StratisError::Msg(err_str));
+            }
+
             self.thin_pool.suspend()?;
             let devices_result = self
                 .backstore
@@ -805,6 +811,12 @@ impl Pool for StratPool {
                     return Ok((SetCreateAction::new(vec![]), None));
                 }
 
+                let block_size_summary = unowned_devices.blocksizes();
+                if block_size_summary.len() > 1 {
+                    let err_str = "The devices specified to be added to the cache tier do not have uniform physcal and logical block sizes.".into();
+                    return Err(StratisError::Msg(err_str));
+                }
+
                 self.thin_pool.suspend()?;
                 let bdev_info_res = self.backstore.add_cachedevs(
                     Name::new(pool_name.to_string()),
@@ -830,6 +842,12 @@ impl Pool for StratPool {
 
                 if unowned_devices.is_empty() {
                     return Ok((SetCreateAction::new(vec![]), None));
+                }
+
+                let block_size_summary = unowned_devices.blocksizes();
+                if block_size_summary.len() > 1 {
+                    let err_str = "The devices specified to be added to the data tier do not have uniform physcal and logical block sizes.".into();
+                    return Err(StratisError::Msg(err_str));
                 }
 
                 let cached = self.cached();

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -286,7 +286,9 @@ impl StratPool {
             metadata_size,
         };
 
-        // Change the pool to started at this point not that the pool has been set up.
+        // The value of the started field in the pool metadata needs to be
+        // updated unless the value is already present in the metadata and has
+        // value true.
         needs_save |= !metadata.started.unwrap_or(false);
 
         if needs_save {

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -579,19 +579,20 @@ impl Pool for StratPool {
                 return Err(StratisError::Msg(err_str));
             }
 
-            let current_logical_sector_size = self
+            let current_data_logical_sector_size = self
                 .backstore
                 .block_size_summary(BlockDevTier::Data)
                 .expect("always exists for data tier")
                 .validate()
-                .expect("All operations prevented if validate() function returns an error");
-            let data_block_size = block_size_summary
+                .expect("All operations prevented if validate() function returns an error")
+                .logical_sector_size;
+            let cache_logical_sector_size = block_size_summary
                 .keys()
                 .next()
                 .expect("unowned_devices is not empty")
                 .logical_sector_size;
-            if data_block_size != current_logical_sector_size {
-                let err_str = format!("The logical block size of the devices proposed for the cache tier, {}, does not match the logical block size of the data tier, {}", data_block_size, current_logical_sector_size);
+            if cache_logical_sector_size != current_data_logical_sector_size {
+                let err_str = format!("The logical block size of the devices proposed for the cache tier, {}, does not match the logical block size of the data tier, {}", cache_logical_sector_size, current_data_logical_sector_size);
                 return Err(StratisError::Msg(err_str));
             }
 
@@ -833,19 +834,18 @@ impl Pool for StratPool {
                     return Err(StratisError::Msg(err_str));
                 }
 
-                let current_logical_sector_size = self
+                let current_sector_sizes = self
                     .backstore
                     .block_size_summary(BlockDevTier::Cache)
                     .expect("already returned if no cache tier")
                     .validate()
                     .expect("All devices of the cache tier must be in use, so there can only be one representative logical sector size.");
-                let cache_block_size = block_size_summary
+                let added_sector_sizes = block_size_summary
                     .keys()
                     .next()
-                    .expect("unowned devices is not empty")
-                    .logical_sector_size;
-                if cache_block_size != current_logical_sector_size {
-                    let err_str = format!("The logical block size of the devices proposed for extending the cache tier, {}, does not match the logical block size of the existing cache devices, {}", cache_block_size, current_logical_sector_size);
+                    .expect("unowned devices is not empty");
+                if added_sector_sizes != &current_sector_sizes {
+                    let err_str = format!("The block sizes of the devices proposed for extending the cache tier, {}, do not match the block size of the existing cache devices, {}", added_sector_sizes, current_sector_sizes);
                     return Err(StratisError::Msg(err_str));
                 }
 
@@ -882,19 +882,18 @@ impl Pool for StratPool {
                     return Err(StratisError::Msg(err_str));
                 }
 
-                let current_logical_sector_size = self
+                let current_sector_sizes = self
                     .backstore
                     .block_size_summary(BlockDevTier::Data)
                     .expect("always exists")
                     .validate()
                     .expect("All operations prevented if validate() function on data tier block size sumary returns an error");
-                let data_block_size = block_size_summary
+                let added_sector_sizes = block_size_summary
                     .keys()
                     .next()
-                    .expect("unowned devices is not empty")
-                    .logical_sector_size;
-                if data_block_size != current_logical_sector_size {
-                    let err_str = format!("The logical block size of the devices proposed for extending the data tier, {}, does not match the logical block size of the existing data devices, {}", data_block_size, current_logical_sector_size);
+                    .expect("unowned devices is not empty");
+                if added_sector_sizes != &current_sector_sizes {
+                    let err_str = format!("The sector sizes of the devices proposed for extending the data tier, {}, do not match the sector sizes of the existing data devices, {}", added_sector_sizes, current_sector_sizes);
                     return Err(StratisError::Msg(err_str));
                 }
 

--- a/src/engine/strat_engine/pool.rs
+++ b/src/engine/strat_engine/pool.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{collections::HashMap, path::Path, vec::Vec};
+use std::{cmp::max, collections::HashMap, path::Path, vec::Vec};
 
 use chrono::{DateTime, Utc};
 use serde_json::{Map, Value};
@@ -227,6 +227,8 @@ impl StratPool {
 
         let mut backstore =
             Backstore::setup(uuid, &metadata.backstore, datadevs, cachedevs, timestamp)?;
+        let action_avail = max(action_avail, backstore.action_availability());
+
         let pool_name = &metadata.name;
 
         let mut thinpool = match ThinPool::setup(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "min")]
-#[cfg_attr(feature = "dbus_enabled", allow(dead_code))]
 #[macro_use]
 extern crate nix;
 


### PR DESCRIPTION
Related #2880

* Add in_use detection to individual block devices. (1)A block devices is considered in use if the space that is allocated from it exceeds that allocated for Stratis metadata.
* Add an AllocatedAbove struct to tidy up management of segments allocated to the data tier or cache tier from their block devices.
* Assert an invariant that blockdev is considered to be in use by criterion (1) exactly when it is considered in use because it is included in the AllocatedAbove data structure.
* Read BLKSSZGET and BLKPBSZGET ioctls along with other device information when examining devices.
* Calculate whether an existing pool should have reduced ActionAvailability. If the data cap device could be extended so that its logical or physical block size could change, then ActionAvailability is set to no actions. There is no check on the cache tier; if the pool has a cache tier and it is working, then the situation has to be assumed to be correct.
* Require identical block sizes for devices being newly added to either the cache or the data tier.
* Do not allow initializing a cache where the logical block size of the resulting cache would differ from that of the data tier.
* Require the block sizes of the devices to be added to the cache or data tier to match the current block sizes.
* When creating a new pool, require block sizes to match.