### PR TITLE
do not unshare mount namespace if stratisd pid is 1

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,7 +7,7 @@ pub use self::{
     shared::{total_allocated, total_used},
     sim_engine::SimEngine,
     strat_engine::{
-        crypt_metadata_size, get_dm, get_dm_init, set_up_crypt_logging, unshare_namespace,
+        crypt_metadata_size, get_dm, get_dm_init, set_up_crypt_logging, unshare_mount_namespace,
         StaticHeader, StaticHeaderResult, StratEngine, StratKeyActions, ThinPoolSizeParams, BDA,
         CLEVIS_TANG_TRUST_URL,
     },

--- a/src/engine/strat_engine/backstore/blockdevmgr.rs
+++ b/src/engine/strat_engine/backstore/blockdevmgr.rs
@@ -759,7 +759,7 @@ mod tests {
         backstore::devices::{ProcessedPathInfos, UnownedDevices},
         cmd,
         names::KeyDescription,
-        ns::{unshare_namespace, MemoryFilesystem},
+        ns::{unshare_mount_namespace, MemoryFilesystem},
         tests::{crypt, loopbacked, real},
     };
 
@@ -986,7 +986,7 @@ mod tests {
     }
 
     fn test_clevis_initialize(paths: &[&Path]) {
-        unshare_namespace().unwrap();
+        unshare_mount_namespace().unwrap();
         let pool_name = Name::new("pool_name".to_string());
         let _memfs = MemoryFilesystem::new().unwrap();
         let pool_uuid = PoolUuid::new_v4();
@@ -1048,7 +1048,7 @@ mod tests {
 
     fn test_clevis_both_initialize(paths: &[&Path]) {
         fn test_both(paths: &[&Path], key_desc: &KeyDescription) -> Result<(), Box<dyn Error>> {
-            unshare_namespace()?;
+            unshare_mount_namespace()?;
             let _memfs = MemoryFilesystem::new().unwrap();
             let pool_uuid = PoolUuid::new_v4();
             let pool_name = Name::new("pool_name".to_string());

--- a/src/engine/strat_engine/backstore/crypt/mod.rs
+++ b/src/engine/strat_engine/backstore/crypt/mod.rs
@@ -53,7 +53,7 @@ mod tests {
                     },
                     shared::acquire_crypt_device,
                 },
-                ns::{unshare_namespace, MemoryFilesystem},
+                ns::{unshare_mount_namespace, MemoryFilesystem},
                 tests::{crypt, loopbacked, real},
             },
             types::{DevUuid, DevicePath, KeyDescription, Name, PoolUuid, UnlockMethod},
@@ -354,7 +354,7 @@ mod tests {
             paths: &[&Path],
             key_desc: &KeyDescription,
         ) -> Result<(), Box<dyn Error>> {
-            unshare_namespace()?;
+            unshare_mount_namespace()?;
             let _memfs = MemoryFilesystem::new()?;
             let path = paths
                 .get(0)
@@ -419,7 +419,7 @@ mod tests {
     }
 
     fn test_clevis_initialize(paths: &[&Path]) {
-        unshare_namespace().unwrap();
+        unshare_mount_namespace().unwrap();
         let _memfs = MemoryFilesystem::new().unwrap();
         let path = paths[0];
         let pool_name = Name::new("pool_name".to_string());

--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -703,7 +703,7 @@ mod test {
         strat_engine::{
             backstore::crypt_metadata_size,
             cmd,
-            ns::unshare_namespace,
+            ns::unshare_mount_namespace,
             tests::{crypt, loopbacked, real, FailDevice},
         },
         types::{ActionAvailability, EngineAction, KeyDescription},
@@ -713,7 +713,7 @@ mod test {
 
     /// Verify that a pool rename causes the pool metadata to get the new name.
     fn test_pool_rename(paths: &[&Path]) {
-        unshare_namespace().unwrap();
+        unshare_mount_namespace().unwrap();
         let engine = StratEngine::initialize().unwrap();
 
         let name1 = "name1";
@@ -913,7 +913,7 @@ mod test {
             Ok(())
         }
 
-        unshare_namespace()?;
+        unshare_mount_namespace()?;
         let engine = StratEngine::initialize()?;
         let uuid =
             test_async!(engine.create_pool(name, paths_with_fail_device, Some(encryption_info)))?

--- a/src/engine/strat_engine/keys.rs
+++ b/src/engine/strat_engine/keys.rs
@@ -37,7 +37,7 @@ use crate::{
         shared,
         strat_engine::{
             names::KeyDescription,
-            ns::{is_in_root_namespace, NS_TMPFS_LOCATION},
+            ns::{is_in_root_mount_namespace, NS_TMPFS_LOCATION},
         },
         types::{Key, MappingCreateAction, MappingDeleteAction, SizedKeyMemory},
     },
@@ -461,7 +461,7 @@ impl MemoryPrivateFilesystem {
         // Don't do check as PID 1 as we may be in a container
         if getpid().as_raw() != 1 {
             // Check that the namespace is now different.
-            if is_in_root_namespace()? {
+            if is_in_root_mount_namespace()? {
                 return Err(StratisError::Msg(
                     "It was detected that the in-memory key files would have ended up \
                     visible on the host system; aborting operation prior to generating \

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -27,7 +27,7 @@ pub use self::{
     engine::StratEngine,
     keys::StratKeyActions,
     metadata::{StaticHeader, StaticHeaderResult, BDA},
-    ns::unshare_namespace,
+    ns::unshare_mount_namespace,
     thinpool::ThinPoolSizeParams,
 };
 

--- a/src/engine/strat_engine/ns.rs
+++ b/src/engine/strat_engine/ns.rs
@@ -24,17 +24,17 @@ pub const NS_TMPFS_LOCATION: &str = "/run/stratisd/ns_mounts";
 
 /// Unshare the mount namespace if the stratisd mount namespace for this thread is in the root namespace.
 // Precondition: If running in a container, PID is not 1 OR the container does share the host PID.
-pub fn unshare_namespace() -> StratisResult<()> {
+pub fn unshare_mount_namespace() -> StratisResult<()> {
     // Only create a new mount namespace if the thread is in the root namespace.
-    if is_in_root_namespace()? {
+    if is_in_root_mount_namespace()? {
         unshare(CloneFlags::CLONE_NEWNS)?;
     }
-    assert!(!is_in_root_namespace()?);
+    assert!(!is_in_root_mount_namespace()?);
     Ok(())
 }
 
 /// Check if the stratisd mount namespace for this thread is in the root namespace.
-pub fn is_in_root_namespace() -> StratisResult<bool> {
+pub fn is_in_root_mount_namespace() -> StratisResult<bool> {
     let pid_one_stat = stat(INIT_MNT_NS_PATH)?;
     let self_stat = stat(format!("/proc/self/task/{}/ns/mnt", gettid()).as_str())?;
     Ok(pid_one_stat.st_ino == self_stat.st_ino && pid_one_stat.st_dev == self_stat.st_dev)

--- a/src/engine/strat_engine/ns.rs
+++ b/src/engine/strat_engine/ns.rs
@@ -22,6 +22,8 @@ const INIT_MNT_NS_PATH: &str = "/proc/1/ns/mnt";
 /// Path to where private namespace mounts are mounted
 pub const NS_TMPFS_LOCATION: &str = "/run/stratisd/ns_mounts";
 
+/// Unshare the mount namespace if the stratisd mount namespace for this thread is in the root namespace.
+// Precondition: If running in a container, PID is not 1 OR the container does share the host PID.
 pub fn unshare_namespace() -> StratisResult<()> {
     // Only create a new mount namespace if the thread is in the root namespace.
     if is_in_root_namespace()? {

--- a/src/stratis/run.rs
+++ b/src/stratis/run.rs
@@ -16,6 +16,8 @@ use tokio::{
     task,
 };
 
+use nix::unistd::getpid;
+
 #[cfg(feature = "dbus_enabled")]
 use crate::dbus_api::DbusAction;
 use crate::{
@@ -48,7 +50,20 @@ async fn signal_thread() -> StratisResult<()> {
 /// Always check for devicemapper context.
 pub fn run(sim: bool) -> StratisResult<()> {
     if !sim {
-        unshare_namespace()?;
+        // If stratisd is running as PID 1, then it is definitely in a container and the
+        // unshare_namespace() command method will fail silently, since the mount namespace will
+        // remain the same after the unshare command. Also, containers give us a native mount
+        // isolation so unsharing the mount namespace is unnecessary. So any filesystem mounts
+        // inside a container won't be visible by the host.
+        //
+        // Note that it is possible for stratisd to be running in a container and not as PID 1, but
+        // this situation is less easily detected. However, stratisd will not fail in the
+        // unshare_namespace() method if that is the case.
+        if getpid().as_raw() != 1 {
+            unshare_namespace()?;
+        } else {
+            debug!("Running as PID 1, not unsharing mount namespace");
+        }
     }
 
     set_up_crypt_logging();

--- a/src/stratis/run.rs
+++ b/src/stratis/run.rs
@@ -22,7 +22,8 @@ use nix::unistd::getpid;
 use crate::dbus_api::DbusAction;
 use crate::{
     engine::{
-        set_up_crypt_logging, unshare_namespace, Engine, SimEngine, StratEngine, UdevEngineEvent,
+        set_up_crypt_logging, unshare_mount_namespace, Engine, SimEngine, StratEngine,
+        UdevEngineEvent,
     },
     stratis::{
         dm::dm_event_thread, errors::StratisResult, ipc_support::setup, stratis::VERSION,
@@ -51,16 +52,16 @@ async fn signal_thread() -> StratisResult<()> {
 pub fn run(sim: bool) -> StratisResult<()> {
     if !sim {
         // If stratisd is running as PID 1, then it is definitely in a container and the
-        // unshare_namespace() command method will fail silently, since the mount namespace will
+        // unshare_mount_namespace() command method will fail silently, since the mount namespace will
         // remain the same after the unshare command. Also, containers give us a native mount
         // isolation so unsharing the mount namespace is unnecessary. So any filesystem mounts
         // inside a container won't be visible by the host.
         //
         // Note that it is possible for stratisd to be running in a container and not as PID 1, but
         // this situation is less easily detected. However, stratisd will not fail in the
-        // unshare_namespace() method if that is the case.
+        // unshare_mount_namespace() method if that is the case.
         if getpid().as_raw() != 1 {
-            unshare_namespace()?;
+            unshare_mount_namespace()?;
         } else {
             debug!("Running as PID 1, not unsharing mount namespace");
         }


### PR DESCRIPTION
If stratis runs in a container as PID 1, unsharing the mount namespace will not work and we should work the user about that. Also stratisd crashes while asserting that the mount namespace has been unshared.

Related: https://github.com/stratis-storage/stratisd/issues/3185

Signed-off-by: Sébastien Han <seb@redhat.com>