### PR TITLE
build udev lib bins statically

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -109,6 +109,7 @@ jobs:
           curl
           device-mapper-persistent-data
           dbus-devel
+          glibc-static
           libblkid-devel
           make
           systemd-devel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,7 @@ jobs:
           dbus-devel
           libblkid-devel
           git
+          glibc-static
           make
           python3-coverage
           python3-dbus-client-gen
@@ -252,6 +253,7 @@ jobs:
           dbus-devel
           dbus-tools
           device-mapper-persistent-data
+          glibc-static
           libblkid-devel
           make
           python3-justbytes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -278,6 +278,7 @@ jobs:
           dbus-devel
           dbus-tools
           device-mapper-persistent-data
+          glibc-static
           libblkid-devel
           make
           python3-dbus

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,6 +55,7 @@ jobs:
           dbus-devel
           dbus-tools
           device-mapper-persistent-data
+          glibc-static
           libblkid-devel
           make
           python3-dbus
@@ -120,6 +121,7 @@ jobs:
           dbus-devel
           dbus-tools
           device-mapper-persistent-data
+          glibc-static
           libblkid-devel
           make
           python3-dbus

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ exclude = [
 ]
 
 [[bin]]
+name = "stratisd"
+required-features = ["engine"]
+
+[[bin]]
 name = "stratis-dumpmetadata"
 required-features = ["engine", "extras", "min"]
 
@@ -38,6 +42,16 @@ required-features = ["engine", "min"]
 name = "stratisd-min"
 path = "src/bin/stratis-min/stratisd-min.rs"
 required-features = ["engine", "min"]
+
+[[bin]]
+name = "stratis-str-cmp"
+path = "src/bin/udev-lib/stratis-str-cmp.rs"
+required-features = ["udev_scripts"]
+
+[[bin]]
+name = "stratis-base32-decode"
+path = "src/bin/udev-lib/stratis-base32-decode.rs"
+required-features = ["udev_scripts"]
 
 [[bin]]
 name = "stratis-utils"
@@ -248,3 +262,4 @@ dbus_enabled = ["dbus", "dbus-tree"]
 extras = ["pretty-hex"]
 min = ["rpassword"]
 systemd_compat = ["bindgen"]
+udev_scripts = ["data-encoding"]

--- a/src/bin/stratis-utils.rs
+++ b/src/bin/stratis-utils.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use clap::{Arg, Command};
-use data_encoding::BASE32_NOPAD;
 use serde_json::{json, Value};
 
 use devicemapper::{Bytes, Sectors};
@@ -114,21 +113,6 @@ impl Display for ExecutableError {
 }
 
 impl Error for ExecutableError {}
-
-/// Compare two strings and output on stdout 0 if they match and 1 if they do not.
-fn string_compare(arg1: &str, arg2: &str) {
-    if arg1 == arg2 {
-        println!("0");
-    } else {
-        println!("1");
-    }
-}
-
-fn base32_decode(var_name: &str, base32_str: &str) -> Result<(), Box<dyn Error>> {
-    let base32_decoded = String::from_utf8(BASE32_NOPAD.decode(base32_str.as_bytes())?)?;
-    println!("{}={}", var_name, base32_decoded);
-    Ok(())
-}
 
 // Get a prediction of filesystem size given a list of filesystem sizes and
 // whether or not the pool allows overprovisioning.
@@ -282,37 +266,7 @@ fn parse_args() -> Result<(), Box<dyn Error>> {
     let args = env::args().collect::<Vec<_>>();
     let argv1 = args[0].as_str();
 
-    if argv1.ends_with("stratis-str-cmp") {
-        let parser = Command::new("stratis-str-cmp")
-            .arg(
-                Arg::new("left")
-                    .help("First string to compare")
-                    .required(true),
-            )
-            .arg(
-                Arg::new("right")
-                    .help("Second string to compare")
-                    .required(true),
-            );
-        let matches = parser.get_matches_from(&args);
-        string_compare(
-            matches.value_of("left").expect("required argument"),
-            matches.value_of("right").expect("required argument"),
-        );
-    } else if argv1.ends_with("stratis-base32-decode") {
-        let parser = Command::new("stratis-base32-decode")
-            .arg(Arg::new("key").help("Key for output string").required(true))
-            .arg(
-                Arg::new("value")
-                    .help("value to be decoded from base32 encoded sequence")
-                    .required(true),
-            );
-        let matches = parser.get_matches_from(&args);
-        base32_decode(
-            matches.value_of("key").expect("required argument"),
-            matches.value_of("value").expect("required argument"),
-        )?;
-    } else if argv1.ends_with("stratis-predict-usage") {
+    if argv1.ends_with("stratis-predict-usage") {
         let parser = Command::new("stratis-predict-usage")
             .about("Predicts space usage for Stratis.")
             .subcommand_required(true)

--- a/src/bin/udev-lib/stratis-base32-decode.rs
+++ b/src/bin/udev-lib/stratis-base32-decode.rs
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use data_encoding::BASE32_NOPAD;
+use std::{env, error::Error};
+
+fn base32_decode(var_name: &str, base32_str: &str) -> Result<(), Box<dyn Error>> {
+    let base32_decoded = String::from_utf8(BASE32_NOPAD.decode(base32_str.as_bytes())?)?;
+    println!("{}={}", var_name, base32_decoded);
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = env::args().collect();
+    let key = args
+        .get(1)
+        .ok_or("missing first argument, this program requires exactly 2 arguments")?;
+    let value = args
+        .get(2)
+        .ok_or("missing second argument, this program requires exactly 2 arguments")?;
+
+    base32_decode(key, value)?;
+
+    Ok(())
+}

--- a/src/bin/udev-lib/stratis-str-cmp.rs
+++ b/src/bin/udev-lib/stratis-str-cmp.rs
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::{env, error::Error};
+
+/// Compare two strings and output on stdout 0 if they match and 1 if they do not.
+fn string_compare(arg1: &str, arg2: &str) {
+    if arg1 == arg2 {
+        println!("0");
+    } else {
+        println!("1");
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = env::args().collect();
+    let left = args
+        .get(1)
+        .ok_or("missing first argument, this program requires exactly 2 arguments")?;
+    let right = args
+        .get(2)
+        .ok_or("missing second argument, this program requires exactly 2 arguments")?;
+
+    string_compare(left, right);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,36 +1,47 @@
+#[cfg(feature = "engine")]
 #[macro_use]
 extern crate nix;
 
+#[cfg(feature = "engine")]
 #[macro_use]
 extern crate serde_derive;
+#[cfg(feature = "engine")]
 #[macro_use]
 extern crate log;
 
+#[cfg(feature = "engine")]
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;
 
+#[cfg(feature = "engine")]
 #[cfg(test)]
 #[macro_use]
 extern crate assert_matches;
 
+#[cfg(feature = "engine")]
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(feature = "engine")]
 #[macro_use]
 extern crate serde_json;
 
+#[cfg(feature = "engine")]
 #[macro_use]
 extern crate libcryptsetup_rs;
 
+#[cfg(feature = "engine")]
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "engine")]
 pub mod engine;
 
 #[cfg(feature = "dbus_enabled")]
 pub mod dbus_api;
 
+#[cfg(feature = "engine")]
 pub mod stratis;
 
 #[cfg(feature = "min")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,6 +10,7 @@ macro_rules! test_async {
     };
 }
 
+#[cfg(feature = "engine")]
 macro_rules! spawn_blocking {
     ($expr:expr) => {
         tokio::task::spawn_blocking(move || $expr)


### PR DESCRIPTION
This patch extracts both stratis-base32-decode and stratis-str-cmp from stratis-util. They are now two distinct binaries.
Also, when built, they are built statically.

```
$ ldd target/x86_64-unknown-linux-gnu/release/stratis-base32-decode
        statically linked
```
Related: https://github.com/stratis-storage/stratisd/issues/3195
Co-authored-by: mulhern <amulhern@redhat.com>
Signed-off-by: Sébastien Han <seb@redhat.com>