### PR TITLE
Increase crc dependency lower bound to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,18 +236,18 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "1.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
 name = "crypto-common"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ version = "3.1.9"
 optional = true
 
 [dependencies.crc]
-version = "2.0.0"
+version = "3.0.0"
 optional = true
 
 [dependencies.data-encoding]


### PR DESCRIPTION
Closes https://github.com/stratis-storage/project/issues/585