### PR TITLE
Fix key description in bind_key error message

### DIFF
--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -828,8 +828,8 @@ impl Backstore {
                 Err(StratisError::Msg(format!(
                     "Block devices have already been bound with key description {}; \
                         requested key description {} can't be applied",
-                    key_desc.as_application_str(),
                     kd.as_application_str(),
+                    key_desc.as_application_str(),
                 )))
             }
         } else {

--- a/tests/common/daemon.rs
+++ b/tests/common/daemon.rs
@@ -16,7 +16,7 @@ fn start_stratisd_min(sim: bool) -> Result<Child, Box<dyn std::error::Error>> {
         cmd.arg("--sim");
     }
     let child = cmd.spawn().expect("stratisd-min failed to start");
-    thread::sleep(time::Duration::from_millis(250));
+    thread::sleep(time::Duration::from_secs(1));
     Ok(child)
 }
 


### PR DESCRIPTION
The requested key is reported as the bound key and vice versa:

```
# stratis pool bind keyring p1 pool1key2
Execution failed:
stratisd failed to perform the operation that you requested. It returned the following information via the D-Bus:
 1: Block devices have already been bound with key description pool1key2;
 requested key description pool1key can't be applied.
```

In this case pool `p1` is already bound with `pool1key` and `pool1key2` is the requested key description.