### PR TITLE
Increase devicemapper dependency lower bound to 0.33.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,17 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,13 +359,13 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaf758a11609262ca9c93b7ff6fdbedc0c2f4e49d597474a7f70eab23eee699"
+checksum = "bc9076a6cb8ea32b2d975474450fae8b28201c8d5af5ae4e2f5401a7f3ab4225"
 dependencies = [
  "bitflags 1.3.2",
  "devicemapper-sys",
- "env_logger 0.9.3",
+ "env_logger",
  "lazy_static",
  "log",
  "nix 0.26.2",
@@ -423,19 +412,6 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "env_logger"
@@ -610,15 +586,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1370,7 +1337,7 @@ dependencies = [
  "dbus-tree",
  "devicemapper",
  "either",
- "env_logger 0.10.0",
+ "env_logger",
  "futures",
  "iocuddle",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ version = "2.3.0"
 optional = true
 
 [dependencies.devicemapper]
-version = "0.33.1"
+version = "0.33.3"
 optional = true
 
 [dependencies.dbus]


### PR DESCRIPTION
Closes https://github.com/stratis-storage/stratisd/issues/3301