### PR TITLE
Use new 'create_options' argument when creating DM devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,8 +360,7 @@ dependencies = [
 [[package]]
 name = "devicemapper"
 version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9076a6cb8ea32b2d975474450fae8b28201c8d5af5ae4e2f5401a7f3ab4225"
+source = "git+https://github.com/bmr-cymru/devicemapper-rs?branch=bmr-create-options#7b538ff67051f70be9e7ba4c2b82c62166b96481"
 dependencies = [
  "bitflags 1.3.2",
  "devicemapper-sys",
@@ -378,8 +377,7 @@ dependencies = [
 [[package]]
 name = "devicemapper-sys"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b0f9d16560f830ae6e90b769017333c4561d2c84f39e7aa7d935d2e7bcbc4c"
+source = "git+https://github.com/bmr-cymru/devicemapper-rs?branch=bmr-create-options#7b538ff67051f70be9e7ba4c2b82c62166b96481"
 dependencies = [
  "bindgen 0.63.0",
  "nix 0.26.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,8 @@ optional = true
 
 [dependencies.devicemapper]
 version = "0.33.3"
+git = "https://github.com/bmr-cymru/devicemapper-rs"
+branch = "bmr-create-options"
 optional = true
 
 [dependencies.dbus]

--- a/src/engine/strat_engine/backstore/backstore.rs
+++ b/src/engine/strat_engine/backstore/backstore.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use serde_json::Value;
 use tempfile::TempDir;
 
-use devicemapper::{CacheDev, Device, DmDevice, LinearDev, Sectors};
+use devicemapper::{CacheDev, Device, DmDevice, DmOptions, LinearDev, Sectors};
 
 use crate::{
     engine::{
@@ -60,6 +60,7 @@ fn make_cache(
         &dm_name,
         Some(&dm_uuid),
         cache_tier.meta_segments.map_to_dm(),
+        Some(DmOptions::private()),
     )?;
 
     if new {
@@ -77,6 +78,7 @@ fn make_cache(
         &dm_name,
         Some(&dm_uuid),
         cache_tier.cache_segments.map_to_dm(),
+        Some(DmOptions::private()),
     )?;
 
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
@@ -88,6 +90,7 @@ fn make_cache(
         cache,
         origin,
         CACHE_BLOCK_SIZE,
+        Some(DmOptions::private()),
     )?)
 }
 
@@ -147,6 +150,7 @@ impl Backstore {
             &dm_name,
             Some(&dm_uuid),
             data_tier.segments.map_to_dm(),
+            Some(DmOptions::private()),
         ) {
             Ok(origin) => origin,
             Err(e) => {
@@ -389,7 +393,13 @@ impl Backstore {
         if create {
             let table = self.data_tier.segments.map_to_dm();
             let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
-            let origin = LinearDev::setup(get_dm(), &dm_name, Some(&dm_uuid), table)?;
+            let origin = LinearDev::setup(
+                get_dm(),
+                &dm_name,
+                Some(&dm_uuid),
+                table,
+                Some(DmOptions::private()),
+            )?;
             self.linear = Some(origin);
         }
 

--- a/src/engine/strat_engine/thinpool/filesystem.rs
+++ b/src/engine/strat_engine/thinpool/filesystem.rs
@@ -75,8 +75,15 @@ impl StratFilesystem {
     ) -> StratisResult<(FilesystemUuid, StratFilesystem)> {
         let fs_uuid = FilesystemUuid::new_v4();
         let (dm_name, dm_uuid) = format_thin_ids(pool_uuid, ThinRole::Filesystem(fs_uuid));
-        let mut thin_dev =
-            ThinDev::new(get_dm(), &dm_name, Some(&dm_uuid), size, thinpool_dev, id)?;
+        let mut thin_dev = ThinDev::new(
+            get_dm(),
+            &dm_name,
+            Some(&dm_uuid),
+            size,
+            thinpool_dev,
+            id,
+            Some(DmOptions::default()),
+        )?;
 
         if let Err(err) = create_fs(&thin_dev.devnode(), Some(StratisUuid::Fs(fs_uuid)), false) {
             if let Err(err2) = retry_with_index(Fixed::from_millis(100).take(4), |i| {
@@ -123,6 +130,7 @@ impl StratFilesystem {
             fssave.size,
             thinpool_dev,
             fssave.thin_id,
+            Some(DmOptions::default()),
         )?;
         Ok(StratFilesystem {
             used: init_used(&thin_dev),
@@ -192,6 +200,7 @@ impl StratFilesystem {
             snapshot_dm_uuid,
             thin_pool,
             snapshot_thin_id,
+            Some(DmOptions::default()),
         ) {
             Ok(thin_dev) => {
                 // If the source is mounted, XFS puts a dummy record in the

--- a/src/engine/strat_engine/thinpool/thinpool.rs
+++ b/src/engine/strat_engine/thinpool/thinpool.rs
@@ -354,6 +354,7 @@ impl ThinPool {
             &dm_name,
             Some(&dm_uuid),
             segs_to_table(backstore_device, &[meta_segments]),
+            Some(DmOptions::private()),
         )?;
 
         // Wipe the first 4 KiB, i.e. 8 sectors as recommended in kernel DM
@@ -371,6 +372,7 @@ impl ThinPool {
             &dm_name,
             Some(&dm_uuid),
             segs_to_table(backstore_device, &[data_segments]),
+            Some(DmOptions::private()),
         )?;
 
         let (dm_name, dm_uuid) = format_flex_ids(pool_uuid, FlexRole::MetadataVolume);
@@ -379,6 +381,7 @@ impl ThinPool {
             &dm_name,
             Some(&dm_uuid),
             segs_to_table(backstore_device, &[mdv_segments]),
+            Some(DmOptions::private()),
         )?;
         let mdv = MetadataVol::initialize(pool_uuid, mdv_dev)?;
 
@@ -403,6 +406,7 @@ impl ThinPool {
                 "no_discard_passdown".to_string(),
                 "skip_block_zeroing".to_string(),
             ],
+            Some(DmOptions::private()),
         )?;
 
         let thin_pool_status = thinpool_dev.status(get_dm(), DmOptions::default()).ok();
@@ -463,6 +467,7 @@ impl ThinPool {
             &dm_name,
             Some(&dm_uuid),
             segs_to_table(backstore_device, &data_segments),
+            Some(DmOptions::private()),
         )?;
 
         // TODO: Remove in stratisd 4.0.
@@ -492,6 +497,7 @@ impl ThinPool {
                         "error_if_no_space".to_owned(),
                     ]
                 }),
+            Some(DmOptions::private()),
         )?;
 
         // TODO: Remove in stratisd 4.0.
@@ -505,6 +511,7 @@ impl ThinPool {
             &dm_name,
             Some(&dm_uuid),
             segs_to_table(backstore_device, &mdv_segments),
+            Some(DmOptions::private()),
         )?;
         let mdv = MetadataVol::setup(pool_uuid, mdv_dev)?;
         let filesystem_metadatas = mdv.filesystems()?;
@@ -1672,6 +1679,7 @@ fn setup_metadev(
         &dm_name,
         Some(&dm_uuid),
         segs_to_table(device, &meta_segments),
+        Some(DmOptions::private()),
     )?;
 
     if !device_exists(get_dm(), thinpool_name)? {
@@ -1703,6 +1711,7 @@ fn attempt_thin_repair(
         &dm_name,
         Some(&dm_uuid),
         segs_to_table(device, spare_segments),
+        Some(DmOptions::private()),
     )?;
 
     thin_repair(&meta_dev.devnode(), &new_meta_dev.devnode())?;


### PR DESCRIPTION
Update Stratis to use the `create_options` argument when calling DM `new()` and `setup()` methods.