### PR TITLE
On UnlockPool, start the pool directly instead of relying on catching udev events

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -17,9 +17,10 @@ pub use self::{
         EncryptionInfo, EngineAction, FilesystemUuid, GrowAction, KeyDescription, Lockable,
         LockedPoolInfo, LockedPoolsInfo, MappingCreateAction, MappingDeleteAction,
         MaybeInconsistent, Name, PoolDiff, PoolEncryptionInfo, PoolIdentifier, PoolUuid,
-        PropChangeAction, RenameAction, ReportType, SetCreateAction, SetDeleteAction, StartAction,
-        StopAction, StoppedPoolInfo, StoppedPoolsInfo, StratBlockDevDiff, StratFilesystemDiff,
-        StratPoolDiff, StratisUuid, ThinPoolDiff, ToDisplay, UdevEngineEvent, UnlockMethod,
+        PropChangeAction, RenameAction, ReportType, SetCreateAction, SetDeleteAction,
+        SetUnlockAction, StartAction, StopAction, StoppedPoolInfo, StoppedPoolsInfo,
+        StratBlockDevDiff, StratFilesystemDiff, StratPoolDiff, StratisUuid, ThinPoolDiff,
+        ToDisplay, UdevEngineEvent, UnlockMethod,
     },
 };
 

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -112,7 +112,7 @@ pub fn get_devno_from_path(path: &Path) -> StratisResult<Device> {
 /// because they will not have the opportunity to be processed.
 pub fn find_stratis_devs_by_uuid(
     pool_uuid: PoolUuid,
-    uuids: Vec<DevUuid>,
+    uuids: &[DevUuid],
 ) -> StratisResult<HashMap<DevUuid, (DevicePath, Device)>> {
     let mut map = HashMap::new();
     if uuids.is_empty() {

--- a/src/engine/strat_engine/liminal/liminal.rs
+++ b/src/engine/strat_engine/liminal/liminal.rs
@@ -86,8 +86,8 @@ impl LiminalDevices {
         );
     }
 
-    /// Unlock the liminal encrypted devices that correspond to the given pool UUID.
-    pub fn unlock_pool(
+    // Unlock the liminal encrypted devices that correspond to the given pool UUID.
+    fn unlock_pool(
         &mut self,
         pools: &Table<PoolUuid, StratPool>,
         pool_uuid: PoolUuid,
@@ -178,7 +178,7 @@ impl LiminalDevices {
         pools: &Table<PoolUuid, StratPool>,
         id: PoolIdentifier<PoolUuid>,
         unlock_method: Option<UnlockMethod>,
-    ) -> StratisResult<(Name, PoolUuid, StratPool)> {
+    ) -> StratisResult<(Name, PoolUuid, StratPool, Vec<DevUuid>)> {
         let pool_uuid = match id {
             PoolIdentifier::Uuid(u) => u,
             PoolIdentifier::Name(n) => self
@@ -234,7 +234,7 @@ impl LiminalDevices {
             .iter()
             .map(|(dev_uuid, _)| *dev_uuid)
             .collect::<Vec<_>>();
-        match find_stratis_devs_by_uuid(pool_uuid, uuids) {
+        match find_stratis_devs_by_uuid(pool_uuid, &uuids) {
             Ok(infos) => infos.into_iter().for_each(|(dev_uuid, (path, devno))| {
                 if let Ok(Ok(Some(bda))) = bda_wrapper(&path) {
                     self.uuid_lookup
@@ -262,7 +262,7 @@ impl LiminalDevices {
         };
 
         match self.try_setup_pool(pools, pool_uuid, stopped_pool, handles) {
-            Ok((name, pool)) => Ok((name, pool_uuid, pool)),
+            Ok((name, pool)) => Ok((name, pool_uuid, pool, uuids)),
             Err(e) => Err(handle_unlock_rollback(e, all_uuids)),
         }
     }


### PR DESCRIPTION
Supercedes #3328 
Closes #3324 