### PR TITLE
dracut: remove dependency on plymouth

### DIFF
--- a/dracut/90stratis/module-setup.sh
+++ b/dracut/90stratis/module-setup.sh
@@ -12,7 +12,6 @@ check() {
 		xfs_growfs \
 		xfs_db \
 		udevadm \
-		/usr/bin/systemd-ask-password \
 		/usr/sbin/thin_metadata_size \
 		/usr/lib/udev/stratis-str-cmp \
 		/usr/lib/udev/stratis-base32-decode ||
@@ -22,7 +21,7 @@ check() {
 
 # called by dracut
 depends() {
-	echo dm
+	echo dm systemd-ask-password
 	return 0
 }
 
@@ -43,16 +42,12 @@ install() {
 		xfs_growfs \
 		xfs_db \
 		udevadm \
-		plymouth \
-		/usr/sbin/plymouthd \
 		/usr/sbin/thin_metadata_size \
 		/usr/lib/udev/stratis-base32-decode \
 		/usr/lib/udev/stratis-str-cmp
 
 	# Dracut dependencies
-	inst_multiple $systemdutildir/system-generators/stratis-setup-generator \
-		$systemdutildir/system/plymouth-start.service \
-		plymouth
+	inst_multiple $systemdutildir/system-generators/stratis-setup-generator
 
 	inst_rules "$moddir/61-stratisd.rules"
 	inst_simple "$moddir/stratisd-min.service" $systemdutildir/system/stratisd-min.service

--- a/dracut/90stratis/module-setup.sh
+++ b/dracut/90stratis/module-setup.sh
@@ -12,8 +12,7 @@ check() {
 		xfs_growfs \
 		xfs_db \
 		udevadm \
-		plymouth \
-		/usr/sbin/plymouthd \
+		/usr/bin/systemd-ask-password \
 		/usr/sbin/thin_metadata_size \
 		/usr/lib/udev/stratis-str-cmp \
 		/usr/lib/udev/stratis-base32-decode ||

--- a/dracut/90stratis/stratis-rootfs-setup
+++ b/dracut/90stratis/stratis-rootfs-setup
@@ -19,10 +19,9 @@ if $(stratis-min pool is-stopped "$STRATIS_ROOTFS_UUID"); then
 	if $(stratis-min pool is-encrypted "$STRATIS_ROOTFS_UUID"); then
 		ATTEMPTS_REMAINING=3
 		if
-			! while [ $((ATTEMPTS_REMAINING--)) -gt 0 ]
-			do
+			! while [ $((ATTEMPTS_REMAINING--)) -gt 0 ]; do
 				systemd-ask-password --id="stratis:$STRATIS_ROOTFS_UUID" "Enter password for Stratis pool with UUID $STRATIS_ROOTFS_UUID containing root filesystem" |
-				stratis-min pool start --prompt --unlock-method=keyring "$STRATIS_ROOTFS_UUID" && break
+					stratis-min pool start --prompt --unlock-method=keyring "$STRATIS_ROOTFS_UUID" && break
 			done
 		then
 			echo Failed to start pool with UUID $STRATIS_ROOTFS_UUID using a passphrase >&2

--- a/dracut/90stratis/stratis-rootfs-setup
+++ b/dracut/90stratis/stratis-rootfs-setup
@@ -17,10 +17,14 @@ done
 
 if $(stratis-min pool is-stopped "$STRATIS_ROOTFS_UUID"); then
 	if $(stratis-min pool is-encrypted "$STRATIS_ROOTFS_UUID"); then
-		if ! plymouth ask-for-password \
-			--command="stratis-min pool start --prompt --unlock-method=keyring $STRATIS_ROOTFS_UUID" \
-			--prompt="Enter password for Stratis pool with UUID $STRATIS_ROOTFS_UUID containing root filesystem" \
-			--number-of-tries=3; then
+		ATTEMPTS_REMAINING=3
+		if
+			! while [ $((ATTEMPTS_REMAINING--)) -gt 0 ]
+			do
+				systemd-ask-password --id="stratis:$STRATIS_ROOTFS_UUID" "Enter password for Stratis pool with UUID $STRATIS_ROOTFS_UUID containing root filesystem" |
+				stratis-min pool start --prompt --unlock-method=keyring "$STRATIS_ROOTFS_UUID" && break
+			done
+		then
 			echo Failed to start pool with UUID $STRATIS_ROOTFS_UUID using a passphrase >&2
 			exit 1
 		fi


### PR DESCRIPTION
I'm adding stratis root fs support on the NixOS distribution, and they asked me to make it work without plymouth, so I've replaced that with systemd-ask-password. 