### PR TITLE
Version 3.5.6

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -58,5 +58,5 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=rawhide IGNORE_ARGS="--ignore-category low --ignore-high=libcryptsetup-rs" make -f Makefile_dependencies check-fedora-versions
+          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f38 IGNORE_ARGS="--ignore-category low --ignore-high=libcryptsetup-rs" make -f Makefile_dependencies check-fedora-versions
           COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f37 IGNORE_ARGS="--ignore-category low --ignore-high=libcryptsetup-rs" make -f Makefile_dependencies check-fedora-versions
-          COMPARE_FEDORA_VERSIONS=./ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f36 IGNORE_ARGS="--ignore-category low --ignore-high=libcryptsetup-rs" make -f Makefile_dependencies check-fedora-versions

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,24 @@
+stratisd 3.5.6
+==============
+Recommended Rust toolchain version: 1.69.0
+Lowest supported Rust toolchain version: 1.66.1
+
+Recommended development platform for Python development: Fedora 38
+
+- Cherry-picked commits:
+  * Advance compare_fedora_versions Fedora versions arguments
+  * Remove unnecessary Unpin constraints in futures
+  * Avoid double acquisition of CryptDevice when reading metadata
+  * Return an error if there is no unlock method
+  * Return an error if no unlock method after initialization
+  * Increase libcryptsetup-rs dependency lower bound to 0.7.1
+  * Increase libcryptsetup-rs dependency lower bound to 0.8.0
+
+- Tidies and Maintenance:
+  * Add missing PR entry in changelog for stratisd 3.5.5
+  * Add list of cherry-picked commits for stratisd 3.5.5
+
+
 stratisd 3.5.5
 ==============
 Recommended Rust toolchain version: 1.69.0

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,11 @@ stratisd 3.5.5
 Recommended Rust toolchain version: 1.69.0
 Lowest supported Rust toolchain version: 1.66.1
 
+Recommended development platform for Python development: Fedora 38
+
+- Set up patch branch:
+  https://github.com/stratis-storage/stratisd/issues/3344
+
 
 stratisd 3.5.4
 ==============

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,18 @@ Lowest supported Rust toolchain version: 1.66.1
 
 Recommended development platform for Python development: Fedora 38
 
+- Cherry-picked commits:
+  * Patch Cargo.toml to avoid loopdev FTBFS
+  * Update recommended Rust to 1.69.0
+  * Advance current development environment to Fedora 38
+  * Increase libcryptsetup-rs dependency lower bound to 0.7.0
+  * Exclude a few more files from crate
+  * Use SPDX license string
+  * Include license header in source code files
+  * Include license header in build.rs
+  * Ensure persistent keyring is attached before Clevis bind
+  * Increase libc dependency lower bound to 0.2.142
+
 - Set up patch branch:
   https://github.com/stratis-storage/stratisd/issues/3344
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,9 +722,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5135abfc7c15f611c4976eebabee836c3dbfb8b0a71cdcf1e95ce22ec7b83c"
+checksum = "54de25d80cf59c099a01fc9939251bbf8021c131adf97beb7d57c094b16ed474"
 dependencies = [
  "bitflags",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -98,7 +104,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -159,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
  "once_cell",
@@ -171,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -210,12 +216,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
  "num-traits",
  "winapi",
 ]
@@ -233,18 +239,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [
  "anstream",
  "anstyle",
@@ -255,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colorchoice"
@@ -307,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "dbus"
@@ -369,9 +375,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -514,7 +520,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -629,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -716,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
 
 [[package]]
 name = "libcryptsetup-rs"
@@ -782,7 +788,7 @@ checksum = "23c4c2ad2d5cbd2f5a05620c3daf45930add53ec207fa99ce5eec971089dc35f"
 dependencies = [
  "libc",
  "nix 0.14.1",
- "quick-error 1.2.3",
+ "quick-error",
 ]
 
 [[package]]
@@ -807,18 +813,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "loopdev"
@@ -853,14 +856,13 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -907,16 +909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "peeking_take_while"
@@ -1011,25 +1003,24 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
  "rand",
  "rand_chacha",
  "rand_xorshift",
@@ -1046,16 +1037,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1110,13 +1095,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1133,9 +1118,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "retry"
@@ -1183,7 +1168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -1214,7 +1199,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1355,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1394,9 +1379,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "libc",
@@ -1417,7 +1402,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1434,9 +1419,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "utf8parse"
@@ -1502,7 +1487,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -1524,7 +1509,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratisd"
-version = "3.5.5"
+version = "3.5.6"
 dependencies = [
  "assert_cmd",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,9 +722,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9bf2004df62b9820328e6a2ffa603b694ac2cb4d683057fb58938c38ba9abd"
+checksum = "ce5135abfc7c15f611c4976eebabee836c3dbfb8b0a71cdcf1e95ce22ec7b83c"
 dependencies = [
  "bitflags",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ version = "0.2.142"
 optional = true
 
 [dependencies.libcryptsetup-rs]
-version = "0.7.0"
+version = "0.7.1"
 features = ["mutex"]
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ version = "0.2.142"
 optional = true
 
 [dependencies.libcryptsetup-rs]
-version = "0.7.1"
+version = "0.8.0"
 features = ["mutex"]
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratisd"
-version = "3.5.5"
+version = "3.5.6"
 authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.org>"]
 edition = "2021"
 rust-version = "1.66.1"  # LOWEST SUPPORTED RUST TOOLCHAIN

--- a/src/engine/strat_engine/backstore/crypt/handle.rs
+++ b/src/engine/strat_engine/backstore/crypt/handle.rs
@@ -424,7 +424,10 @@ impl CryptHandle {
 
     /// Load the required information for Stratis from the LUKS2 metadata.
     pub fn load_metadata(physical_path: &Path) -> StratisResult<Option<CryptMetadata>> {
-        load_crypt_metadata(physical_path)
+        match setup_crypt_device(physical_path)? {
+            Some(ref mut device) => load_crypt_metadata(device, physical_path),
+            None => Ok(None),
+        }
     }
 
     /// Get the encryption info for this encrypted device.

--- a/src/engine/strat_engine/backstore/crypt/handle.rs
+++ b/src/engine/strat_engine/backstore/crypt/handle.rs
@@ -205,8 +205,15 @@ impl CryptHandle {
             .and_then(|path| clevis_info_from_metadata(&mut device).map(|ci| (path, ci)))
             .and_then(|(_, clevis_info)| {
                 let encryption_info =
-                    EncryptionInfo::from_options((encryption_info.key_description().cloned(), clevis_info))
-                        .expect("Encrypted device must be provided encryption parameters");
+                    if let Some(info) = EncryptionInfo::from_options((encryption_info.key_description().cloned(), clevis_info)) {
+                        info
+                    } else {
+                        return Err(StratisError::Msg(format!(
+                            "No valid encryption method that can be used to unlock device {} found after initialization",
+                            physical_path.display()
+                        )));
+                    };
+
                 let device_path = DevicePath::new(physical_path)?;
                 let devno = get_devno_from_path(physical_path)?;
                 Ok(CryptHandle::new(

--- a/src/engine/strat_engine/backstore/crypt/shared.rs
+++ b/src/engine/strat_engine/backstore/crypt/shared.rs
@@ -402,8 +402,15 @@ pub fn load_crypt_metadata(
     };
     let clevis_info = clevis_info_from_metadata(device)?;
 
-    let encryption_info = EncryptionInfo::from_options((key_description, clevis_info))
-        .expect("Must have at least one unlock method");
+    let encryption_info =
+        if let Some(info) = EncryptionInfo::from_options((key_description, clevis_info)) {
+            info
+        } else {
+            return Err(StratisError::Msg(format!(
+                "No valid encryption method that can be used to unlock device {} found",
+                physical_path.display()
+            )));
+        };
 
     let path = vec![DEVICEMAPPER_PATH, &activation_name.to_string()]
         .into_iter()

--- a/src/engine/strat_engine/backstore/crypt/shared.rs
+++ b/src/engine/strat_engine/backstore/crypt/shared.rs
@@ -370,18 +370,16 @@ pub fn setup_crypt_device(physical_path: &Path) -> StratisResult<Option<CryptDev
 }
 
 /// Load crypt device metadata.
-pub fn load_crypt_metadata(physical_path: &Path) -> StratisResult<Option<CryptMetadata>> {
+pub fn load_crypt_metadata(
+    device: &mut CryptDevice,
+    physical_path: &Path,
+) -> StratisResult<Option<CryptMetadata>> {
     let physical = DevicePath::new(physical_path)?;
 
-    let mut device = match setup_crypt_device(physical_path)? {
-        Some(d) => d,
-        None => return Ok(None),
-    };
-
-    let identifiers = identifiers_from_metadata(&mut device)?;
-    let activation_name = activation_name_from_metadata(&mut device)?;
-    let pool_name = pool_name_from_metadata(&mut device)?;
-    let key_description = key_desc_from_metadata(&mut device);
+    let identifiers = identifiers_from_metadata(device)?;
+    let activation_name = activation_name_from_metadata(device)?;
+    let pool_name = pool_name_from_metadata(device)?;
+    let key_description = key_desc_from_metadata(device);
     let devno = get_devno_from_path(physical_path)?;
     let key_description = match key_description
         .as_ref()
@@ -402,7 +400,7 @@ pub fn load_crypt_metadata(physical_path: &Path) -> StratisResult<Option<CryptMe
         }
         None => None,
     };
-    let clevis_info = clevis_info_from_metadata(&mut device)?;
+    let clevis_info = clevis_info_from_metadata(device)?;
 
     let encryption_info = EncryptionInfo::from_options((key_description, clevis_info))
         .expect("Must have at least one unlock method");
@@ -429,7 +427,7 @@ pub fn setup_crypt_handle(
     physical_path: &Path,
     unlock_method: Option<UnlockMethod>,
 ) -> StratisResult<Option<CryptHandle>> {
-    let metadata = match load_crypt_metadata(physical_path)? {
+    let metadata = match load_crypt_metadata(device, physical_path)? {
         Some(m) => m,
         None => return Ok(None),
     };

--- a/src/engine/structures/lock.rs
+++ b/src/engine/structures/lock.rs
@@ -520,8 +520,7 @@ impl<U, T> Clone for AllOrSomeLock<U, T> {
 
 impl<U, T> AllOrSomeLock<U, T>
 where
-    U: AsUuid + Unpin,
-    T: Unpin,
+    U: AsUuid,
 {
     /// Issue a read on a single element identified by a name or UUID.
     pub async fn read(&self, key: PoolIdentifier<U>) -> Option<SomeLockReadGuard<U, T>> {
@@ -582,8 +581,7 @@ struct SomeRead<U: AsUuid, T>(AllOrSomeLock<U, T>, PoolIdentifier<U>, AtomicBool
 
 impl<U, T> Future for SomeRead<U, T>
 where
-    U: AsUuid + Unpin,
-    T: Unpin,
+    U: AsUuid,
 {
     type Output = Option<SomeLockReadGuard<U, T>>;
 
@@ -689,8 +687,7 @@ struct SomeWrite<U: AsUuid, T>(AllOrSomeLock<U, T>, PoolIdentifier<U>, AtomicBoo
 
 impl<U, T> Future for SomeWrite<U, T>
 where
-    U: AsUuid + Unpin,
-    T: Unpin,
+    U: AsUuid,
 {
     type Output = Option<SomeLockWriteGuard<U, T>>;
 


### PR DESCRIPTION
Maintenance or non-conflicting fixes from main development branch. Candidate commits that I chose to omit from this PR were:

* Remove rpassword dependency: https://github.com/stratis-storage/stratisd/commit/8ade99c329cddbf1f898d40957b735219077245a, because there were some mild conflicts and because the commit introduces a whole new method for obtaining a passord.
* Wrap liminal device invocation in blocking spawn: https://github.com/stratis-storage/stratisd/commit/19d3f794ab566ff9a152deaec04b1a8d53e7fe46 because there was a bunch of conflict.

I could be persuaded into including either, if the reasons are compelling enough.

