### PR TITLE
README: update IRC network

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Development mailing list: stratis-devel@lists.fedorahosted.org, -- subscribe
 
 #### IRC
 
-irc.freenode.net #stratis-storage.
+irc.libera.chat #stratis-storage.
 
 ## For Developers
 


### PR DESCRIPTION
I assume stratis-storage is no longer on Freenode, as there is a channel on libera.chat.