### PR TITLE
Regression test for CryptHandle unlocking with both keyring and Clevis enabled

### DIFF
--- a/src/engine/strat_engine/backstore/crypt/mod.rs
+++ b/src/engine/strat_engine/backstore/crypt/mod.rs
@@ -380,9 +380,17 @@ mod tests {
                 .token_handle()
                 .json_get(CLEVIS_LUKS_TOKEN_ID)
                 .unwrap();
+            handle.deactivate().unwrap();
         }
 
-        crypt::insert_and_cleanup_key(paths, both_initialize);
+        fn unlock_clevis(paths: &[&Path]) {
+            let path = paths.get(0).copied().expect("Expected exactly one path");
+            CryptHandle::setup(path, Some(UnlockMethod::Clevis))
+                .unwrap()
+                .unwrap();
+        }
+
+        crypt::insert_and_remove_key(paths, both_initialize, unlock_clevis);
     }
 
     #[test]

--- a/src/engine/strat_engine/backstore/crypt/shared.rs
+++ b/src/engine/strat_engine/backstore/crypt/shared.rs
@@ -756,7 +756,7 @@ pub fn activate(
     unlock_method: UnlockMethod,
     name: &DmName,
 ) -> StratisResult<()> {
-    if let Some(kd) = key_desc {
+    if let (Some(kd), UnlockMethod::Keyring) = (key_desc, unlock_method) {
         let key_description_missing = keys::search_key_persistent(kd)
             .map_err(|_| {
                 StratisError::Msg(format!(


### PR DESCRIPTION
Related to #3485 
bz https://bugzilla.redhat.com/show_bug.cgi?id=2246920