### PR TITLE
Run cockpit storage tests in PRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,6 +33,25 @@ jobs:
           - fedora-rawhide
 
     - job: tests
+      identifier: local
       trigger: pull_request
       targets:
           - fedora-rawhide
+
+    # run Cockpit storage tests, see plans/ with `cockpit == yes`
+    - job: tests
+      identifier: cockpit
+      trigger: pull_request
+      notifications:
+        failure_comment:
+          message: "Cockpit tests failed for commit {commit_sha}. @martinpitt, @jelly, @mvollmer please check."
+      targets:
+      - fedora-development
+      tf_extra_params:
+        environments:
+          - artifacts:
+            - type: repository-file
+              id: https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/repo/fedora-$releasever/group_cockpit-main-builds-fedora-$releasever.repo
+            tmt:
+              context:
+                plan: "cockpit"

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,4 +1,9 @@
 summary: top level management
+
+adjust:
+  when: plan == cockpit
+  enabled: false
+
 prepare:
   - name: Install packages
     how: install

--- a/plans/cockpit.fmf
+++ b/plans/cockpit.fmf
@@ -1,0 +1,20 @@
+# reverse dependency test for https://github.com/cockpit-project/cockpit
+# packit should automatically notify the cockpit maintainers on failures.
+# For questions, please contact @martinpitt, @jelly, @mvollmer
+
+enabled: false
+adjust:
+  when: plan == cockpit
+  enabled: true
+
+discover:
+    how: fmf
+    url: https://github.com/cockpit-project/cockpit
+    ref: main
+execute:
+    how: tmt
+
+/optional:
+    summary: Run tests for optional packages (including storage)
+    discover+:
+        test: /test/browser/optional


### PR DESCRIPTION
This provides additional API/regression validation for stratisd PRs.

See https://cockpit-project.org/blog/tmt-cross-project-testing.html

Fixes https://issues.redhat.com/browse/COCKPIT-1070

-----

When done seriously, this is an ongoing commitment. We found a [couple of stratis bugs/regressions](https://github.com/cockpit-project/bots/issues?q=is%3Aissue+label%3Aknownissue+stratis) so far, like 
https://github.com/stratis-storage/stratisd/issues/3348 or the regression fixed by # 3486. With this setup, we have a good chance of prevent landing such regressions.

This approach is still fairly new, so let's treat this as an experiment. We do need to talk about commitments and expectations, though. From our side, I propose:

 * We don't expect you to become experts in our tests. When they fail, it would be nice if you could have a quick look at the log and see if it's something obvious. But in general, we expect that someone from our team will investigate and discuss that with you. The PR where that happened provides a nice place to collect notes.

 * Whenever one of our tests fail, three of our team members will be notified by packit automatically, so that we can timely investigate them. However, when your own tests fail as well, I propose that you fix them first, and we only get active if *only* the cockpit tests fail.

 * We don't expect you to block PRs on these tests, especially not if the testing farm has [infrastructure problems](https://artifacts.dev.testing-farm.io/1887dce2-fc0b-46ac-b8c3-78658d6af08b/) . E.g. sometimes they to run into provisioning errors. Just ignore these then -- we see them too in our projects, and will usually prod #testing-farm then. But as you already run your own tests on TF, you should be familiar with this, and such outages will affect current PRs already.

 * We would like you to at least give us a chance on that workday to look at a failed test (not infra failure, a "real" one) before you land a PR, so that this all makes sense. If something is urgent and you quick-land, then at least we still retain the benefit of having a trace in which PR tests started to fail, but then the damage is possibly already done. Note that this isn't a big new commitment from our side: we already spend many hours every week looking at regressions, and it takes a lot more effort to track them down weeks after they happened. So this will acually *reduce* both our and your time spent on hunting down regressions, because the context (PR) is fresh and small, as opposed to "whatever changed in Fedora in the last 4 weeks".

Please let me know about any other question that you may have. I'm happy to discuss them here or in a gmeet for higher bandwidth.

Thanks!