### PR TITLE
Do not suppress output via command-line option for mkfs.xfs or thin_check

### DIFF
--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -342,11 +342,7 @@ pub fn set_uuid(devnode: &Path, uuid: FilesystemUuid) -> StratisResult<()> {
 
 /// Call thin_check on a thinpool
 pub fn thin_check(devnode: &Path) -> StratisResult<()> {
-    execute_cmd(
-        Command::new(get_executable(THIN_CHECK).as_os_str())
-            .arg("-q")
-            .arg(devnode),
-    )
+    execute_cmd(Command::new(get_executable(THIN_CHECK).as_os_str()).arg(devnode))
 }
 
 /// Call thin_repair on a thinpool

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -299,7 +299,6 @@ pub fn create_fs(devnode: &Path, uuid: Option<StratisUuid>) -> StratisResult<()>
 
     let mut command = Command::new(get_executable(MKFS_XFS).as_os_str());
     command.arg("-f");
-    command.arg("-q");
     command.arg(devnode);
 
     if let Some(uuid) = uuid {


### PR DESCRIPTION
Related #3520 