### PR TITLE
Use total size when calculating integrity metadata

### DIFF
--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -108,12 +108,10 @@ impl DataTier<v2::StratBlockDev> {
     pub fn new(mut block_mgr: BlockDevMgr<v2::StratBlockDev>) -> DataTier<v2::StratBlockDev> {
         for (_, bd) in block_mgr.blockdevs_mut() {
             bd.alloc_raid_meta(raid_meta_space());
-            bd.alloc_int_meta_back(integrity_meta_space(
-                // NOTE: Subtracting metadata size works here because the only metadata currently
-                // recorded in a newly created block device is the BDA. If this becomes untrue in
-                // the future, this code will no longer work.
-                bd.total_size().sectors() - bd.metadata_size(),
-            ));
+            // NOTE: over-allocates integrity metadata slightly. Some of the
+            // total size of the device will not make use of the integrity
+            // metadata.
+            bd.alloc_int_meta_back(integrity_meta_space(bd.total_size().sectors()));
         }
         DataTier {
             block_mgr,


### PR DESCRIPTION
Related #3637 