### PR TITLE
Remove preallocation of RAID metadata

### DIFF
--- a/src/bin/utils/predict_usage.rs
+++ b/src/bin/utils/predict_usage.rs
@@ -13,9 +13,7 @@ use serde_json::{json, Value};
 
 use devicemapper::{Bytes, Sectors};
 
-use stratisd::engine::{
-    crypt_metadata_size, integrity_meta_space, raid_meta_space, ThinPoolSizeParams, BDA,
-};
+use stratisd::engine::{crypt_metadata_size, integrity_meta_space, ThinPoolSizeParams, BDA};
 
 // 2^FS_SIZE_START_POWER is the logical size of the smallest Stratis
 // filesystem for which usage data exists in FSSizeLookup::internal, i.e.,
@@ -164,7 +162,6 @@ pub fn predict_filesystem_usage(
 }
 
 fn predict_pool_metadata_usage(device_sizes: Vec<Sectors>) -> Result<Sectors, Box<dyn Error>> {
-    let raid_metadata_alloc = raid_meta_space();
     let stratis_metadata_alloc = BDA::default().extended_size().sectors();
     let stratis_avail_sizes = device_sizes
         .iter()
@@ -178,9 +175,7 @@ fn predict_pool_metadata_usage(device_sizes: Vec<Sectors>) -> Result<Sectors, Bo
             );
 
             info!("Deduction for integrity space: {:}", integrity_deduction);
-            info!("Deduction for raid space: {:}", raid_metadata_alloc);
             (*s).checked_sub(*stratis_metadata_alloc)
-                .and_then(|r| r.checked_sub(*raid_metadata_alloc))
                 .and_then(|r| r.checked_sub(*integrity_deduction))
                 .map(Sectors)
                 .map(|x| {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,10 +10,9 @@ pub use self::{
     shared::{total_allocated, total_used},
     sim_engine::SimEngine,
     strat_engine::{
-        crypt_metadata_size, get_dm, get_dm_init, integrity_meta_space, raid_meta_space,
-        register_clevis_token, set_up_crypt_logging, unshare_mount_namespace, StaticHeader,
-        StaticHeaderResult, StratEngine, StratKeyActions, ThinPoolSizeParams, BDA,
-        CLEVIS_TANG_TRUST_URL,
+        crypt_metadata_size, get_dm, get_dm_init, integrity_meta_space, register_clevis_token,
+        set_up_crypt_logging, unshare_mount_namespace, StaticHeader, StaticHeaderResult,
+        StratEngine, StratKeyActions, ThinPoolSizeParams, BDA, CLEVIS_TANG_TRUST_URL,
     },
     structures::{AllLockReadGuard, ExclusiveGuard, SharedGuard, Table},
     types::{

--- a/src/engine/strat_engine/backstore/blockdev/v1.rs
+++ b/src/engine/strat_engine/backstore/blockdev/v1.rs
@@ -605,7 +605,6 @@ impl Recordable<BaseBlockDevSave> for StratBlockDev {
             uuid: self.uuid(),
             user_info: self.user_info.clone(),
             hardware_info: self.hardware_info.clone(),
-            raid_meta_allocs: Vec::new(),
             integrity_meta_allocs: Vec::new(),
         }
     }

--- a/src/engine/strat_engine/backstore/data_tier.rs
+++ b/src/engine/strat_engine/backstore/data_tier.rs
@@ -15,7 +15,7 @@ use crate::{
             backstore::{
                 blockdev::{
                     v1,
-                    v2::{self, integrity_meta_space, raid_meta_space},
+                    v2::{self, integrity_meta_space},
                     InternalBlockDev,
                 },
                 blockdevmgr::BlockDevMgr,
@@ -107,7 +107,6 @@ impl DataTier<v2::StratBlockDev> {
     /// WARNING: metadata changing event
     pub fn new(mut block_mgr: BlockDevMgr<v2::StratBlockDev>) -> DataTier<v2::StratBlockDev> {
         for (_, bd) in block_mgr.blockdevs_mut() {
-            bd.alloc_raid_meta(raid_meta_space());
             // NOTE: over-allocates integrity metadata slightly. Some of the
             // total size of the device will not make use of the integrity
             // metadata.
@@ -142,7 +141,6 @@ impl DataTier<v2::StratBlockDev> {
             .collect::<Vec<_>>();
         assert_eq!(bds.len(), uuids.len());
         for bd in bds {
-            bd.alloc_raid_meta(raid_meta_space());
             bd.alloc_int_meta_back(integrity_meta_space(
                 // NOTE: Subtracting metadata size works here because the only metadata currently
                 // recorded in a newly created block device is the BDA. If this becomes untrue in

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -837,7 +837,7 @@ pub fn initialize_devices(
 
         bda.initialize(&mut f)?;
 
-        v2::StratBlockDev::new(devno, bda, &[], &[], &[], None, hw_id, devnode).map_err(|(e, _)| e)
+        v2::StratBlockDev::new(devno, bda, &[], &[], None, hw_id, devnode).map_err(|(e, _)| e)
     }
 
     /// Clean up an unencrypted device after initialization failure.

--- a/src/engine/strat_engine/backstore/mod.rs
+++ b/src/engine/strat_engine/backstore/mod.rs
@@ -13,7 +13,7 @@ mod range_alloc;
 mod shared;
 
 pub use self::{
-    blockdev::v2::{integrity_meta_space, raid_meta_space},
+    blockdev::v2::integrity_meta_space,
     devices::{find_stratis_devs_by_uuid, get_devno_from_path, ProcessedPathInfos, UnownedDevices},
 };
 

--- a/src/engine/strat_engine/liminal/setup.rs
+++ b/src/engine/strat_engine/liminal/setup.rs
@@ -547,7 +547,6 @@ fn get_blockdev(
     // conclusion is metadata corruption.
     let segments = segment_table.get(&dev_uuid);
     let meta = data_map.get(&dev_uuid);
-    let raid = meta.map(|base| &base.1.raid_meta_allocs);
     let integrity = meta.map(|base| &base.1.integrity_meta_allocs);
 
     assert_eq!(info.luks, None);
@@ -557,7 +556,6 @@ fn get_blockdev(
             info.dev_info.device_number,
             bda,
             segments.unwrap_or(&vec![]),
-            raid.unwrap_or(&vec![]),
             integrity.unwrap_or(&vec![]),
             bd_save.user_info.clone(),
             bd_save.hardware_info.clone(),

--- a/src/engine/strat_engine/mod.rs
+++ b/src/engine/strat_engine/mod.rs
@@ -26,7 +26,7 @@ mod writing;
 pub use self::{backstore::ProcessedPathInfos, pool::v1::StratPool};
 
 pub use self::{
-    backstore::{integrity_meta_space, raid_meta_space},
+    backstore::integrity_meta_space,
     crypt::{
         crypt_metadata_size, register_clevis_token, set_up_crypt_logging, CLEVIS_TANG_TRUST_URL,
     },

--- a/src/engine/strat_engine/serde_structs.rs
+++ b/src/engine/strat_engine/serde_structs.rs
@@ -137,9 +137,6 @@ pub struct BaseBlockDevSave {
     pub uuid: DevUuid,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
-    pub raid_meta_allocs: Vec<(Sectors, Sectors)>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
     pub integrity_meta_allocs: Vec<(Sectors, Sectors)>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(serialize_with = "serialize_option_string")]


### PR DESCRIPTION
I'm going to put up the integrity metadata allocation profile work in a separate PR.