### PR TITLE
Give better error message on Clevis unlock failure

### DIFF
--- a/src/engine/strat_engine/crypt/handle/v1.rs
+++ b/src/engine/strat_engine/crypt/handle/v1.rs
@@ -41,9 +41,9 @@ use crate::{
                     TOKEN_TYPE_KEY,
                 },
                 shared::{
-                    acquire_crypt_device, activate, add_keyring_keyslot, check_luks2_token,
-                    clevis_info_from_metadata, device_from_physical_path, ensure_inactive,
-                    ensure_wiped, get_keyslot_number, interpret_clevis_config,
+                    acquire_crypt_device, activate, activate_by_token, add_keyring_keyslot,
+                    check_luks2_token, clevis_info_from_metadata, device_from_physical_path,
+                    ensure_inactive, ensure_wiped, get_keyslot_number, interpret_clevis_config,
                     key_desc_from_metadata, luks2_token_type_is_valid, read_key, wipe_fallback,
                 },
             },
@@ -520,11 +520,11 @@ impl CryptHandle {
             }
             if try_unlock_clevis {
                 log_on_failure!(
-                    device.token_handle().activate_by_token::<()>(
+                    activate_by_token(
+                        &mut device,
                         None,
                         Some(CLEVIS_LUKS_TOKEN_ID),
-                        None,
-                        CryptActivate::empty(),
+                        CryptActivate::empty()
                     ),
                     "libcryptsetup reported that the decrypted Clevis passphrase \
                     is unable to open the encrypted device"

--- a/src/engine/strat_engine/crypt/handle/v2.rs
+++ b/src/engine/strat_engine/crypt/handle/v2.rs
@@ -37,10 +37,10 @@ use crate::{
                     LUKS2_TOKEN_ID, STRATIS_MEK_SIZE,
                 },
                 shared::{
-                    acquire_crypt_device, activate, add_keyring_keyslot, clevis_info_from_metadata,
-                    device_from_physical_path, ensure_wiped, get_keyslot_number,
-                    interpret_clevis_config, key_desc_from_metadata, luks2_token_type_is_valid,
-                    wipe_fallback,
+                    acquire_crypt_device, activate, activate_by_token, add_keyring_keyslot,
+                    clevis_info_from_metadata, device_from_physical_path, ensure_wiped,
+                    get_keyslot_number, interpret_clevis_config, key_desc_from_metadata,
+                    luks2_token_type_is_valid, wipe_fallback,
                 },
             },
             device::blkdev_size,
@@ -757,12 +757,7 @@ impl CryptHandle {
             None => 0,
         };
         let mut crypt = self.acquire_crypt_device()?;
-        crypt.token_handle().activate_by_token::<()>(
-            None,
-            None,
-            None,
-            CryptActivate::KEYRING_KEY,
-        )?;
+        activate_by_token(&mut crypt, None, None, CryptActivate::KEYRING_KEY)?;
         crypt
             .context_handle()
             .resize(&self.activation_name().to_string(), processed_size)


### PR DESCRIPTION
This PR fixes a bug in our clevis decrypt command where it reported success in failure cases and also provides better error messages to the user when the failure occurs.

cc @martinpitt 