### PR TITLE
Increase libcryptsetup-rs dependency lower bound to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,9 +698,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5083eeb8843b0295aba9a3ddda83b35097bc0f367cb6d9db793a1435e3eee6c"
+checksum = "186b5b6114517ab1d6e25741c6fb21060aae750e70868842efc9dd1efd08baa1"
 dependencies = [
  "bitflags 2.4.0",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ version = "0.2.155"
 optional = true
 
 [dependencies.libcryptsetup-rs]
-version = "0.11.2"
+version = "0.12.0"
 features = ["mutex"]
 optional = true
 


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/748