### PR TITLE
Increase libcryptsetup-rs dependency lower bound to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ version = "0.2.155"
 optional = true
 
 [dependencies.libcryptsetup-rs]
-version = ">=0.11.2,<0.13.0"
+version = "0.12.0"
 features = ["mutex"]
 optional = true
 


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/748