### PR TITLE
Increase libblkid-rs dependency lower bound to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ version = "0.14.0"
 optional = true
 
 [dependencies.libblkid-rs]
-version = ">=0.3.2,<0.5.0"
+version = "0.4.0"
 optional = true
 
 [dependencies.libc]


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/748