### PR TITLE
Increase GitHub Action checkout version to v5

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -51,11 +51,11 @@ jobs:
         with:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: stratisd
       - name: Check out ci repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ci
           repository: stratis-storage/ci

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -54,11 +54,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: stratisd
+          persist-credentials: false
       - name: Check out ci repo
         uses: actions/checkout@v5
         with:
           path: ci
           repository: stratis-storage/ci
+          persist-credentials: false
       - name: Run comparisons of macro version specs with Fedora packages
         # yamllint disable rule:line-length
         run: |

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -100,6 +100,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
@@ -142,6 +144,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd
@@ -193,6 +197,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
@@ -141,7 +141,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd
@@ -192,7 +192,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: typos-cli
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
         run: ${{ matrix.task }}
 
@@ -110,7 +110,7 @@ jobs:
         with:
           components: cargo
           toolchain: 1.77.0  # LOWEST SUPPORTED RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: stratisd
       - name: Overwrite stratisd dependencies as necessary
@@ -176,7 +176,7 @@ jobs:
         with:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Run stratisd-min cli tests
@@ -198,7 +198,7 @@ jobs:
           make
           ncurses
           shfmt
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run shell check
         run: make -f Makefile fmt-shell-ci
 
@@ -218,7 +218,7 @@ jobs:
           python3-dbus
       - name: Install pyright
         run: pip install --user pyright
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run lint
         run: >
           PATH=${PATH}:/github/home/.local/bin
@@ -254,7 +254,7 @@ jobs:
         with:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd
@@ -306,7 +306,7 @@ jobs:
         with:
           components: cargo
           toolchain: 1.77.0  # LOWEST SUPPORTED RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: stratisd
       - name: Overwrite stratisd dependencies as necessary

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           crate: typos-cli
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
         run: ${{ matrix.task }}
 
@@ -113,6 +115,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: stratisd
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
         with:
@@ -177,6 +180,8 @@ jobs:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Run stratisd-min cli tests
@@ -199,6 +204,8 @@ jobs:
           ncurses
           shfmt
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Run shell check
         run: make -f Makefile fmt-shell-ci
 
@@ -219,6 +226,8 @@ jobs:
       - name: Install pyright
         run: pip install --user pyright
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Run lint
         run: >
           PATH=${PATH}:/github/home/.local/bin
@@ -255,6 +264,8 @@ jobs:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd
@@ -309,6 +320,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: stratisd
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
         run: ${{ matrix.task }}
 
@@ -72,7 +72,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run cargo-update
         run: cargo update
       - name: Build all targets
@@ -117,7 +117,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-auditable
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run matrix task
         run: ${{ matrix.task }}
 
@@ -146,11 +146,11 @@ jobs:
         with:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: stratisd
       - name: Check out ci repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ci
           repository: stratis-storage/ci
@@ -208,7 +208,7 @@ jobs:
         with:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
         run: ${{ matrix.task }}
 
@@ -73,6 +75,8 @@ jobs:
         with:
           crate: cargo-audit
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Run cargo-update
         run: cargo update
       - name: Build all targets
@@ -118,6 +122,8 @@ jobs:
         with:
           crate: cargo-auditable
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Run matrix task
         run: ${{ matrix.task }}
 
@@ -149,11 +155,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: stratisd
+          persist-credentials: false
       - name: Check out ci repo
         uses: actions/checkout@v5
         with:
           path: ci
           repository: stratis-storage/ci
+          persist-credentials: false
       - name: Run comparisons of macro version specs with Fedora packages
         # yamllint disable rule:line-length
         run: |
@@ -209,6 +217,8 @@ jobs:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd

--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Install pyright
         run: pip install --user pyright
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Run test
         run: ${{ matrix.task }}
         working-directory: ${{ matrix.working-directory }}

--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -71,7 +71,7 @@ jobs:
           ${{ matrix.dependencies }}
       - name: Install pyright
         run: pip install --user pyright
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run test
         run: ${{ matrix.task }}
         working-directory: ${{ matrix.working-directory }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -103,6 +103,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
@@ -148,6 +150,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
@@ -147,7 +147,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Overwrite stratisd dependencies as necessary
         uses: stratis-storage/github-actions/stratisd-modify@HEAD
       - name: Build stratisd

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
         run: ${{ matrix.task }}
 
@@ -91,7 +91,7 @@ jobs:
         with:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd
@@ -145,7 +145,7 @@ jobs:
         with:
           components: cargo
           toolchain: ${{ matrix.toolchain }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd
@@ -209,7 +209,7 @@ jobs:
         with:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -52,6 +52,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Test ${{ matrix.task }} on ${{ matrix.toolchain }} toolchain
         run: ${{ matrix.task }}
 
@@ -92,6 +94,8 @@ jobs:
           components: ${{ matrix.components }}
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd
@@ -146,6 +150,8 @@ jobs:
           components: cargo
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd
@@ -210,6 +216,8 @@ jobs:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Build stratisd
         run: PROFILEDIR=debug make -f Makefile build-all
       - name: Install stratisd


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated CI workflows to use the latest checkout action version for improved reliability.
  - Disabled credential persistence during repository checkout to align with security best practices.
  - Applied consistently across all workflows without altering their logic or behavior.
  - No impact on product features or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->