### PR TITLE
Make ordering consistent for blockdevs and blockdevs_mut call

### DIFF
--- a/src/engine/strat_engine/backstore/backstore/v1.rs
+++ b/src/engine/strat_engine/backstore/backstore/v1.rs
@@ -437,8 +437,7 @@ impl Backstore {
     }
 
     /// Return a reference to all the blockdevs that this pool has ownership
-    /// of. The blockdevs may be returned in any order. It is unsafe to assume
-    /// that they are grouped by tier or any other organization.
+    /// of.
     pub fn blockdevs(&self) -> Vec<(DevUuid, BlockDevTier, &StratBlockDev)> {
         self.datadevs()
             .into_iter()
@@ -451,17 +450,20 @@ impl Backstore {
             .collect()
     }
 
+    /// Return a mutable reference to all the blockdevs that this pool has ownership
+    /// of.
     pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, BlockDevTier, &mut StratBlockDev)> {
         match self.cache_tier {
-            Some(ref mut cache) => cache
+            Some(ref mut cache) => self
+                .data_tier
                 .blockdevs_mut()
                 .into_iter()
-                .map(|(uuid, dev)| (uuid, BlockDevTier::Cache, dev))
+                .map(|(uuid, dev)| (uuid, BlockDevTier::Data, dev))
                 .chain(
-                    self.data_tier
+                    cache
                         .blockdevs_mut()
                         .into_iter()
-                        .map(|(uuid, dev)| (uuid, BlockDevTier::Data, dev)),
+                        .map(|(uuid, dev)| (uuid, BlockDevTier::Cache, dev)),
                 )
                 .collect(),
             None => self

--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -705,8 +705,7 @@ impl Backstore {
     }
 
     /// Return a reference to all the blockdevs that this pool has ownership
-    /// of. The blockdevs may be returned in any order. It is unsafe to assume
-    /// that they are grouped by tier or any other organization.
+    /// of.
     pub fn blockdevs(&self) -> Vec<(DevUuid, BlockDevTier, &StratBlockDev)> {
         self.datadevs()
             .into_iter()
@@ -719,17 +718,20 @@ impl Backstore {
             .collect()
     }
 
+    /// Return a mutable reference to all the blockdevs that this pool has ownership
+    /// of.
     pub fn blockdevs_mut(&mut self) -> Vec<(DevUuid, BlockDevTier, &mut StratBlockDev)> {
         match self.cache_tier {
-            Some(ref mut cache) => cache
+            Some(ref mut cache) => self
+                .data_tier
                 .blockdevs_mut()
                 .into_iter()
-                .map(|(uuid, dev)| (uuid, BlockDevTier::Cache, dev))
+                .map(|(uuid, dev)| (uuid, BlockDevTier::Data, dev))
                 .chain(
-                    self.data_tier
+                    cache
                         .blockdevs_mut()
                         .into_iter()
-                        .map(|(uuid, dev)| (uuid, BlockDevTier::Data, dev)),
+                        .map(|(uuid, dev)| (uuid, BlockDevTier::Cache, dev)),
                 )
                 .collect(),
             None => self


### PR DESCRIPTION
Related to #3651 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed incorrect tier labeling for mutable block devices so Data and Cache are distinguished correctly.
  - Standardized ordering to list Data-tier devices before Cache-tier devices when a cache is present.

- Documentation
  - Simplified/clarified comments describing device-listing behavior.

No changes to public APIs or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->