### PR TITLE
Update real version of libdbus-sys dependency to 0.2.6 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "libdbus-sys"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+checksum = "5cbe856efeb50e4681f010e9aaa2bf0a644e10139e54cde10fc83a307c23bd9f"
 dependencies = [
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,4 +365,3 @@ wildcard_imports = { level = "deny", priority = 4 }
 platforms = ["*-unknown-linux-gnu"]
 tier = "2"
 all-features = true
-exclude-crate-paths = [ { name = "libdbus-sys", exclude = "vendor" } ]


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a crate-specific exclusion from packaging metadata so dependencies are treated uniformly.
  * Standardized vendor filtering to ensure consistent handling of all dependencies.
  * Improves build consistency and reduces edge cases in dependency preparation.
  * No user-facing feature changes; only build/configuration behavior adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->