### PR TITLE
Remove mention of IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,9 @@ with `stratisd`.
 
 See [https://stratis-storage.github.io/](https://stratis-storage.github.io/).
 
-## Getting involved
+## Mailing list
 
-### Communication channels
-
-If you have questions, please don't hesitate to ask them, either on the mailing list or
-IRC.
-
-#### Mailing list
-
-Development mailing list: stratis-devel@lists.fedorahosted.org, -- subscribe
-[here](https://lists.fedoraproject.org/admin/lists/stratis-devel.lists.fedorahosted.org/).
-
-#### IRC
-
-irc.libera.chat #stratis-storage.
+Mailing list: stratis-devel@lists.fedorahosted.org — [subscribe or manage your subscription](https://lists.fedoraproject.org/admin/lists/stratis-devel.lists.fedorahosted.org/).
 
 ## For Developers
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced “Getting involved” with a streamlined “Mailing list” line, consolidating subscription info and adding a link to manage subscriptions.
  * Removed the obsolete “Communication channels” subsection, including IRC details.
  * Confirmed “For Developers” content remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->