### PR TITLE
Revert "Use Fedora specfile for Packit builds"

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,7 @@ downstream_package_name: stratisd
 actions:
     post-upstream-clone:
         - "git clone https://github.com/stratis-storage/ci --depth=1 ../distro"
-        - "bash -c '(cd ../distro; wget https://src.fedoraproject.org/rpms/stratisd/raw/rawhide/f/stratisd.spec)'"
+        - "mv ../distro/mockbuild_test/stratisd.spec ../distro/stratisd.spec"
         - "cargo install cargo-get"
         - "cargo install cargo-vendor-filterer"
     create-archive:
@@ -22,12 +22,10 @@ actions:
         - "cargo get package.version"
 
 srpm_build_deps:
-    - cargo
     - git
+    - cargo
     - openssl-devel
     - python3-semantic_version
-    - wget2
-    - wget2-wget
 
 jobs:
     - job: copr_build


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/811
Related https://github.com/stratis-storage/stratisd/pull/3908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated packaging workflow to use an existing spec file rather than downloading one, reducing external network calls and improving build predictability.
  - Streamlined SRPM build dependencies by reordering tools and removing unnecessary packages, leading to faster, leaner builds.
  - No changes to public interfaces or functionality; end-user behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->