### PR TITLE
Remove no longer entailed assertion

### DIFF
--- a/src/engine/strat_engine/engine.rs
+++ b/src/engine/strat_engine/engine.rs
@@ -594,9 +594,10 @@ impl Engine for StratEngine {
         }
 
         let mut guard = self.pools.modify_all().await;
-        let (pool_name, mut pool) = guard
-            .remove_by_uuid(uuid)
-            .expect("Must succeed since self.pools.get_by_uuid() returned a value");
+        let (pool_name, mut pool) = match guard.remove_by_uuid(uuid) {
+            Some(value) => value,
+            None => return Ok(DeleteAction::Identity),
+        };
 
         let (res, mut pool) = spawn_blocking!((
             match pool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes when attempting to destroy or rename a pool that doesn’t exist; these operations now safely no-op and report a clear status.
  * Improves robustness for edge cases where a pool ID is missing or already removed.
  * No changes to public APIs or user-facing commands; behavior is more predictable and stable under invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->