### PR TITLE
Increase lowest supported version of Rust to 1.85

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
-          toolchain: 1.82.0  # LOWEST SUPPORTED RUST TOOLCHAIN
+          toolchain: 1.85.0  # LOWEST SUPPORTED RUST TOOLCHAIN
       - uses: actions/checkout@v6
         with:
           path: stratisd
@@ -317,7 +317,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
-          toolchain: 1.82.0  # LOWEST SUPPORTED RUST TOOLCHAIN
+          toolchain: 1.85.0  # LOWEST SUPPORTED RUST TOOLCHAIN
       - uses: actions/checkout@v6
         with:
           path: stratisd

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -112,7 +112,7 @@ jobs:
           # MANDATORY CHECKS USING CURRENT DEVELOPMENT ENVIRONMENT
           - toolchain: 1.92.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
           # MANDATORY CHECKS USING LOWEST SUPPORTED ENVIRONMENT PROXY
-          - toolchain: 1.82.0  # LOWEST SUPPORTED RUST TOOLCHAIN
+          - toolchain: 1.85.0  # LOWEST SUPPORTED RUST TOOLCHAIN
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies for Ubuntu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [".", "stratisd_proc_macros"]
 [workspace.package]
 authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.org>"]
 edition = "2021"
-rust-version = "1.82.0"  # LOWEST SUPPORTED RUST TOOLCHAIN
+rust-version = "1.85.0"  # LOWEST SUPPORTED RUST TOOLCHAIN
 
 [[bin]]
 name = "stratisd"


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Rust toolchain version from 1.82.0 to 1.85.0 across build configurations and testing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->