### PR TITLE
Substitute DateTime::from_timestamp for Utc.timezone_opt

### DIFF
--- a/src/engine/shared.rs
+++ b/src/engine/shared.rs
@@ -14,7 +14,7 @@ use std::{
     sync::LazyLock,
 };
 
-use chrono::{DateTime, LocalResult, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use nix::poll::{poll, PollFd, PollFlags};
 use regex::Regex;
 
@@ -349,11 +349,10 @@ pub fn total_allocated(allocated: &Diff<Bytes>, metadata_size: &Diff<Bytes>) -> 
 /// Convert a u64 value representing seconds, and a u32 value representing
 /// nanoseconds to a timestamp.
 pub fn unsigned_to_timestamp(secs: u64, nanos: u32) -> StratisResult<DateTime<Utc>> {
-    let secs_arg = secs.try_into();
-    match secs_arg {
-        Ok(val) => match Utc.timestamp_opt(val, nanos) {
-            LocalResult::Single(timestamp) => Ok(timestamp),
-            _ => Err(StratisError::Msg(format!(
+    match secs.try_into() {
+        Ok(val) => match DateTime::from_timestamp(val, nanos) {
+            Some(timestamp) => Ok(timestamp),
+            None => Err(StratisError::Msg(format!(
                 "{val} (for seconds) and {nanos} (for nanoseconds) are not valid timestamp args"
             ))),
         },
@@ -366,7 +365,8 @@ pub fn unsigned_to_timestamp(secs: u64, nanos: u32) -> StratisResult<DateTime<Ut
 /// Return a timestamp which is equal to Utc::now() truncated to the nearest
 /// second.
 pub fn now_to_timestamp() -> DateTime<Utc> {
-    Utc.timestamp_opt(Utc::now().timestamp(), 0).unwrap()
+    DateTime::from_timestamp(Utc::now().timestamp(), 0)
+        .expect("DateTime::timestamp() always returns valid seconds value")
 }
 
 #[cfg(test)]

--- a/src/engine/strat_engine/metadata/mda.rs
+++ b/src/engine/strat_engine/metadata/mda.rs
@@ -399,7 +399,7 @@ impl MDAHeader {
 mod tests {
     use std::io::Cursor;
 
-    use chrono::{TimeZone, Utc};
+    use chrono::Utc;
     use proptest::{collection, num};
 
     use super::*;
@@ -457,8 +457,7 @@ mod tests {
                       nsec in 0..UTC_TIMESTAMP_NSECS_BOUND) {
 
             let header = MDAHeader {
-                // Argument values are correct by construction
-                last_updated: Utc.timestamp_opt(sec, nsec).unwrap(),
+                last_updated: DateTime::from_timestamp(sec, nsec).expect("values are correct by construction"),
                 used: MetaDataSize::new(Bytes::from(data.len())),
                 data_crc: CASTAGNOLI.checksum(data),
             };

--- a/src/engine/strat_engine/metadata/static_header.rs
+++ b/src/engine/strat_engine/metadata/static_header.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use byteorder::{ByteOrder, LittleEndian};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use crc::{Crc, CRC_32_ISCSI};
 use serde_json::Value;
 
@@ -154,10 +154,8 @@ impl StaticHeader {
             mda_size: mda_data_size.region_size().mda_size(),
             reserved_size: ReservedSize::new(RESERVED_SECTORS),
             flags: 0,
-            // Must succeed, since seconds must be valid
-            initialization_time: Utc
-                .timestamp_opt(initialization_time.timestamp(), 0)
-                .unwrap(),
+            initialization_time: DateTime::from_timestamp(initialization_time.timestamp(), 0)
+                .expect("DateTime::timestamp() always returns valid seconds value"),
         }
     }
 
@@ -572,7 +570,7 @@ pub mod tests {
 
     use proptest::{option, prelude::BoxedStrategy, strategy::Strategy};
 
-    use chrono::{TimeZone, Utc};
+    use chrono::Utc;
 
     use devicemapper::{Bytes, Sectors, IEC};
 
@@ -748,7 +746,8 @@ pub mod tests {
             ..sh
         };
         let sh_newer = StaticHeader {
-            initialization_time: Utc.timestamp_opt(ts.timestamp() + 1, 0).unwrap(),
+            initialization_time: DateTime::from_timestamp(ts.timestamp() + 1, 0)
+                .expect("DateTime::timestamp() always returns valid seconds value"),
             ..sh
         };
         assert_ne!(sh_older, sh_newer);


### PR DESCRIPTION
Closes #4007 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal timestamp handling logic to use modern library APIs, improving code maintainability and consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->