### PR TITLE
stratisd.service: Remove DefaultDependencies=no and After=multi-user.target

### DIFF
--- a/systemd/stratisd.service.in
+++ b/systemd/stratisd.service.in
@@ -1,8 +1,6 @@
 [Unit]
 Description=Stratis daemon
 Documentation=man:stratisd(8)
-DefaultDependencies=no
-After=multi-user.target
 
 [Service]
 BusName=org.storage.stratis3


### PR DESCRIPTION
## Summary

Removes `DefaultDependencies=no` and `After=multi-user.target` from `stratisd.service.in`.

These two directives created an ordering cycle for any `multi-user.target` service that depends on `stratisd.service`:

```
dependent.service → (After) stratisd.service → (After) multi-user.target → (Wants) dependent.service
```

With default dependencies restored, systemd adds `After=basic.target` automatically, which is sufficient since `stratisd` is a `Type=dbus` service and D-Bus is available after `basic.target`.

## Why this is safe

The Clevis/fstab boot path introduced in #3826 is handled entirely by `stratisd-min-postinitrd` and the `stratis-fstab-setup` units — they are independent of `stratisd.service`. Change 3 in #3826 (moving from `After=local-fs.target` to `After=multi-user.target`) was not needed for the Clevis fix; changes 1 and 2 of that PR (the new `stratis-fstab-setup-with-network@.service` and removing `Before=local-fs-pre.target` from `stratisd-min-postinitrd.service`) are what fixed Clevis/Tang support.

A QEMU-based reproduction at https://github.com/kriansa/stratisd-boot-cycle-repro verifies:
1. The ordering cycle exists with the current unit file
2. Removing the two lines resolves the cycle
3. A simulated Clevis/network fstab service (matching `stratis-fstab-setup-with-network@` ordering) completes successfully after the fix

## Test plan

- [ ] Boot with `stratisd.service` enabled and a downstream service with `After=stratisd.service` in `multi-user.target` — confirm no ordering cycle
- [ ] Confirm `stratisd` starts correctly (D-Bus available via `basic.target`)
- [ ] Test Clevis/Tang fstab path is unaffected

Closes #3968