### PR TITLE
Include cryptsetup as a required executable in dracut

### DIFF
--- a/dracut/50stratis/module-setup.sh.in
+++ b/dracut/50stratis/module-setup.sh.in
@@ -2,7 +2,8 @@
 
 # called by dracut
 check() {
-	require_binaries stratis-min \
+	require_binaries cryptsetup \
+        stratis-min \
 		@LIBEXECDIR@/stratisd-min \
 		$systemdutildir/system-generators/stratis-setup-generator \
 		thin_check \
@@ -33,7 +34,8 @@ installkernel() {
 # called by dracut
 install() {
 	# Stratis dependencies
-	inst_multiple stratis-min \
+	inst_multiple cryptsetup \
+        stratis-min \
 		@LIBEXECDIR@/stratisd-min \
 		thin_check \
 		thin_repair \


### PR DESCRIPTION
Part of the solution for https://bugzilla.redhat.com/show_bug.cgi?id=2477897
Closes https://github.com/stratis-storage/project/issues/872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system initialization by ensuring cryptographic utilities are properly validated as required dependencies and correctly installed during system setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stratis-storage/stratisd/pull/4031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->