### PR TITLE
Fix missing signal for blockdev size on block device growth

### DIFF
--- a/src/dbus/pool/pool_3_3/methods.rs
+++ b/src/dbus/pool/pool_3_3/methods.rs
@@ -12,7 +12,10 @@ use crate::{
         consts::OK_STRING,
         manager::Manager,
         types::DbusErrorEnum,
-        util::{engine_to_dbus_err_tuple, send_pool_foreground_signals},
+        util::{
+            engine_to_dbus_err_tuple, send_blockdev_physical_size_signal,
+            send_pool_foreground_signals,
+        },
     },
     engine::{DevUuid, Engine, EngineAction, Lockable, PoolIdentifier, PoolUuid},
     stratis::StratisError,
@@ -56,9 +59,17 @@ pub async fn grow_physical_device_method(
     .await
     {
         Ok(Ok((action, diff))) => match action.changed() {
-            Some(_) => {
+            Some((_, dev_uuid)) => {
                 if let Some(d) = diff {
                     send_pool_foreground_signals(connection, manager, pool_uuid, d).await;
+                    match manager.read().await.blockdev_get_path(&dev_uuid) {
+                        Some(p) => {
+                            send_blockdev_physical_size_signal(connection, p).await;
+                        }
+                        None => {
+                            warn!("No path found for blockdev with UUID {dev_uuid}");
+                        }
+                    }
                 }
                 (true, DbusErrorEnum::OK as u16, OK_STRING.to_string())
             }

--- a/src/dbus/util.rs
+++ b/src/dbus/util.rs
@@ -15,7 +15,8 @@ use devicemapper::DmError;
 use crate::{
     dbus::{
         blockdev::{
-            BlockdevR3, BlockdevR4, BlockdevR5, BlockdevR6, BlockdevR7, BlockdevR8, BlockdevR9,
+            BlockdevR0, BlockdevR1, BlockdevR2, BlockdevR3, BlockdevR4, BlockdevR5, BlockdevR6,
+            BlockdevR7, BlockdevR8, BlockdevR9,
         },
         consts::STRATIS_BASE_PATH,
         filesystem::{
@@ -1998,5 +1999,91 @@ pub async fn send_last_reencrypted_signal(connection: &Arc<Connection>, path: &O
         last_reencrypted_timestamp_changed,
         "last reencryption timestamp",
         "pool.r9"
+    );
+}
+
+pub async fn send_blockdev_physical_size_signal(
+    connection: &Arc<Connection>,
+    path: &ObjectPath<'_>,
+) {
+    send_signal!(
+        connection,
+        BlockdevR0,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r0"
+    );
+    send_signal!(
+        connection,
+        BlockdevR1,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r1"
+    );
+    send_signal!(
+        connection,
+        BlockdevR2,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r2"
+    );
+    send_signal!(
+        connection,
+        BlockdevR3,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r3"
+    );
+    send_signal!(
+        connection,
+        BlockdevR4,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r4"
+    );
+    send_signal!(
+        connection,
+        BlockdevR5,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r5"
+    );
+    send_signal!(
+        connection,
+        BlockdevR6,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r6"
+    );
+    send_signal!(
+        connection,
+        BlockdevR7,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r7"
+    );
+    send_signal!(
+        connection,
+        BlockdevR8,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r8"
+    );
+    send_signal!(
+        connection,
+        BlockdevR9,
+        path,
+        total_physical_size_changed,
+        "total physical size",
+        "blockdev.r9"
     );
 }


### PR DESCRIPTION
Closes #4026 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Block device physical size changes are now properly reported when storage operations update device configurations, ensuring accurate physical size tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stratis-storage/stratisd/pull/4032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->