### PR TITLE
Clean up for registration and deregistration code

### DIFF
--- a/src/dbus/manager/manager_3_0/methods.rs
+++ b/src/dbus/manager/manager_3_0/methods.rs
@@ -17,9 +17,7 @@ use zbus::{
 
 use crate::{
     dbus::{
-        blockdev::unregister_blockdev,
         consts::OK_STRING,
-        filesystem::unregister_filesystem,
         manager::Manager,
         pool::{register_pool, unregister_pool},
         types::DbusErrorEnum,
@@ -196,27 +194,7 @@ pub async fn destroy_pool_method(
 
     match engine.destroy_pool(uuid).await {
         Ok(DeleteAction::Deleted(uuid)) => {
-            for dev_uuid in dev_uuids {
-                let maybe_dev_path = manager.write().await.blockdev_get_path(&dev_uuid).cloned();
-                if let Some(dev_path) = maybe_dev_path {
-                    if let Err(e) = unregister_blockdev(connection, manager, &dev_path).await {
-                        warn!(
-                            "Failed to unregister {dev_path} representing blockdev {dev_uuid}: {e}"
-                        );
-                    }
-                }
-            }
-            for fs_uuid in fs_uuids {
-                let maybe_fs_path = manager.write().await.filesystem_get_path(&fs_uuid).cloned();
-                if let Some(fs_path) = maybe_fs_path {
-                    if let Err(e) = unregister_filesystem(connection, manager, &fs_path).await {
-                        warn!(
-                            "Failed to unregister {fs_path} representing filesystem {fs_uuid}: {e}"
-                        );
-                    }
-                }
-            }
-            match unregister_pool(connection, manager, &pool).await {
+            match unregister_pool(connection, manager, &pool, &fs_uuids, &dev_uuids).await {
                 Ok(u) => {
                     assert_eq!(uuid, u);
                     (

--- a/src/dbus/manager/manager_3_0/methods.rs
+++ b/src/dbus/manager/manager_3_0/methods.rs
@@ -135,12 +135,12 @@ pub async fn create_pool_method(
     {
         Ok(CreateAction::Created(uuid)) => {
             match register_pool(engine, connection, manager, counter, uuid).await {
-                Ok((pool_path, fs_paths)) => (
+                Ok((pool_path, _, bd_paths)) => (
                     (
                         true,
                         (
                             OwnedObjectPath::from(pool_path),
-                            fs_paths.into_iter().map(OwnedObjectPath::from).collect(),
+                            bd_paths.into_iter().map(OwnedObjectPath::from).collect(),
                         ),
                     ),
                     DbusErrorEnum::OK as u16,

--- a/src/dbus/manager/manager_3_2/methods.rs
+++ b/src/dbus/manager/manager_3_2/methods.rs
@@ -15,7 +15,6 @@ use zbus::{
 
 use crate::{
     dbus::{
-        blockdev::unregister_blockdev,
         consts::OK_STRING,
         filesystem::unregister_filesystem,
         manager::Manager,
@@ -152,61 +151,48 @@ pub async fn stop_pool_method(
             .await
     );
 
-    match action {
-        Ok(StopAction::Stopped(_) | StopAction::Partial(_)) | Err(_) => {
-            let (dev_uuids_rem, fs_uuids_rem) =
-                match engine.get_pool(PoolIdentifier::Uuid(pool_uuid)).await {
-                    Some(p) => (
-                        p.blockdevs()
-                            .into_iter()
-                            .map(|(u, _, _)| u)
-                            .collect::<HashSet<_>>(),
-                        p.filesystems()
-                            .into_iter()
-                            .map(|(_, u, _)| u)
-                            .collect::<HashSet<_>>(),
-                    ),
-                    None => (HashSet::default(), HashSet::default()),
-                };
-
-            for fs_uuid in fs_uuids.into_iter().filter(|u| !fs_uuids_rem.contains(u)) {
-                let maybe_fs_path = manager.write().await.filesystem_get_path(&fs_uuid).cloned();
-                if let Some(fs_path) = maybe_fs_path {
-                    if let Err(e) = unregister_filesystem(connection, manager, &fs_path).await {
-                        warn!(
-                            "Failed to unregister {fs_path} representing filesystem {fs_uuid}: {e}"
-                        );
+    match &action {
+        Ok(StopAction::Stopped(_) | StopAction::Partial(_)) => {
+            if let Err(e) = unregister_pool(connection, manager, &pool, &fs_uuids, &dev_uuids).await
+            {
+                warn!("Failed to remove pool with path {pool} from the D-Bus: {e}");
+            }
+            send_stopped_pools_signals(connection).await;
+            let stopped_pools = engine.stopped_pools().await;
+            let stopped = stopped_pools
+                .stopped
+                .get(&pool_uuid)
+                .or_else(|| stopped_pools.partially_constructed.get(&pool_uuid));
+            if stopped.map(|s| s.info.is_some()).unwrap_or(false) {
+                send_locked_pools_signals(connection).await;
+            }
+        }
+        Err(_) => match engine.get_pool(PoolIdentifier::Uuid(pool_uuid)).await {
+            Some(g) => {
+                let rem_fs = g
+                    .filesystems()
+                    .into_iter()
+                    .map(|(_, uuid, _)| uuid)
+                    .collect::<HashSet<_>>();
+                for fs_uuid in fs_uuids.iter().filter(|u| !rem_fs.contains(u)) {
+                    match manager.read().await.filesystem_get_path(fs_uuid).cloned() {
+                        Some(p) => {
+                            if let Err(e) = unregister_filesystem(connection, manager, &p).await {
+                                warn!("Failed to unregister filesystem: {e}");
+                            }
+                        }
+                        None => {
+                            warn!("Could not find filesystem path for UUID {fs_uuid}");
+                        }
                     }
                 }
             }
-
-            for dev_uuid in dev_uuids.into_iter().filter(|u| !dev_uuids_rem.contains(u)) {
-                let maybe_dev_path = manager.write().await.blockdev_get_path(&dev_uuid).cloned();
-                if let Some(dev_path) = maybe_dev_path {
-                    if let Err(e) = unregister_blockdev(connection, manager, &dev_path).await {
-                        warn!(
-                            "Failed to unregister {dev_path} representing blockdev {dev_uuid}: {e}"
-                        );
-                    }
-                }
+            None => {
+                warn!("Failed to find pool with UUID {pool_uuid} even though pool failed to stop");
             }
-        }
-        _ => {}
-    }
-
-    if let Ok(StopAction::Stopped(_) | StopAction::Partial(_)) = action {
-        if let Err(e) = unregister_pool(connection, manager, &pool).await {
-            warn!("Failed to remove pool with path {pool} from the D-Bus: {e}");
-        }
-        send_stopped_pools_signals(connection).await;
-        let stopped_pools = engine.stopped_pools().await;
-        let stopped = stopped_pools
-            .stopped
-            .get(&pool_uuid)
-            .or_else(|| stopped_pools.partially_constructed.get(&pool_uuid));
-        if stopped.map(|s| s.info.is_some()).unwrap_or(false) {
-            send_locked_pools_signals(connection).await;
-        }
+        },
+        Ok(StopAction::Identity) => {}
+        Ok(StopAction::CleanedUp(_)) => unreachable!("!has_partially_constructed above"),
     }
 
     match action {

--- a/src/dbus/manager/manager_3_2/methods.rs
+++ b/src/dbus/manager/manager_3_2/methods.rs
@@ -17,7 +17,7 @@ use crate::{
     dbus::{
         blockdev::unregister_blockdev,
         consts::OK_STRING,
-        filesystem::{register_filesystem, unregister_filesystem},
+        filesystem::unregister_filesystem,
         manager::Manager,
         pool::{register_pool, unregister_pool},
         types::DbusErrorEnum,
@@ -83,30 +83,11 @@ pub async fn start_pool_method(
                     );
                 }
             };
-            let mut fs_paths = Vec::default();
-            for fs_uuid in guard
-                .filesystems()
-                .into_iter()
-                .map(|(_, fs_uuid, _)| fs_uuid)
-                .collect::<Vec<_>>()
-            {
-                let fs_path = match register_filesystem(
-                    engine, connection, manager, counter, pool_uuid, fs_uuid,
-                )
-                .await
-                {
-                    Ok(fp) => fp,
-                    Err(e) => {
-                        let (rc, rs) = engine_to_dbus_err_tuple(&e);
-                        return (default_return, rc, rs);
-                    }
-                };
-                fs_paths.push(OwnedObjectPath::from(fs_path));
-            }
-            let (pool_path, dev_paths) =
+            let (pool_path, fs_paths, dev_paths) =
                 match register_pool(engine, connection, manager, counter, pool_uuid).await {
-                    Ok((pp, dp)) => (
+                    Ok((pp, fp, dp)) => (
                         OwnedObjectPath::from(pp),
+                        fp.into_iter().map(OwnedObjectPath::from).collect(),
                         dp.into_iter().map(OwnedObjectPath::from).collect(),
                     ),
                     Err(e) => {

--- a/src/dbus/manager/manager_3_4/methods.rs
+++ b/src/dbus/manager/manager_3_4/methods.rs
@@ -10,7 +10,6 @@ use zbus::{zvariant::OwnedObjectPath, Connection};
 use crate::{
     dbus::{
         consts::OK_STRING,
-        filesystem::register_filesystem,
         manager::Manager,
         pool::register_pool,
         types::DbusErrorEnum,
@@ -81,30 +80,11 @@ pub async fn start_pool_method(
                     );
                 }
             };
-            let mut fs_paths = Vec::default();
-            for fs_uuid in guard
-                .filesystems()
-                .into_iter()
-                .map(|(_, fs_uuid, _)| fs_uuid)
-                .collect::<Vec<_>>()
-            {
-                let fs_path = match register_filesystem(
-                    engine, connection, manager, counter, pool_uuid, fs_uuid,
-                )
-                .await
-                {
-                    Ok(fp) => fp,
-                    Err(e) => {
-                        let (rc, rs) = engine_to_dbus_err_tuple(&e);
-                        return (default_return, rc, rs);
-                    }
-                };
-                fs_paths.push(OwnedObjectPath::from(fs_path));
-            }
-            let (pool_path, dev_paths) =
+            let (pool_path, fs_paths, dev_paths) =
                 match register_pool(engine, connection, manager, counter, pool_uuid).await {
-                    Ok((pp, dp)) => (
+                    Ok((pp, fp, dp)) => (
                         OwnedObjectPath::from(pp),
+                        fp.into_iter().map(OwnedObjectPath::from).collect(),
                         dp.into_iter().map(OwnedObjectPath::from).collect(),
                     ),
                     Err(e) => {

--- a/src/dbus/manager/manager_3_6/methods.rs
+++ b/src/dbus/manager/manager_3_6/methods.rs
@@ -9,7 +9,6 @@ use zbus::Connection;
 
 use crate::{
     dbus::{
-        blockdev::unregister_blockdev,
         consts::OK_STRING,
         filesystem::unregister_filesystem,
         manager::Manager,
@@ -57,72 +56,61 @@ pub async fn stop_pool_method(
 
     let action = handle_action!(engine.stop_pool(id.clone(), true).await);
 
-    match action {
-        Ok(StopAction::Stopped(_) | StopAction::Partial(_)) | Err(_) => {
-            let (dev_uuids_rem, fs_uuids_rem) = match engine.get_pool(id).await {
-                Some(p) => (
-                    p.blockdevs()
-                        .into_iter()
-                        .map(|(u, _, _)| u)
-                        .collect::<HashSet<_>>(),
-                    p.filesystems()
-                        .into_iter()
-                        .map(|(_, u, _)| u)
-                        .collect::<HashSet<_>>(),
-                ),
-                None => (HashSet::default(), HashSet::default()),
+    match &action {
+        Ok(StopAction::Stopped(pool_uuid) | StopAction::Partial(pool_uuid)) => {
+            let path = manager.read().await.pool_get_path(pool_uuid).cloned();
+            match path {
+                Some(pool) => {
+                    if let Err(e) =
+                        unregister_pool(connection, manager, &pool.as_ref(), &fs_uuids, &dev_uuids)
+                            .await
+                    {
+                        warn!("Failed to remove pool with path {pool} from the D-Bus: {e}");
+                    }
+                }
+                None => {
+                    warn!("Failed to unregister the stopped pool from the D-Bus");
+                }
             };
-
-            for fs_uuid in fs_uuids.into_iter().filter(|u| !fs_uuids_rem.contains(u)) {
-                let maybe_fs_path = manager.write().await.filesystem_get_path(&fs_uuid).cloned();
-                if let Some(fs_path) = maybe_fs_path {
-                    if let Err(e) = unregister_filesystem(connection, manager, &fs_path).await {
-                        warn!(
-                            "Failed to unregister {fs_path} representing filesystem {fs_uuid}: {e}"
-                        );
-                    }
-                }
-            }
-
-            for dev_uuid in dev_uuids.into_iter().filter(|u| !dev_uuids_rem.contains(u)) {
-                let maybe_dev_path = manager.write().await.blockdev_get_path(&dev_uuid).cloned();
-                if let Some(dev_path) = maybe_dev_path {
-                    if let Err(e) = unregister_blockdev(connection, manager, &dev_path).await {
-                        warn!(
-                            "Failed to unregister {dev_path} representing blockdev {dev_uuid}: {e}"
-                        );
-                    }
-                }
+            send_stopped_pools_signals(connection).await;
+            let stopped = {
+                let stopped_pools = engine.stopped_pools().await;
+                stopped_pools
+                    .stopped
+                    .get(pool_uuid)
+                    .or_else(|| stopped_pools.partially_constructed.get(pool_uuid))
+                    .map(|s| s.info.is_some())
+                    .unwrap_or(false)
+            };
+            if stopped {
+                send_locked_pools_signals(connection).await;
             }
         }
-        _ => {}
-    }
-
-    if let Ok(StopAction::Stopped(pool_uuid) | StopAction::Partial(pool_uuid)) = action {
-        let path = manager.read().await.pool_get_path(&pool_uuid).cloned();
-        match path {
-            Some(pool) => {
-                if let Err(e) = unregister_pool(connection, manager, &pool.as_ref()).await {
-                    warn!("Failed to remove pool with path {pool} from the D-Bus: {e}");
+        Err(_) => match engine.get_pool(id.clone()).await {
+            Some(g) => {
+                let rem_fs = g
+                    .filesystems()
+                    .into_iter()
+                    .map(|(_, uuid, _)| uuid)
+                    .collect::<HashSet<_>>();
+                for fs_uuid in fs_uuids.iter().filter(|u| !rem_fs.contains(u)) {
+                    match manager.read().await.filesystem_get_path(fs_uuid).cloned() {
+                        Some(p) => {
+                            if let Err(e) = unregister_filesystem(connection, manager, &p).await {
+                                warn!("Failed to unregister filesystem: {e}");
+                            }
+                        }
+                        None => {
+                            warn!("Could not find filesystem path for UUID {fs_uuid}");
+                        }
+                    }
                 }
             }
             None => {
-                warn!("Failed to unregister the stopped pool from the D-Bus");
+                warn!("Failed to find pool with ID {id:?} even though pool failed to stop");
             }
-        };
-        send_stopped_pools_signals(connection).await;
-        let stopped = {
-            let stopped_pools = engine.stopped_pools().await;
-            stopped_pools
-                .stopped
-                .get(&pool_uuid)
-                .or_else(|| stopped_pools.partially_constructed.get(&pool_uuid))
-                .map(|s| s.info.is_some())
-                .unwrap_or(false)
-        };
-        if stopped {
-            send_locked_pools_signals(connection).await;
-        }
+        },
+        Ok(StopAction::Identity | StopAction::CleanedUp(_)) => {}
     }
 
     match action {
@@ -131,7 +119,7 @@ pub async fn stop_pool_method(
             DbusErrorEnum::OK as u16,
             OK_STRING.to_string(),
         ),
-        Ok(StopAction::Stopped(pool_uuid)) => (
+        Ok(StopAction::Stopped(pool_uuid) | StopAction::CleanedUp(pool_uuid)) => (
             (true, pool_uuid.simple().to_string()),
             DbusErrorEnum::OK as u16,
             OK_STRING.to_string(),
@@ -141,7 +129,6 @@ pub async fn stop_pool_method(
             DbusErrorEnum::ERROR as u16,
             "Pool was stopped, but some component devices were not torn down".to_string(),
         ),
-        Ok(StopAction::CleanedUp(_)) => unreachable!("!has_partially_constructed above"),
         Err(e) => {
             let (rc, rs) = engine_to_dbus_err_tuple(&e);
             (default_return, rc, rs)

--- a/src/dbus/manager/manager_3_8/methods.rs
+++ b/src/dbus/manager/manager_3_8/methods.rs
@@ -20,7 +20,6 @@ use devicemapper::Bytes;
 use crate::{
     dbus::{
         consts::OK_STRING,
-        filesystem::register_filesystem,
         manager::Manager,
         pool::register_pool,
         types::DbusErrorEnum,
@@ -114,12 +113,12 @@ pub async fn create_pool_method(
     ) {
         Ok(CreateAction::Created(uuid)) => {
             match register_pool(engine, connection, manager, counter, uuid).await {
-                Ok((pool_path, fs_paths)) => (
+                Ok((pool_path, _, bd_paths)) => (
                     (
                         true,
                         (
                             OwnedObjectPath::from(pool_path),
-                            fs_paths.into_iter().map(OwnedObjectPath::from).collect(),
+                            bd_paths.into_iter().map(OwnedObjectPath::from).collect(),
                         ),
                     ),
                     DbusErrorEnum::OK as u16,
@@ -208,30 +207,11 @@ pub async fn start_pool_method(
                     );
                 }
             };
-            let mut fs_paths = Vec::default();
-            for fs_uuid in guard
-                .filesystems()
-                .into_iter()
-                .map(|(_, fs_uuid, _)| fs_uuid)
-                .collect::<Vec<_>>()
-            {
-                let fs_path = match register_filesystem(
-                    engine, connection, manager, counter, pool_uuid, fs_uuid,
-                )
-                .await
-                {
-                    Ok(fp) => fp,
-                    Err(e) => {
-                        let (rc, rs) = engine_to_dbus_err_tuple(&e);
-                        return (default_return, rc, rs);
-                    }
-                };
-                fs_paths.push(OwnedObjectPath::from(fs_path));
-            }
-            let (pool_path, dev_paths) =
+            let (pool_path, fs_paths, dev_paths) =
                 match register_pool(engine, connection, manager, counter, pool_uuid).await {
-                    Ok((pp, dp)) => (
+                    Ok((pp, fp, dp)) => (
                         OwnedObjectPath::from(pp),
+                        fp.into_iter().map(OwnedObjectPath::from).collect(),
                         dp.into_iter().map(OwnedObjectPath::from).collect(),
                     ),
                     Err(e) => {

--- a/src/dbus/manager/manager_3_9/methods.rs
+++ b/src/dbus/manager/manager_3_9/methods.rs
@@ -16,7 +16,6 @@ use zbus::{
 use crate::{
     dbus::{
         consts::OK_STRING,
-        filesystem::register_filesystem,
         manager::Manager,
         pool::register_pool,
         types::DbusErrorEnum,
@@ -94,29 +93,13 @@ pub async fn start_pool_method(
                     );
                 }
             };
-            let mut fs_paths = Vec::default();
-            for fs_uuid in guard
-                .filesystems()
-                .into_iter()
-                .map(|(_, fs_uuid, _)| fs_uuid)
-                .collect::<Vec<_>>()
-            {
-                let fs_path = match register_filesystem(
-                    engine, connection, manager, counter, pool_uuid, fs_uuid,
-                )
-                .await
-                {
-                    Ok(fp) => fp,
-                    Err(e) => {
-                        let (rc, rs) = engine_to_dbus_err_tuple(&e);
-                        return (default_return, rc, rs);
-                    }
-                };
-                fs_paths.push(OwnedObjectPath::from(fs_path));
-            }
-            let (pool_path, dev_paths) =
+            let (pool_path, fs_paths, dev_paths) =
                 match register_pool(engine, connection, manager, counter, pool_uuid).await {
-                    Ok(pp) => pp,
+                    Ok((pp, fp, dp)) => (
+                        OwnedObjectPath::from(pp),
+                        fp.into_iter().map(OwnedObjectPath::from).collect(),
+                        dp.into_iter().map(OwnedObjectPath::from).collect(),
+                    ),
                     Err(e) => {
                         let (rc, rs) = engine_to_dbus_err_tuple(&e);
                         return (default_return, rc, rs);
@@ -129,17 +112,7 @@ pub async fn start_pool_method(
             send_stopped_pools_signals(connection).await;
 
             (
-                (
-                    true,
-                    (
-                        OwnedObjectPath::from(pool_path),
-                        dev_paths
-                            .into_iter()
-                            .map(OwnedObjectPath::from)
-                            .collect::<Vec<_>>(),
-                        fs_paths,
-                    ),
-                ),
+                (true, (pool_path, dev_paths, fs_paths)),
                 DbusErrorEnum::OK as u16,
                 OK_STRING.to_string(),
             )

--- a/src/dbus/pool/mod.rs
+++ b/src/dbus/pool/mod.rs
@@ -45,10 +45,9 @@ pub async fn register_pool<'a>(
     manager: &Lockable<Arc<RwLock<Manager>>>,
     counter: &Arc<AtomicU64>,
     pool_uuid: PoolUuid,
-) -> StratisResult<(ObjectPath<'a>, Vec<ObjectPath<'a>>)> {
+) -> StratisResult<(ObjectPath<'a>, Vec<ObjectPath<'a>>, Vec<ObjectPath<'a>>)> {
     match engine.get_pool(PoolIdentifier::Uuid(pool_uuid)).await {
         Some(pool) => {
-
             let path = ObjectPath::try_from(format!(
                 "{}/{}",
                 consts::STRATIS_BASE_PATH,
@@ -178,10 +177,11 @@ pub async fn register_pool<'a>(
 
             manager.write().await.add_pool(&path, pool_uuid)?;
 
+            let mut fs_paths = Vec::new();
             let fs_uuids = pool.filesystems().into_iter().map(|(_, u, _)| u).collect::<Vec<_>>();
             for fs_uuid in fs_uuids {
                 match register_filesystem(engine, connection, manager, counter, pool_uuid, fs_uuid).await {
-                    Ok(_) => (),
+                    Ok(op) => fs_paths.push(op),
                     Err(_) => {
                         warn!("Unable to register object path for filesystem with UUID {fs_uuid} belonging to pool {pool_uuid} on the D-Bus");
                     },
@@ -198,7 +198,8 @@ pub async fn register_pool<'a>(
                     },
                 }
             }
-            Ok((path, bd_paths))
+
+            Ok((path, fs_paths, bd_paths))
         }
         None => {
             Err(StratisError::Msg(format!("Pool with {pool_uuid} was successfully started but appears to have been removed before it could be exposed on the D-Bus")))

--- a/src/dbus/pool/mod.rs
+++ b/src/dbus/pool/mod.rs
@@ -11,8 +11,11 @@ use tokio::sync::RwLock;
 use zbus::{zvariant::ObjectPath, Connection};
 
 use crate::{
-    dbus::{consts, register_blockdev, register_filesystem, Manager},
-    engine::{Engine, Lockable, PoolIdentifier, PoolUuid},
+    dbus::{
+        blockdev::unregister_blockdev, consts, filesystem::unregister_filesystem,
+        register_blockdev, register_filesystem, Manager,
+    },
+    engine::{DevUuid, Engine, FilesystemUuid, Lockable, PoolIdentifier, PoolUuid},
     stratis::{StratisError, StratisResult},
 };
 
@@ -211,7 +214,30 @@ pub async fn unregister_pool(
     connection: &Arc<Connection>,
     manager: &Lockable<Arc<RwLock<Manager>>>,
     path: &ObjectPath<'_>,
+    fs_uuids: &[FilesystemUuid],
+    dev_uuids: &[DevUuid],
 ) -> StratisResult<PoolUuid> {
+    // Unregister all filesystems
+    for fs_uuid in fs_uuids {
+        let maybe_fs_path = manager.write().await.filesystem_get_path(fs_uuid).cloned();
+        if let Some(fs_path) = maybe_fs_path {
+            if let Err(e) = unregister_filesystem(connection, manager, &fs_path).await {
+                warn!("Failed to unregister {fs_path} representing filesystem {fs_uuid}: {e}");
+            }
+        }
+    }
+
+    // Unregister all blockdevs
+    for dev_uuid in dev_uuids {
+        let maybe_dev_path = manager.write().await.blockdev_get_path(dev_uuid).cloned();
+        if let Some(dev_path) = maybe_dev_path {
+            if let Err(e) = unregister_blockdev(connection, manager, &dev_path).await {
+                warn!("Failed to unregister {dev_path} representing blockdev {dev_uuid}: {e}");
+            }
+        }
+    }
+
+    // Unregister the pool itself
     let uuid = {
         let mut lock = manager.write().await;
         let uuid = lock


### PR DESCRIPTION
Closes #4028 

I manually tested with dbus-monitor and did a little bit of additional cleanup to make registration and deregistration consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pool creation/start now uses a single registration flow that returns pool, filesystem, and device D-Bus object paths for responses.
  * Pool stopping and pool destruction delegate teardown to a centralized unregister operation that accepts filesystem/device UUID lists.
  * Simplified component lifecycle handling by removing per-filesystem/per-device unregister loops.

* **Bug Fixes**
  * Improved robustness: failures to unregister individual filesystem/block device objects now produce warnings instead of aborting.
  * On stop errors, retained/unpresent components are selectively cleaned up to match current engine state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->