### PR TITLE
Increase lowest supported rust toolchain to 1.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [".", "stratisd_proc_macros"]
 [workspace.package]
 authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.org>"]
 edition = "2021"
-rust-version = "1.85.0"  # LOWEST SUPPORTED RUST TOOLCHAIN
+rust-version = "1.87.0"  # LOWEST SUPPORTED RUST TOOLCHAIN
 
 [[bin]]
 name = "stratisd"


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/875