### PR TITLE
Return owned LinearDevs from make_cache on error

### DIFF
--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -58,6 +58,8 @@ use crate::{
 /// typical size.
 const CACHE_BLOCK_SIZE: Sectors = Sectors(2048); // 1024 KiB
 
+type MakeCacheError = Box<(StratisError, Option<LinearDev>, Option<LinearDev>)>;
+
 /// Make a DM cache device. If the cache device is being made new,
 /// take extra steps to make it clean.
 fn make_cache(
@@ -66,39 +68,49 @@ fn make_cache(
     origin: LinearDev,
     cap: Option<LinearDev>,
     new: bool,
-) -> StratisResult<CacheDev> {
+) -> Result<CacheDev, MakeCacheError> {
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-    let meta = LinearDev::setup(
+    let meta = match LinearDev::setup(
         get_dm(),
         &dm_name,
         Some(&dm_uuid),
         cache_tier.meta_segments.map_to_dm(),
-    )?;
+    ) {
+        Ok(m) => m,
+        Err(e) => return Err(Box::new((e.into(), Some(origin), cap))),
+    };
 
     if new {
         // See comment in ThinPool::new() method
-        wipe_sectors(
+        if let Err(e) = wipe_sectors(
             meta.devnode(),
             Sectors(0),
             cmp::min(Sectors(8), meta.size()),
-        )?;
+        ) {
+            return Err(Box::new((e, Some(origin), cap)));
+        }
     }
 
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-    let cache = LinearDev::setup(
+    let cache = match LinearDev::setup(
         get_dm(),
         &dm_name,
         Some(&dm_uuid),
         cache_tier.cache_segments.map_to_dm(),
-    )?;
+    ) {
+        Ok(c) => c,
+        Err(e) => return Err(Box::new((e.into(), Some(origin), cap))),
+    };
 
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
     if cap.is_some() {
         let dm = get_dm();
-        dm.device_suspend(
+        if let Err(e) = dm.device_suspend(
             &DevId::Name(&dm_name),
             DmOptions::default().set_flags(DmFlags::DM_SUSPEND),
-        )?;
+        ) {
+            return Err(Box::new((e.into(), Some(origin), cap)));
+        }
         let table = CacheDevTargetTable::new(
             Sectors(0),
             origin.size(),
@@ -112,14 +124,18 @@ fn make_cache(
                 Vec::new(),
             ),
         );
-        dm.table_load(
+        if let Err(e) = dm.table_load(
             &DevId::Name(&dm_name),
             &table.to_raw_table(),
             DmOptions::default(),
-        )?;
-        dm.device_suspend(&DevId::Name(&dm_name), DmOptions::private())?;
+        ) {
+            return Err(Box::new((e.into(), Some(origin), cap)));
+        }
+        if let Err(e) = dm.device_suspend(&DevId::Name(&dm_name), DmOptions::private()) {
+            return Err(Box::new((e.into(), Some(origin), cap)));
+        }
     };
-    Ok(CacheDev::setup(
+    match CacheDev::setup(
         get_dm(),
         &dm_name,
         Some(&dm_uuid),
@@ -127,7 +143,10 @@ fn make_cache(
         cache,
         origin,
         CACHE_BLOCK_SIZE,
-    )?)
+    ) {
+        Ok(cd) => Ok(cd),
+        Err(e) => Err(Box::new((e.into(), None, cap))),
+    }
 }
 
 /// Set up the linear device on top of the data tier that can later be converted to a
@@ -549,7 +568,7 @@ impl Backstore {
                     let cache_device = match make_cache(pool_uuid, &cache_tier, origin, None, false)
                     {
                         Ok(cd) => cd,
-                        Err(e) => {
+                        Err(boxed) => { let (e, _origin, _cap) = *boxed;
                             return Err(e);
                         }
                     };
@@ -706,7 +725,14 @@ impl Backstore {
                         .take()
                         .expect("some space has already been allocated from the backstore => (cache_tier.is_none() <=> self.placeholder.is_some())");
 
-                let cache = make_cache(pool_uuid, &cache_tier, origin, Some(placeholder), true)?;
+                let cache = match make_cache(pool_uuid, &cache_tier, origin, Some(placeholder), true) {
+                    Ok(cache) => cache,
+                    Err(boxed) => { let (e, maybe_origin, maybe_placeholder) = *boxed;
+                        self.cap_device.origin = maybe_origin;
+                        self.cap_device.placeholder = maybe_placeholder;
+                        return Err(e);
+                    }
+                };
 
                 self.cap_device.cache = Some(cache);
 

--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -66,11 +66,12 @@ fn make_cache(
     pool_uuid: PoolUuid,
     cache_tier: &CacheTier<StratBlockDev>,
     origin: LinearDev,
+    origin_table: Vec<TargetLine<LinearDevTargetParams>>,
     cap: Option<LinearDev>,
     new: bool,
 ) -> Result<CacheDev, MakeCacheError> {
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
-    let meta = match LinearDev::setup(
+    let mut meta = match LinearDev::setup(
         get_dm(),
         &dm_name,
         Some(&dm_uuid),
@@ -87,19 +88,23 @@ fn make_cache(
             Sectors(0),
             cmp::min(Sectors(8), meta.size()),
         ) {
+            let _ = meta.teardown(get_dm());
             return Err(Box::new((e, Some(origin), cap)));
         }
     }
 
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::CacheSub);
-    let cache = match LinearDev::setup(
+    let mut cache = match LinearDev::setup(
         get_dm(),
         &dm_name,
         Some(&dm_uuid),
         cache_tier.cache_segments.map_to_dm(),
     ) {
         Ok(c) => c,
-        Err(e) => return Err(Box::new((e.into(), Some(origin), cap))),
+        Err(e) => {
+            let _ = meta.teardown(get_dm());
+            return Err(Box::new((e.into(), Some(origin), cap)));
+        }
     };
 
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::Cache);
@@ -109,6 +114,8 @@ fn make_cache(
             &DevId::Name(&dm_name),
             DmOptions::default().set_flags(DmFlags::DM_SUSPEND),
         ) {
+            let _ = cache.teardown(get_dm());
+            let _ = meta.teardown(get_dm());
             return Err(Box::new((e.into(), Some(origin), cap)));
         }
         let table = CacheDevTargetTable::new(
@@ -129,9 +136,13 @@ fn make_cache(
             &table.to_raw_table(),
             DmOptions::default(),
         ) {
+            let _ = cache.teardown(get_dm());
+            let _ = meta.teardown(get_dm());
             return Err(Box::new((e.into(), Some(origin), cap)));
         }
         if let Err(e) = dm.device_suspend(&DevId::Name(&dm_name), DmOptions::private()) {
+            let _ = cache.teardown(get_dm());
+            let _ = meta.teardown(get_dm());
             return Err(Box::new((e.into(), Some(origin), cap)));
         }
     };
@@ -145,7 +156,12 @@ fn make_cache(
         CACHE_BLOCK_SIZE,
     ) {
         Ok(cd) => Ok(cd),
-        Err(e) => Err(Box::new((e.into(), None, cap))),
+        Err(e) => {
+            let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
+            let maybe_origin =
+                LinearDev::setup(get_dm(), &dm_name, Some(&dm_uuid), origin_table).ok();
+            Err(Box::new((e.into(), maybe_origin, cap)))
+        }
     }
 }
 
@@ -565,10 +581,17 @@ impl Backstore {
                         }
                     };
 
-                    let cache_device = match make_cache(pool_uuid, &cache_tier, origin, None, false)
-                    {
+                    let cache_device = match make_cache(
+                        pool_uuid,
+                        &cache_tier,
+                        origin,
+                        data_tier.segments.map_to_dm(),
+                        None,
+                        false,
+                    ) {
                         Ok(cd) => cd,
-                        Err(boxed) => { let (e, _origin, _cap) = *boxed;
+                        Err(boxed) => {
+                            let (e, _origin, _cap) = *boxed;
                             return Err(e);
                         }
                     };
@@ -725,9 +748,17 @@ impl Backstore {
                         .take()
                         .expect("some space has already been allocated from the backstore => (cache_tier.is_none() <=> self.placeholder.is_some())");
 
-                let cache = match make_cache(pool_uuid, &cache_tier, origin, Some(placeholder), true) {
+                let cache = match make_cache(
+                    pool_uuid,
+                    &cache_tier,
+                    origin,
+                    self.data_tier.segments.map_to_dm(),
+                    Some(placeholder),
+                    true,
+                ) {
                     Ok(cache) => cache,
-                    Err(boxed) => { let (e, maybe_origin, maybe_placeholder) = *boxed;
+                    Err(boxed) => {
+                        let (e, maybe_origin, maybe_placeholder) = *boxed;
                         self.cap_device.origin = maybe_origin;
                         self.cap_device.placeholder = maybe_placeholder;
                         return Err(e);

--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -774,7 +774,9 @@ impl Backstore {
 
                 let origin = self.cap_device.origin
                         .take()
-                        .expect("some space has already been allocated from the backstore => (cache_tier.is_none() <=> self.origin.is_some())");
+                        .ok_or_else(|| StratisError::Msg(
+                            "Expected origin device but it was not present; cap device is in an inconsistent state".to_string()
+                        ))?;
                 let placeholder = self.cap_device.placeholder
                         .take()
                         .expect("some space has already been allocated from the backstore => (cache_tier.is_none() <=> self.placeholder.is_some())");

--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -791,10 +791,10 @@ impl Backstore {
                 ) {
                     Ok(cache) => cache,
                     Err(boxed) => {
-                        let err = *boxed;
-                        self.cap_device.origin = err.origin;
-                        self.cap_device.placeholder = err.cap;
-                        return Err(err.error);
+                        let MakeCacheError { error, origin, cap } = *boxed;
+                        self.cap_device.origin = origin;
+                        self.cap_device.placeholder = cap;
+                        return Err(error);
                     }
                 };
 

--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -58,7 +58,11 @@ use crate::{
 /// typical size.
 const CACHE_BLOCK_SIZE: Sectors = Sectors(2048); // 1024 KiB
 
-type MakeCacheError = Box<(StratisError, Option<LinearDev>, Option<LinearDev>)>;
+struct MakeCacheError {
+    error: StratisError,
+    origin: Option<LinearDev>,
+    cap: Option<LinearDev>,
+}
 
 /// Make a DM cache device. If the cache device is being made new,
 /// take extra steps to make it clean.
@@ -69,7 +73,7 @@ fn make_cache(
     origin_table: Vec<TargetLine<LinearDevTargetParams>>,
     cap: Option<LinearDev>,
     new: bool,
-) -> Result<CacheDev, MakeCacheError> {
+) -> Result<CacheDev, Box<MakeCacheError>> {
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
     let mut meta = match LinearDev::setup(
         get_dm(),
@@ -78,7 +82,13 @@ fn make_cache(
         cache_tier.meta_segments.map_to_dm(),
     ) {
         Ok(m) => m,
-        Err(e) => return Err(Box::new((e.into(), Some(origin), cap))),
+        Err(e) => {
+            return Err(Box::new(MakeCacheError {
+                error: e.into(),
+                origin: Some(origin),
+                cap,
+            }))
+        }
     };
 
     if new {
@@ -89,7 +99,11 @@ fn make_cache(
             cmp::min(Sectors(8), meta.size()),
         ) {
             let _ = meta.teardown(get_dm());
-            return Err(Box::new((e, Some(origin), cap)));
+            return Err(Box::new(MakeCacheError {
+                error: e,
+                origin: Some(origin),
+                cap,
+            }));
         }
     }
 
@@ -103,7 +117,11 @@ fn make_cache(
         Ok(c) => c,
         Err(e) => {
             let _ = meta.teardown(get_dm());
-            return Err(Box::new((e.into(), Some(origin), cap)));
+            return Err(Box::new(MakeCacheError {
+                error: e.into(),
+                origin: Some(origin),
+                cap,
+            }));
         }
     };
 
@@ -116,7 +134,11 @@ fn make_cache(
         ) {
             let _ = cache.teardown(get_dm());
             let _ = meta.teardown(get_dm());
-            return Err(Box::new((e.into(), Some(origin), cap)));
+            return Err(Box::new(MakeCacheError {
+                error: e.into(),
+                origin: Some(origin),
+                cap,
+            }));
         }
         let table = CacheDevTargetTable::new(
             Sectors(0),
@@ -138,12 +160,20 @@ fn make_cache(
         ) {
             let _ = cache.teardown(get_dm());
             let _ = meta.teardown(get_dm());
-            return Err(Box::new((e.into(), Some(origin), cap)));
+            return Err(Box::new(MakeCacheError {
+                error: e.into(),
+                origin: Some(origin),
+                cap,
+            }));
         }
         if let Err(e) = dm.device_suspend(&DevId::Name(&dm_name), DmOptions::private()) {
             let _ = cache.teardown(get_dm());
             let _ = meta.teardown(get_dm());
-            return Err(Box::new((e.into(), Some(origin), cap)));
+            return Err(Box::new(MakeCacheError {
+                error: e.into(),
+                origin: Some(origin),
+                cap,
+            }));
         }
     };
     match CacheDev::setup(
@@ -160,7 +190,11 @@ fn make_cache(
             let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::OriginSub);
             let maybe_origin =
                 LinearDev::setup(get_dm(), &dm_name, Some(&dm_uuid), origin_table).ok();
-            Err(Box::new((e.into(), maybe_origin, cap)))
+            Err(Box::new(MakeCacheError {
+                error: e.into(),
+                origin: maybe_origin,
+                cap,
+            }))
         }
     }
 }
@@ -591,8 +625,7 @@ impl Backstore {
                     ) {
                         Ok(cd) => cd,
                         Err(boxed) => {
-                            let (e, _origin, _cap) = *boxed;
-                            return Err(e);
+                            return Err(boxed.error);
                         }
                     };
                     (None, Some(cache_device), Some(cache_tier), None)
@@ -758,10 +791,10 @@ impl Backstore {
                 ) {
                     Ok(cache) => cache,
                     Err(boxed) => {
-                        let (e, maybe_origin, maybe_placeholder) = *boxed;
-                        self.cap_device.origin = maybe_origin;
-                        self.cap_device.placeholder = maybe_placeholder;
-                        return Err(e);
+                        let err = *boxed;
+                        self.cap_device.origin = err.origin;
+                        self.cap_device.placeholder = err.cap;
+                        return Err(err.error);
                     }
                 };
 

--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -64,15 +64,14 @@ struct MakeCacheError {
     cap: Option<LinearDev>,
 }
 
-/// Make a DM cache device. If the cache device is being made new,
-/// take extra steps to make it clean.
+/// Make a DM cache device. If a cap device is provided, the cache
+/// is being newly created, so take extra steps to make it clean.
 fn make_cache(
     pool_uuid: PoolUuid,
     cache_tier: &CacheTier<StratBlockDev>,
     origin: LinearDev,
     origin_table: Vec<TargetLine<LinearDevTargetParams>>,
     cap: Option<LinearDev>,
-    new: bool,
 ) -> Result<CacheDev, Box<MakeCacheError>> {
     let (dm_name, dm_uuid) = format_backstore_ids(pool_uuid, CacheRole::MetaSub);
     let mut meta = match LinearDev::setup(
@@ -91,7 +90,7 @@ fn make_cache(
         }
     };
 
-    if new {
+    if cap.is_some() {
         // See comment in ThinPool::new() method
         if let Err(e) = wipe_sectors(
             meta.devnode(),
@@ -621,7 +620,6 @@ impl Backstore {
                         origin,
                         data_tier.segments.map_to_dm(),
                         None,
-                        false,
                     ) {
                         Ok(cd) => cd,
                         Err(boxed) => {
@@ -787,7 +785,6 @@ impl Backstore {
                     origin,
                     self.data_tier.segments.map_to_dm(),
                     Some(placeholder),
-                    true,
                 ) {
                     Ok(cache) => cache,
                     Err(boxed) => {


### PR DESCRIPTION
Fixes the resource leak and invalid `CapDevice` state identified in #4005 (CodeRabbit finding from PR #3996).

In `init_cache`, `self.cap_device.origin` and `self.cap_device.placeholder` are moved out via `.take()` before calling `make_cache`. If `make_cache` fails, these values are dropped and `CapDevice` is left in an invalid state with all three fields (`origin`, `placeholder`, `cache`) set to `None`.

### Two approaches considered:

1. **Change `make_cache` to return owned values on error (chosen):** Replace all `?` operators in `make_cache` with explicit `match`/`if let` blocks that carry the `origin` and `cap` (`placeholder`) values through each error path. The caller destructures the error and restores `CapDevice` fields.
2. **Rollback at the call site by reconstructing DM devices:** On `make_cache` failure, call `make_placeholder_dev` to rebuild the placeholder device. I did not chose this approach because `make_cache` could leave DM devices in a partially suspended state, making it unsafe to reconstruct them from the same underlying device.

### Changes:
  - Added type alias `MakeCacheError` for the boxed error tuple because the unboxed tuple carries two `LinearDev` values and is large enough to bloat every `Result` return in `make_cache`
  - Changed `make_cache` return type from `StratisResult<CacheDev>` to `Result<CacheDev, MakeCacheError>`
  - Replaced all 7 `?` operators in `make_cache` with `match`/`if let Err` blocks that return `(StratisError, Option<LinearDev>, Option<LinearDev>)`
  - Updated `init_cache` call site to restore `self.cap_device.origin` and `self.cap_device.placeholder` from the returned error values
  - Updated setup call site to destructure the new error type

### Test plan:
  - [x] `make -f Makefile clippy passes`
  - [x] `make -f Makefile test passes`
  - [x] `sudo make -f Makefile test-loop-root` (all cache-related tests pass; 5 pre-existing failures in thinpool/engine tests confirmed on unmodified master)

### Known limitation:

When the final `CacheDev::setup` call fails, `origin` has already been consumed by `value`, so it is returned as `None`. In this case, `init_cache` restores `placeholder` but cannot restore `origin`. This is a narrower failure mode than the original bug (where both values were always lost), and rebuilding the origin device in this case would need the same DM device reconstruction that led me to pick this approach over a call-site rollback. Chose not to rebuild `origin` on the `None` path, to fix this, but happy to add that if preferred.

@jbaublitz 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache initialization so partially created device mappings are reliably cleaned up on failure.
  * Preserved and restored cache/origin configuration where possible when setup fails mid-way.
  * Reduced the likelihood of inconsistent backstore state or leftover resources after unsuccessful setup.
  * Enhanced cache-creation error reporting with more complete causal context and original configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->