### PR TITLE
Issue stratisd 3922: Expose MetadataUsed property on pool D-Bus interface r10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "stratisd"
-version = "3.9.2"
+version = "3.10.0"
 dependencies = [
  "assert_cmd",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratisd"
-version = "3.9.2"
+version = "3.10.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/src/dbus/blockdev/blockdev_3_10/mod.rs
+++ b/src/dbus/blockdev/blockdev_3_10/mod.rs
@@ -1,0 +1,182 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use zbus::{
+    self,
+    fdo::Error,
+    interface,
+    zvariant::{ObjectPath, OwnedObjectPath},
+    Connection,
+};
+
+use crate::dbus::blockdev::blockdev_3_0::{
+    devnode_prop, hardware_info_prop, init_time_prop, physical_path_prop, pool_prop, tier_prop,
+    total_physical_size_prop, user_info_prop,
+};
+use crate::{
+    dbus::{
+        blockdev::shared::{blockdev_prop, set_blockdev_prop},
+        manager::Manager,
+    },
+    engine::{DevUuid, Engine, Lockable, PoolUuid},
+    stratis::StratisResult,
+};
+
+use crate::dbus::blockdev::blockdev_3_3::{
+    new_physical_size_prop, send_user_info_signal_on_change, set_user_info_prop,
+};
+
+pub struct BlockdevR10 {
+    engine: Arc<dyn Engine>,
+    connection: Arc<Connection>,
+    manager: Lockable<Arc<RwLock<Manager>>>,
+    parent_uuid: PoolUuid,
+    uuid: DevUuid,
+}
+
+impl BlockdevR10 {
+    fn new(
+        engine: Arc<dyn Engine>,
+        connection: Arc<Connection>,
+        manager: Lockable<Arc<RwLock<Manager>>>,
+        parent_uuid: PoolUuid,
+        uuid: DevUuid,
+    ) -> Self {
+        BlockdevR10 {
+            engine,
+            connection,
+            manager,
+            parent_uuid,
+            uuid,
+        }
+    }
+
+    pub async fn register(
+        engine: Arc<dyn Engine>,
+        connection: &Arc<Connection>,
+        manager: &Lockable<Arc<RwLock<Manager>>>,
+        path: ObjectPath<'_>,
+        parent_uuid: PoolUuid,
+        uuid: DevUuid,
+    ) -> StratisResult<()> {
+        let blockdev = Self::new(
+            engine,
+            Arc::clone(connection),
+            manager.clone(),
+            parent_uuid,
+            uuid,
+        );
+
+        connection.object_server().at(path, blockdev).await?;
+        Ok(())
+    }
+
+    pub async fn unregister(
+        connection: &Arc<Connection>,
+        path: ObjectPath<'_>,
+    ) -> StratisResult<()> {
+        connection
+            .object_server()
+            .remove::<BlockdevR10, _>(path)
+            .await?;
+        Ok(())
+    }
+}
+
+#[interface(name = "org.storage.stratis3.blockdev.r10", introspection_docs = false)]
+impl BlockdevR10 {
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn devnode(&self) -> Result<String, Error> {
+        blockdev_prop(&self.engine, self.parent_uuid, self.uuid, devnode_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn hardware_info(&self) -> Result<(bool, String), Error> {
+        blockdev_prop(
+            &self.engine,
+            self.parent_uuid,
+            self.uuid,
+            hardware_info_prop,
+        )
+        .await
+    }
+
+    #[zbus(property)]
+    async fn user_info(&self) -> Result<(bool, String), Error> {
+        blockdev_prop(&self.engine, self.parent_uuid, self.uuid, user_info_prop).await
+    }
+
+    #[zbus(property)]
+    async fn set_user_info(&self, value: (bool, String)) -> Result<(), zbus::Error> {
+        set_blockdev_prop(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.parent_uuid,
+            self.uuid,
+            value,
+            set_user_info_prop,
+            send_user_info_signal_on_change,
+        )
+        .await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn initialization_time(&self) -> Result<u64, Error> {
+        blockdev_prop(&self.engine, self.parent_uuid, self.uuid, init_time_prop)
+            .await
+            .and_then(|r| r)
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn pool(&self) -> Result<OwnedObjectPath, Error> {
+        pool_prop(self.manager.read().await, self.parent_uuid)
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    fn uuid(&self) -> String {
+        self.uuid.simple().to_string()
+    }
+
+    #[zbus(property(emits_changed_signal = "false"))]
+    async fn tier(&self) -> Result<u16, Error> {
+        blockdev_prop(&self.engine, self.parent_uuid, self.uuid, tier_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn physical_path(&self) -> Result<String, Error> {
+        blockdev_prop(
+            &self.engine,
+            self.parent_uuid,
+            self.uuid,
+            physical_path_prop,
+        )
+        .await
+    }
+
+    #[zbus(property)]
+    async fn total_physical_size(&self) -> Result<String, Error> {
+        blockdev_prop(
+            &self.engine,
+            self.parent_uuid,
+            self.uuid,
+            total_physical_size_prop,
+        )
+        .await
+    }
+
+    #[zbus(property)]
+    async fn new_physical_size(&self) -> Result<(bool, String), Error> {
+        blockdev_prop(
+            &self.engine,
+            self.parent_uuid,
+            self.uuid,
+            new_physical_size_prop,
+        )
+        .await
+    }
+}

--- a/src/dbus/blockdev/mod.rs
+++ b/src/dbus/blockdev/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 
 mod blockdev_3_0;
 mod blockdev_3_1;
+mod blockdev_3_10;
 mod blockdev_3_2;
 mod blockdev_3_3;
 mod blockdev_3_4;
@@ -31,6 +32,7 @@ mod shared;
 
 pub use blockdev_3_0::BlockdevR0;
 pub use blockdev_3_1::BlockdevR1;
+pub use blockdev_3_10::BlockdevR10;
 pub use blockdev_3_2::BlockdevR2;
 pub use blockdev_3_3::BlockdevR3;
 pub use blockdev_3_4::BlockdevR4;
@@ -173,6 +175,18 @@ pub async fn register_blockdev<'a>(
     {
         warn!("Failed to register interface blockdev.r9 for pool with UUID {pool_uuid}: {e}");
     };
+    if let Err(e) = BlockdevR10::register(
+        engine.clone(),
+        connection,
+        manager,
+        path.clone(),
+        pool_uuid,
+        dev_uuid,
+    )
+    .await
+    {
+        warn!("Failed to register interface blockdev.r10 for pool with UUID {pool_uuid}: {e}");
+    };
     manager.write().await.add_blockdev(&path, dev_uuid)?;
     Ok(path)
 }
@@ -192,6 +206,7 @@ pub async fn unregister_blockdev(
     BlockdevR7::unregister(connection, path.clone()).await?;
     BlockdevR8::unregister(connection, path.clone()).await?;
     BlockdevR9::unregister(connection, path.clone()).await?;
+    BlockdevR10::unregister(connection, path.clone()).await?;
 
     let mut lock = manager.write().await;
     let uuid = lock

--- a/src/dbus/filesystem/filesystem_3_10/mod.rs
+++ b/src/dbus/filesystem/filesystem_3_10/mod.rs
@@ -1,0 +1,197 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use zbus::{
+    fdo::Error,
+    interface,
+    zvariant::{ObjectPath, OwnedObjectPath},
+    Connection,
+};
+
+use crate::{
+    dbus::{
+        filesystem::{
+            filesystem_3_0::{
+                created_prop, devnode_prop, name_prop, pool_prop, set_name_method, size_prop,
+                used_prop,
+            },
+            filesystem_3_6::{
+                send_size_limit_signal_on_change, set_size_limit_prop, size_limit_prop,
+            },
+            filesystem_3_7::{
+                merge_scheduled_prop, origin_prop, send_merge_scheduled_signal_on_change,
+                set_merge_scheduled_prop,
+            },
+            shared::{filesystem_prop, set_filesystem_prop},
+        },
+        manager::Manager,
+    },
+    engine::{Engine, FilesystemUuid, Lockable, Name, PoolUuid},
+    stratis::StratisResult,
+};
+
+pub struct FilesystemR10 {
+    engine: Arc<dyn Engine>,
+    connection: Arc<Connection>,
+    manager: Lockable<Arc<RwLock<Manager>>>,
+    parent_uuid: PoolUuid,
+    uuid: FilesystemUuid,
+}
+
+impl FilesystemR10 {
+    fn new(
+        engine: Arc<dyn Engine>,
+        connection: Arc<Connection>,
+        manager: Lockable<Arc<RwLock<Manager>>>,
+        parent_uuid: PoolUuid,
+        uuid: FilesystemUuid,
+    ) -> Self {
+        FilesystemR10 {
+            engine,
+            connection,
+            manager,
+            parent_uuid,
+            uuid,
+        }
+    }
+
+    pub async fn register(
+        engine: Arc<dyn Engine>,
+        connection: &Arc<Connection>,
+        manager: &Lockable<Arc<RwLock<Manager>>>,
+        path: ObjectPath<'_>,
+        parent_uuid: PoolUuid,
+        uuid: FilesystemUuid,
+    ) -> StratisResult<()> {
+        let filesystem = Self::new(
+            engine,
+            Arc::clone(connection),
+            manager.clone(),
+            parent_uuid,
+            uuid,
+        );
+
+        connection.object_server().at(path, filesystem).await?;
+        Ok(())
+    }
+
+    pub async fn unregister(
+        connection: &Arc<Connection>,
+        path: ObjectPath<'_>,
+    ) -> StratisResult<()> {
+        connection
+            .object_server()
+            .remove::<FilesystemR10, _>(path)
+            .await?;
+        Ok(())
+    }
+}
+
+#[interface(
+    name = "org.storage.stratis3.filesystem.r10",
+    introspection_docs = false
+)]
+impl FilesystemR10 {
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn set_name(&self, name: &str) -> ((bool, String), u16, String) {
+        set_name_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.parent_uuid,
+            self.uuid,
+            name,
+        )
+        .await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn created(&self) -> Result<String, Error> {
+        filesystem_prop(&self.engine, self.parent_uuid, self.uuid, created_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "invalidates"))]
+    async fn devnode(&self) -> Result<String, Error> {
+        filesystem_prop(&self.engine, self.parent_uuid, self.uuid, devnode_prop).await
+    }
+
+    #[zbus(property)]
+    async fn merge_scheduled(&self) -> Result<bool, Error> {
+        filesystem_prop(
+            &self.engine,
+            self.parent_uuid,
+            self.uuid,
+            merge_scheduled_prop,
+        )
+        .await
+    }
+
+    #[zbus(property)]
+    async fn set_merge_scheduled(&self, value: bool) -> Result<(), Error> {
+        set_filesystem_prop(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.parent_uuid,
+            self.uuid,
+            value,
+            set_merge_scheduled_prop,
+            send_merge_scheduled_signal_on_change,
+        )
+        .await
+    }
+
+    #[zbus(property)]
+    async fn name(&self) -> Result<Name, Error> {
+        filesystem_prop(&self.engine, self.parent_uuid, self.uuid, name_prop).await
+    }
+
+    #[zbus(property)]
+    async fn origin(&self) -> Result<(bool, String), Error> {
+        filesystem_prop(&self.engine, self.parent_uuid, self.uuid, origin_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn pool(&self) -> Result<OwnedObjectPath, Error> {
+        pool_prop(self.manager.read().await, self.parent_uuid)
+    }
+
+    #[zbus(property)]
+    async fn size(&self) -> Result<String, Error> {
+        filesystem_prop(&self.engine, self.parent_uuid, self.uuid, size_prop).await
+    }
+
+    #[zbus(property)]
+    async fn size_limit(&self) -> Result<(bool, String), Error> {
+        filesystem_prop(&self.engine, self.parent_uuid, self.uuid, size_limit_prop).await
+    }
+
+    #[zbus(property)]
+    async fn set_size_limit(&self, value: (bool, String)) -> Result<(), Error> {
+        set_filesystem_prop(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.parent_uuid,
+            self.uuid,
+            value,
+            set_size_limit_prop,
+            send_size_limit_signal_on_change,
+        )
+        .await
+    }
+
+    #[zbus(property)]
+    async fn used(&self) -> Result<(bool, String), Error> {
+        filesystem_prop(&self.engine, self.parent_uuid, self.uuid, used_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    fn uuid(&self) -> String {
+        self.uuid.simple().to_string()
+    }
+}

--- a/src/dbus/filesystem/mod.rs
+++ b/src/dbus/filesystem/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 
 mod filesystem_3_0;
 mod filesystem_3_1;
+mod filesystem_3_10;
 mod filesystem_3_2;
 mod filesystem_3_3;
 mod filesystem_3_4;
@@ -30,6 +31,7 @@ mod shared;
 
 pub use filesystem_3_0::FilesystemR0;
 pub use filesystem_3_1::FilesystemR1;
+pub use filesystem_3_10::FilesystemR10;
 pub use filesystem_3_2::FilesystemR2;
 pub use filesystem_3_3::FilesystemR3;
 pub use filesystem_3_4::FilesystemR4;
@@ -145,6 +147,15 @@ pub async fn register_filesystem<'a>(
         uuid,
     )
     .await?;
+    FilesystemR10::register(
+        engine.clone(),
+        connection,
+        manager,
+        path.clone(),
+        pool_uuid,
+        uuid,
+    )
+    .await?;
 
     Ok(path)
 }
@@ -173,6 +184,7 @@ pub async fn unregister_filesystem(
     FilesystemR7::unregister(connection, path.clone()).await?;
     FilesystemR8::unregister(connection, path.clone()).await?;
     FilesystemR9::unregister(connection, path.clone()).await?;
+    FilesystemR10::unregister(connection, path.clone()).await?;
 
     Ok(uuid)
 }

--- a/src/dbus/manager/manager_3_10/mod.rs
+++ b/src/dbus/manager/manager_3_10/mod.rs
@@ -1,0 +1,187 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::{
+    path::PathBuf,
+    sync::{atomic::AtomicU64, Arc},
+};
+
+use tokio::sync::RwLock;
+use zbus::{
+    interface,
+    zvariant::{Fd, ObjectPath, OwnedObjectPath},
+    Connection, Result,
+};
+
+use crate::{
+    dbus::{
+        consts,
+        manager::Manager,
+        manager::{
+            manager_3_0::{
+                destroy_pool_method, engine_state_report_method, list_keys_method, set_key_method,
+                unset_key_method, version_prop,
+            },
+            manager_3_2::refresh_state_method,
+            manager_3_6::stop_pool_method,
+            manager_3_8::{create_pool_method, stopped_pools_prop},
+            manager_3_9::start_pool_method,
+        },
+        types,
+    },
+    engine::{Engine, KeyDescription, Lockable, StoppedPoolsInfo},
+};
+
+pub struct ManagerR10 {
+    connection: Arc<Connection>,
+    engine: Arc<dyn Engine>,
+    manager: Lockable<Arc<RwLock<Manager>>>,
+    counter: Arc<AtomicU64>,
+}
+
+impl ManagerR10 {
+    pub fn new(
+        engine: Arc<dyn Engine>,
+        connection: Arc<Connection>,
+        manager: Lockable<Arc<RwLock<Manager>>>,
+        counter: Arc<AtomicU64>,
+    ) -> Self {
+        ManagerR10 {
+            connection,
+            engine,
+            manager,
+            counter,
+        }
+    }
+
+    pub async fn register(
+        engine: &Arc<dyn Engine>,
+        connection: &Arc<Connection>,
+        manager: &Lockable<Arc<RwLock<Manager>>>,
+        counter: &Arc<AtomicU64>,
+    ) -> Result<()> {
+        let manager = Self::new(
+            Arc::clone(engine),
+            Arc::clone(connection),
+            manager.clone(),
+            Arc::clone(counter),
+        );
+        connection
+            .object_server()
+            .at(consts::STRATIS_BASE_PATH, manager)
+            .await?;
+        Ok(())
+    }
+}
+
+#[interface(name = "org.storage.stratis3.Manager.r10")]
+impl ManagerR10 {
+    #[zbus(property(emits_changed_signal = "const"))]
+    #[allow(clippy::unused_self)]
+    fn version(&self) -> &str {
+        version_prop()
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn stopped_pools(&self) -> types::ManagerR8<StoppedPoolsInfo> {
+        stopped_pools_prop(&self.engine).await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn list_keys(&self) -> (Vec<KeyDescription>, u16, String) {
+        list_keys_method(&self.engine).await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn set_key(
+        &self,
+        key_desc: KeyDescription,
+        key_fd: Fd<'_>,
+    ) -> ((bool, bool), u16, String) {
+        set_key_method(&self.engine, &key_desc, key_fd).await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn unset_key(&self, key_desc: KeyDescription) -> (bool, u16, String) {
+        unset_key_method(&self.engine, &key_desc).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn create_pool(
+        &self,
+        name: &str,
+        devices: Vec<PathBuf>,
+        key_desc: Vec<((bool, u32), KeyDescription)>,
+        clevis_info: Vec<((bool, u32), &str, &str)>,
+        journal_size: (bool, u64),
+        tag_spec: (bool, &str),
+        allocate_superblock: (bool, bool),
+    ) -> ((bool, (OwnedObjectPath, Vec<OwnedObjectPath>)), u16, String) {
+        create_pool_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            &self.counter,
+            name,
+            devices,
+            key_desc,
+            clevis_info,
+            journal_size,
+            tag_spec,
+            allocate_superblock,
+        )
+        .await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn destroy_pool(&self, pool: ObjectPath<'_>) -> ((bool, String), u16, String) {
+        destroy_pool_method(&self.engine, &self.connection, &self.manager, pool).await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn start_pool(
+        &self,
+        id: &str,
+        id_type: &str,
+        unlock_method: (bool, (bool, u32)),
+        key_fd: (bool, Fd<'_>),
+        remove_cache: bool,
+    ) -> (
+        (
+            bool,
+            (OwnedObjectPath, Vec<OwnedObjectPath>, Vec<OwnedObjectPath>),
+        ),
+        u16,
+        String,
+    ) {
+        start_pool_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            &self.counter,
+            id,
+            id_type,
+            unlock_method,
+            key_fd,
+            remove_cache,
+        )
+        .await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn stop_pool(&self, id: &str, id_type: &str) -> ((bool, String), u16, String) {
+        stop_pool_method(&self.engine, &self.connection, &self.manager, id, id_type).await
+    }
+
+    #[zbus(out_args("return_code", "return_string"))]
+    async fn refresh_state(&self) -> (u16, String) {
+        refresh_state_method(&self.engine).await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    fn engine_state_report(&self) -> (String, u16, String) {
+        engine_state_report_method(&self.engine)
+    }
+}

--- a/src/dbus/manager/mod.rs
+++ b/src/dbus/manager/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 
 mod manager_3_0;
 mod manager_3_1;
+mod manager_3_10;
 mod manager_3_2;
 mod manager_3_3;
 mod manager_3_4;
@@ -32,6 +33,7 @@ mod manager_3_8;
 mod manager_3_9;
 mod report_3_0;
 mod report_3_1;
+mod report_3_10;
 mod report_3_2;
 mod report_3_3;
 mod report_3_4;
@@ -43,6 +45,7 @@ mod report_3_9;
 
 pub use manager_3_0::ManagerR0;
 pub use manager_3_1::ManagerR1;
+pub use manager_3_10::ManagerR10;
 pub use manager_3_2::ManagerR2;
 pub use manager_3_3::ManagerR3;
 pub use manager_3_4::ManagerR4;
@@ -53,6 +56,7 @@ pub use manager_3_8::ManagerR8;
 pub use manager_3_9::ManagerR9;
 pub use report_3_0::ReportR0;
 pub use report_3_1::ReportR1;
+pub use report_3_10::ReportR10;
 pub use report_3_2::ReportR2;
 pub use report_3_3::ReportR3;
 pub use report_3_4::ReportR4;
@@ -264,6 +268,9 @@ pub async fn register_manager(
     if let Err(e) = ManagerR9::register(engine, connection, manager, counter).await {
         warn!("Failed to register interface Manager.r9: {e}");
     }
+    if let Err(e) = ManagerR10::register(engine, connection, manager, counter).await {
+        warn!("Failed to register interface Manager.r10: {e}");
+    }
     if let Err(e) = ReportR0::register(engine, connection).await {
         warn!("Failed to register interface Report.r0: {e}");
     }
@@ -293,6 +300,9 @@ pub async fn register_manager(
     }
     if let Err(e) = ReportR9::register(engine, connection).await {
         warn!("Failed to register interface Report.r9: {e}");
+    }
+    if let Err(e) = ReportR10::register(engine, connection).await {
+        warn!("Failed to register interface Report.r10: {e}");
     }
     if let Err(e) = connection
         .object_server()

--- a/src/dbus/manager/report_3_10/mod.rs
+++ b/src/dbus/manager/report_3_10/mod.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::sync::Arc;
+
+use zbus::{interface, Connection, Result};
+
+use crate::{
+    dbus::{consts, manager::report_3_0::get_report_method},
+    engine::Engine,
+};
+
+pub struct ReportR10 {
+    engine: Arc<dyn Engine>,
+}
+
+impl ReportR10 {
+    pub fn new(engine: Arc<dyn Engine>) -> Self {
+        ReportR10 { engine }
+    }
+
+    pub async fn register(engine: &Arc<dyn Engine>, connection: &Arc<Connection>) -> Result<()> {
+        let report = Self::new(Arc::clone(engine));
+        connection
+            .object_server()
+            .at(consts::STRATIS_BASE_PATH, report)
+            .await?;
+        Ok(())
+    }
+}
+
+#[interface(name = "org.storage.stratis3.Report.r10", introspection_docs = false)]
+impl ReportR10 {
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    fn get_report(&self, name: &str) -> (String, u16, String) {
+        get_report_method(&self.engine, name)
+    }
+}

--- a/src/dbus/pool/mod.rs
+++ b/src/dbus/pool/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 
 mod pool_3_0;
 mod pool_3_1;
+mod pool_3_10;
 mod pool_3_2;
 mod pool_3_3;
 mod pool_3_4;
@@ -33,6 +34,7 @@ mod shared;
 
 pub use pool_3_0::PoolR0;
 pub use pool_3_1::PoolR1;
+pub use pool_3_10::PoolR10;
 pub use pool_3_2::PoolR2;
 pub use pool_3_3::PoolR3;
 pub use pool_3_4::PoolR4;
@@ -177,6 +179,18 @@ pub async fn register_pool<'a>(
             {
                 warn!("Failed to register interface pool.r9 for pool with UUID {pool_uuid}: {e}");
             }
+            if let Err(e) = PoolR10::register(
+                engine,
+                connection,
+                manager,
+                counter,
+                path.clone(),
+                pool_uuid,
+            )
+            .await
+            {
+                warn!("Failed to register interface pool.r10 for pool with UUID {pool_uuid}: {e}");
+            }
 
             manager.write().await.add_pool(&path, pool_uuid)?;
 
@@ -276,6 +290,9 @@ pub async fn unregister_pool(
     }
     if let Err(e) = PoolR9::unregister(connection, path.clone()).await {
         warn!("Failed to deregister interface pool.r9 for path {path}: {e}");
+    }
+    if let Err(e) = PoolR10::unregister(connection, path.clone()).await {
+        warn!("Failed to deregister interface pool.r10 for path {path}: {e}");
     }
 
     Ok(uuid)

--- a/src/dbus/pool/pool_3_10/mod.rs
+++ b/src/dbus/pool/pool_3_10/mod.rs
@@ -1,0 +1,476 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::{
+    path::PathBuf,
+    sync::{atomic::AtomicU64, Arc},
+};
+
+use tokio::sync::RwLock;
+use zbus::{
+    fdo::Error,
+    interface,
+    zvariant::{ObjectPath, OwnedObjectPath, Value},
+    Connection,
+};
+
+use crate::{
+    dbus::{
+        manager::Manager,
+        pool::{
+            pool_3_0::{
+                add_cache_devs_method, add_data_devs_method, allocated_prop,
+                avail_actions_property, destroy_filesystems_method, encrypted_prop,
+                has_cache_property, name_prop, set_name_method, size_prop,
+                snapshot_filesystem_method, used_prop,
+            },
+            pool_3_1::{
+                enable_overprovisioning_prop, fs_limit_prop, no_alloc_space_prop,
+                send_enable_overprovisioning_signal_on_change, send_fs_limit_signal_on_change,
+                set_enable_overprovisioning_prop, set_fs_limit_prop,
+            },
+            pool_3_3::grow_physical_device_method,
+            pool_3_5::init_cache_method,
+            pool_3_6::create_filesystems_method,
+            pool_3_7::{filesystem_metadata_method, metadata_method},
+            pool_3_8::{
+                bind_clevis_method, bind_keyring_method, clevis_infos_prop, free_token_slots_prop,
+                key_descs_prop, metadata_version_prop, rebind_clevis_method, rebind_keyring_method,
+                unbind_clevis_method, unbind_keyring_method, volume_key_loaded_prop,
+            },
+            pool_3_9::{
+                decrypt_pool_method, encrypt_pool_method, last_reencrypted_timestamp_prop,
+                reencrypt_pool_method,
+            },
+            shared::{pool_prop, set_pool_prop},
+        },
+        types::FilesystemSpec,
+    },
+    engine::{self, ActionAvailability, Engine, KeyDescription, Lockable, PoolUuid},
+    stratis::StratisResult,
+};
+
+pub struct PoolR10 {
+    connection: Arc<Connection>,
+    engine: Arc<dyn Engine>,
+    manager: Lockable<Arc<RwLock<Manager>>>,
+    counter: Arc<AtomicU64>,
+    uuid: PoolUuid,
+}
+
+impl PoolR10 {
+    fn new(
+        engine: Arc<dyn Engine>,
+        connection: Arc<Connection>,
+        manager: Lockable<Arc<RwLock<Manager>>>,
+        counter: Arc<AtomicU64>,
+        uuid: PoolUuid,
+    ) -> Self {
+        PoolR10 {
+            connection,
+            engine,
+            manager,
+            counter,
+            uuid,
+        }
+    }
+
+    pub async fn register(
+        engine: &Arc<dyn Engine>,
+        connection: &Arc<Connection>,
+        manager: &Lockable<Arc<RwLock<Manager>>>,
+        counter: &Arc<AtomicU64>,
+        path: ObjectPath<'_>,
+        uuid: PoolUuid,
+    ) -> StratisResult<()> {
+        let pool = Self::new(
+            Arc::clone(engine),
+            Arc::clone(connection),
+            manager.clone(),
+            Arc::clone(counter),
+            uuid,
+        );
+
+        connection.object_server().at(path, pool).await?;
+        Ok(())
+    }
+
+    pub async fn unregister(
+        connection: &Arc<Connection>,
+        path: ObjectPath<'_>,
+    ) -> StratisResult<()> {
+        connection
+            .object_server()
+            .remove::<PoolR10, _>(path)
+            .await?;
+        Ok(())
+    }
+}
+
+#[interface(name = "org.storage.stratis3.pool.r10")]
+impl PoolR10 {
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn create_filesystems(
+        &self,
+        specs: FilesystemSpec<'_>,
+    ) -> ((bool, Vec<(OwnedObjectPath, String)>), u16, String) {
+        create_filesystems_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            &self.counter,
+            self.uuid,
+            specs,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn destroy_filesystems(
+        &self,
+        filesystems: Vec<ObjectPath<'_>>,
+    ) -> ((bool, Vec<String>), u16, String) {
+        destroy_filesystems_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            filesystems,
+        )
+        .await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn snapshot_filesystem(
+        &self,
+        origin: ObjectPath<'_>,
+        snapshot_name: String,
+    ) -> ((bool, OwnedObjectPath), u16, String) {
+        snapshot_filesystem_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            &self.counter,
+            self.uuid,
+            origin,
+            snapshot_name,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn add_data_devs(
+        &self,
+        devices: Vec<PathBuf>,
+    ) -> ((bool, Vec<OwnedObjectPath>), u16, String) {
+        add_data_devs_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            &self.counter,
+            self.uuid,
+            devices,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn init_cache(
+        &self,
+        devices: Vec<PathBuf>,
+    ) -> ((bool, Vec<OwnedObjectPath>), u16, String) {
+        init_cache_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            &self.counter,
+            self.uuid,
+            devices,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn add_cache_devs(
+        &self,
+        devices: Vec<PathBuf>,
+    ) -> ((bool, Vec<OwnedObjectPath>), u16, String) {
+        add_cache_devs_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            &self.counter,
+            self.uuid,
+            devices,
+        )
+        .await
+    }
+
+    #[zbus(out_args("result", "return_code", "return_string"))]
+    async fn set_name(&self, name: &str) -> ((bool, String), u16, String) {
+        set_name_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            name,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn bind_clevis(
+        &self,
+        pin: String,
+        json: &str,
+        token_slot: (bool, u32),
+    ) -> (bool, u16, String) {
+        bind_clevis_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            pin,
+            json,
+            token_slot,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn bind_keyring(
+        &self,
+        key_desc: KeyDescription,
+        token_slot: (bool, u32),
+    ) -> (bool, u16, String) {
+        bind_keyring_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            key_desc,
+            token_slot,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn rebind_clevis(&self, token_slot: (bool, u32)) -> (bool, u16, String) {
+        rebind_clevis_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            token_slot,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn rebind_keyring(
+        &self,
+        key_desc: KeyDescription,
+        token_slot: (bool, u32),
+    ) -> (bool, u16, String) {
+        rebind_keyring_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            key_desc,
+            token_slot,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn unbind_clevis(&self, token_slot: (bool, u32)) -> (bool, u16, String) {
+        unbind_clevis_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            token_slot,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn unbind_keyring(&self, token_slot: (bool, u32)) -> (bool, u16, String) {
+        unbind_keyring_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            token_slot,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn grow_physical_device(&self, dev: &str) -> (bool, u16, String) {
+        grow_physical_device_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            dev,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn metadata(&self, current: bool) -> (String, u16, String) {
+        metadata_method(&self.engine, self.uuid, current).await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn filesystem_metadata(
+        &self,
+        fs_name: (bool, &str),
+        current: bool,
+    ) -> (String, u16, String) {
+        filesystem_metadata_method(&self.engine, self.uuid, fs_name, current).await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn encrypt_pool(
+        &self,
+        key_descs: Vec<((bool, u32), KeyDescription)>,
+        clevis_infos: Vec<((bool, u32), &str, &str)>,
+    ) -> (bool, u16, String) {
+        encrypt_pool_method(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            key_descs,
+            clevis_infos,
+        )
+        .await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn reencrypt_pool(&self) -> (bool, u16, String) {
+        reencrypt_pool_method(&self.engine, &self.connection, &self.manager, self.uuid).await
+    }
+
+    #[zbus(out_args("results", "return_code", "return_string"))]
+    async fn decrypt_pool(&self) -> (bool, u16, String) {
+        decrypt_pool_method(&self.engine, &self.connection, &self.manager, self.uuid).await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    fn uuid(&self) -> String {
+        self.uuid.simple().to_string()
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn name(&self) -> Result<engine::Name, Error> {
+        pool_prop(&self.engine, self.uuid, name_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn encrypted(&self) -> Result<bool, Error> {
+        pool_prop(&self.engine, self.uuid, encrypted_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn available_actions(&self) -> Result<ActionAvailability, Error> {
+        pool_prop(&self.engine, self.uuid, avail_actions_property).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn key_descriptions(&self) -> Result<Value<'_>, Error> {
+        pool_prop(&self.engine, self.uuid, key_descs_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn clevis_infos(&self) -> Result<Value<'_>, Error> {
+        pool_prop(&self.engine, self.uuid, clevis_infos_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn has_cache(&self) -> Result<bool, Error> {
+        pool_prop(&self.engine, self.uuid, has_cache_property).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn total_physical_size(&self) -> Result<String, Error> {
+        pool_prop(&self.engine, self.uuid, size_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn total_physical_used(&self) -> Result<(bool, String), Error> {
+        pool_prop(&self.engine, self.uuid, used_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn allocated_size(&self) -> Result<String, Error> {
+        pool_prop(&self.engine, self.uuid, allocated_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn fs_limit(&self) -> Result<u64, Error> {
+        pool_prop(&self.engine, self.uuid, fs_limit_prop).await
+    }
+
+    #[zbus(property)]
+    async fn set_fs_limit(&self, fs_limit: u64) -> Result<(), Error> {
+        set_pool_prop(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            set_fs_limit_prop,
+            fs_limit,
+            send_fs_limit_signal_on_change,
+        )
+        .await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn overprovisioning(&self) -> Result<bool, Error> {
+        pool_prop(&self.engine, self.uuid, enable_overprovisioning_prop).await
+    }
+
+    #[zbus(property)]
+    async fn set_overprovisioning(&self, overprov: bool) -> Result<(), Error> {
+        set_pool_prop(
+            &self.engine,
+            &self.connection,
+            &self.manager,
+            self.uuid,
+            set_enable_overprovisioning_prop,
+            overprov,
+            send_enable_overprovisioning_signal_on_change,
+        )
+        .await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn no_alloc_space(&self) -> Result<bool, Error> {
+        pool_prop(&self.engine, self.uuid, no_alloc_space_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn free_token_slots(&self) -> Result<(bool, u8), Error> {
+        pool_prop(&self.engine, self.uuid, free_token_slots_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "false"))]
+    async fn volume_key_loaded(&self) -> Result<Value<'_>, Error> {
+        pool_prop(&self.engine, self.uuid, volume_key_loaded_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn metadata_version(&self) -> Result<u64, Error> {
+        pool_prop(&self.engine, self.uuid, metadata_version_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn last_reencrypted_timestamp(&self) -> Result<(bool, String), Error> {
+        pool_prop(&self.engine, self.uuid, last_reencrypted_timestamp_prop).await
+    }
+}

--- a/src/dbus/pool/pool_3_10/mod.rs
+++ b/src/dbus/pool/pool_3_10/mod.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+mod props;
+
 use std::{
     path::PathBuf,
     sync::{atomic::AtomicU64, Arc},
@@ -30,6 +32,7 @@ use crate::{
                 send_enable_overprovisioning_signal_on_change, send_fs_limit_signal_on_change,
                 set_enable_overprovisioning_prop, set_fs_limit_prop,
             },
+            pool_3_10::props::metadata_used_prop,
             pool_3_3::grow_physical_device_method,
             pool_3_5::init_cache_method,
             pool_3_6::create_filesystems_method,
@@ -472,5 +475,10 @@ impl PoolR10 {
     #[zbus(property(emits_changed_signal = "true"))]
     async fn last_reencrypted_timestamp(&self) -> Result<(bool, String), Error> {
         pool_prop(&self.engine, self.uuid, last_reencrypted_timestamp_prop).await
+    }
+
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn metadata_used(&self) -> Result<String, Error> {
+        pool_prop(&self.engine, self.uuid, metadata_used_prop).await
     }
 }

--- a/src/dbus/pool/pool_3_10/props.rs
+++ b/src/dbus/pool/pool_3_10/props.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::engine::{Pool, PoolUuid, SomeLockReadGuard};
+
+pub fn metadata_used_prop(guard: SomeLockReadGuard<PoolUuid, dyn Pool>) -> String {
+    (*guard.metadata_used().bytes()).to_string()
+}

--- a/src/dbus/util.rs
+++ b/src/dbus/util.rs
@@ -27,7 +27,9 @@ use crate::{
             Manager, ManagerR0, ManagerR1, ManagerR2, ManagerR3, ManagerR4, ManagerR5, ManagerR6,
             ManagerR7, ManagerR8, ManagerR9,
         },
-        pool::{PoolR0, PoolR1, PoolR2, PoolR3, PoolR4, PoolR5, PoolR6, PoolR7, PoolR8, PoolR9},
+        pool::{
+            PoolR0, PoolR1, PoolR10, PoolR2, PoolR3, PoolR4, PoolR5, PoolR6, PoolR7, PoolR8, PoolR9,
+        },
         types::DbusErrorEnum,
     },
     engine::{FilesystemUuid, Lockable, PoolDiff, PoolUuid, StratFilesystemDiff},
@@ -366,6 +368,16 @@ pub async fn send_pool_background_signals(
                 "pool.r9"
             );
         }
+        if diff.pool.metadata_size.changed().is_some() {
+            send_signal!(
+                connection,
+                PoolR10,
+                pool_path,
+                metadata_used_changed,
+                "metadata used",
+                "pool.r10"
+            );
+        }
     }
 }
 
@@ -701,6 +713,16 @@ pub async fn send_pool_foreground_signals(
             no_alloc_space_changed,
             "no alloc space",
             "pool.r9"
+        );
+    }
+    if diff.pool.metadata_size.changed().is_some() {
+        send_signal!(
+            connection,
+            PoolR10,
+            pool_path,
+            metadata_used_changed,
+            "metadata used",
+            "pool.r10"
         );
     }
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -317,6 +317,9 @@ pub trait Pool: Debug + Send + Sync {
     /// store user data.
     fn total_physical_used(&self) -> Option<Sectors>;
 
+    /// The number of Sectors in this pool used for Stratis metadata.
+    fn metadata_used(&self) -> Sectors;
+
     /// Get all the filesystems belonging to this pool.
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)>;
 

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -818,6 +818,10 @@ impl Pool for SimPool {
         Some(Sectors(0))
     }
 
+    fn metadata_used(&self) -> Sectors {
+        Sectors(0)
+    }
+
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.filesystems
             .iter()

--- a/src/engine/strat_engine/pool/dispatch.rs
+++ b/src/engine/strat_engine/pool/dispatch.rs
@@ -196,6 +196,13 @@ impl Pool for AnyPool {
         }
     }
 
+    fn metadata_used(&self) -> Sectors {
+        match self {
+            AnyPool::V1(p) => p.metadata_used(),
+            AnyPool::V2(p) => p.metadata_used(),
+        }
+    }
+
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         match self {
             AnyPool::V1(p) => p.filesystems(),

--- a/src/engine/strat_engine/pool/v1.rs
+++ b/src/engine/strat_engine/pool/v1.rs
@@ -1210,6 +1210,10 @@ impl Pool for StratPool {
             .map(|u| u + self.metadata_size)
     }
 
+    fn metadata_used(&self) -> Sectors {
+        self.metadata_size
+    }
+
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.thin_pool
             .filesystems()

--- a/src/engine/strat_engine/pool/v2.rs
+++ b/src/engine/strat_engine/pool/v2.rs
@@ -1118,6 +1118,10 @@ impl Pool for StratPool {
             .map(|u| u + self.metadata_size)
     }
 
+    fn metadata_used(&self) -> Sectors {
+        self.metadata_size
+    }
+
     fn filesystems(&self) -> Vec<(Name, FilesystemUuid, &dyn Filesystem)> {
         self.thin_pool
             .filesystems()

--- a/stratisd.conf
+++ b/stratisd.conf
@@ -47,6 +47,9 @@
          send_interface="org.storage.stratis3.Report.r9"/>
 
   <allow send_destination="org.storage.stratis3"
+         send_interface="org.storage.stratis3.Report.r10"/>
+
+  <allow send_destination="org.storage.stratis3"
          send_interface="org.freedesktop.DBus.Properties"
          send_member="Get"/>
 
@@ -95,6 +98,10 @@
          send_member="EngineStateReport"/>
 
   <allow send_destination="org.storage.stratis3"
+         send_interface="org.storage.stratis3.Manager.r10"
+         send_member="EngineStateReport"/>
+
+  <allow send_destination="org.storage.stratis3"
          send_interface="org.storage.stratis3.Manager.r0"
          send_member="ListKeys"/>
 
@@ -132,6 +139,10 @@
 
   <allow send_destination="org.storage.stratis3"
          send_interface="org.storage.stratis3.Manager.r9"
+         send_member="ListKeys"/>
+
+  <allow send_destination="org.storage.stratis3"
+         send_interface="org.storage.stratis3.Manager.r10"
          send_member="ListKeys"/>
 </policy>
 

--- a/tests/client-dbus/src/stratisd_client_dbus/_constants.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_constants.py
@@ -18,7 +18,7 @@ General constants.
 SERVICE = "org.storage.stratis3"
 TOP_OBJECT = "/org/storage/stratis3"
 
-REVISION_NUMBER = 9
+REVISION_NUMBER = 10
 
 REVISION = f"r{REVISION_NUMBER}"
 

--- a/tests/client-dbus/src/stratisd_client_dbus/_introspect.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_introspect.py
@@ -14,8 +14,8 @@ SPECS = {
     </signal>
   </interface>
 """,
-    "org.storage.stratis3.Manager.r9": """
-<interface name="org.storage.stratis3.Manager.r9">
+    "org.storage.stratis3.Manager.r10": """
+<interface name="org.storage.stratis3.Manager.r10">
     <method name="CreatePool">
       <arg name="name" type="s" direction="in" />
       <arg name="devices" type="as" direction="in" />
@@ -84,8 +84,8 @@ SPECS = {
     </property>
   </interface>
 """,
-    "org.storage.stratis3.Report.r9": """
-<interface name="org.storage.stratis3.Report.r9">
+    "org.storage.stratis3.Report.r10": """
+<interface name="org.storage.stratis3.Report.r10">
     <method name="GetReport">
       <arg name="name" type="s" direction="in" />
       <arg name="result" type="s" direction="out" />
@@ -94,8 +94,8 @@ SPECS = {
     </method>
   </interface>
 """,
-    "org.storage.stratis3.blockdev.r9": """
-<interface name="org.storage.stratis3.blockdev.r9">
+    "org.storage.stratis3.blockdev.r10": """
+<interface name="org.storage.stratis3.blockdev.r10">
     <property name="Devnode" type="s" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
     </property>
@@ -122,8 +122,8 @@ SPECS = {
     </property>
   </interface>
 """,
-    "org.storage.stratis3.filesystem.r9": """
-<interface name="org.storage.stratis3.filesystem.r9">
+    "org.storage.stratis3.filesystem.r10": """
+<interface name="org.storage.stratis3.filesystem.r10">
     <method name="SetName">
       <arg name="name" type="s" direction="in" />
       <arg name="result" type="(bs)" direction="out" />
@@ -150,8 +150,8 @@ SPECS = {
     </property>
   </interface>
 """,
-    "org.storage.stratis3.pool.r9": """
-<interface name="org.storage.stratis3.pool.r9">
+    "org.storage.stratis3.pool.r10": """
+<interface name="org.storage.stratis3.pool.r10">
     <method name="AddCacheDevs">
       <arg name="devices" type="as" direction="in" />
       <arg name="results" type="(bao)" direction="out" />

--- a/tests/client-dbus/src/stratisd_client_dbus/_introspect.py
+++ b/tests/client-dbus/src/stratisd_client_dbus/_introspect.py
@@ -280,6 +280,7 @@ SPECS = {
     <property name="HasCache" type="b" access="read" />
     <property name="KeyDescriptions" type="v" access="read" />
     <property name="LastReencryptedTimestamp" type="(bs)" access="read" />
+    <property name="MetadataUsed" type="s" access="read" />
     <property name="MetadataVersion" type="t" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
     </property>


### PR DESCRIPTION
## Summary

Closes #3922

Based on #4058 this PR builds on the `jbaublitz:dbus-r10` branch which adds the pool r10 interface

Adds a `MetadataUsed` D-Bus property to the `org.storage.stratis3.pool.r10` interface, allowing users to query how much pool space is consumed by metadata.

## Changes

**Engine layer:**

- Added `metadata_used()` method to the `Pool` trait, returning `Sectors`
- Implemented in `strat_engine` v1 and v2 (returns `self.metadata_size`), `AnyPool` dispatch, and `sim_engine` (returns `Sectors(0)`)

**D-Bus layer:**

- Created `src/dbus/pool/pool_3_10/props.rs` with `metadata_used_prop` getter that converts the sector count to a byte string
- Wired the property into `PoolR10` as `#[zbus(property(emits_changed_signal = "true"))]`
- Added `metadata_used_changed` signal emission in both `send_pool_background_signals` and `send_pool_foreground_signals` in `util.rs`, triggered when `diff.pool.metadata_size`
  changes

@jbaublitz @mulkieran 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stratis 3.10 D-Bus interfaces for managers, reports, pools, filesystems, and block devices, including support for the new versioned object registration and teardown.
  * Introduced pool metadata usage reporting, including a new `MetadataUsed` property and corresponding change notifications.
* **Chores**
  * Updated the Stratis 3.10 package and client D-Bus interface revision.
  * Updated D-Bus policies and introspection definitions for the 3.10 interfaces (including `MetadataUsed`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->