### PR TITLE
Take partial steps toward upgrading stratisd to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,6 +300,13 @@ unused = { level = "deny", priority = 2}
 rust_2018_idioms = { level = "deny", priority = 3 }
 nonstandard_style = { level = "deny", priority = 4 }
 
+rust-2024-compatibility = { level = "deny", priority = 5}
+edition-2024-expr-fragment-specifier = { level = "allow", priority = 6}
+if-let-rescope = { level = "allow", priority = 6}
+rust-2024-incompatible-pat = { level = "allow", priority = 6}
+tail-expr-drop-order = { level = "allow", priority = 6}
+unsafe-op-in-unsafe-fn = { level = "allow", priority = 6}
+
 [lints.clippy]
 all = { level = "deny" }
 cargo = { level = "deny", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,7 +303,6 @@ nonstandard_style = { level = "deny", priority = 4 }
 rust-2024-compatibility = { level = "deny", priority = 5}
 edition-2024-expr-fragment-specifier = { level = "allow", priority = 6}
 if-let-rescope = { level = "allow", priority = 6}
-rust-2024-incompatible-pat = { level = "allow", priority = 6}
 tail-expr-drop-order = { level = "allow", priority = 6}
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,7 +305,6 @@ edition-2024-expr-fragment-specifier = { level = "allow", priority = 6}
 if-let-rescope = { level = "allow", priority = 6}
 rust-2024-incompatible-pat = { level = "allow", priority = 6}
 tail-expr-drop-order = { level = "allow", priority = 6}
-unsafe-op-in-unsafe-fn = { level = "allow", priority = 6}
 
 [lints.clippy]
 all = { level = "deny" }

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,7 @@ fn main() {
                 "#include <systemd/sd-daemon.h>\n#include <systemd/sd-journal.h>",
             )
             .blocklist_type("max_align_t")
+            .wrap_unsafe_ops(true)
             .generate()
             .expect("Could not generate bindings for systemd");
 

--- a/src/bin/tools/dump_metadata.rs
+++ b/src/bin/tools/dump_metadata.rs
@@ -37,7 +37,7 @@ fn fmt_metadata(shr: &StaticHeaderResult, print_bytes: bool) -> String {
     if print_bytes {
         result += "\n\nBytes:\n\n";
         match &shr.bytes {
-            Ok(ref boxed) => {
+            Ok(boxed) => {
                 result += pretty_hex(boxed.as_ref()).as_str();
             }
             Err(e) => {

--- a/src/bin/utils/generators/lib.rs
+++ b/src/bin/utils/generators/lib.rs
@@ -51,7 +51,7 @@ pub fn get_kernel_cmdline() -> Result<HashMap<String, Option<Vec<String>>>, io::
         let value_in_map = cmdline_map.get_mut(&name);
         let value = name_value.next().map(|s| s.to_string());
         match value_in_map {
-            Some(Some(ref mut vec)) => {
+            Some(Some(vec)) => {
                 if let Some(v) = value {
                     vec.push(v);
                 }

--- a/src/engine/sim_engine/pool.rs
+++ b/src/engine/sim_engine/pool.rs
@@ -445,7 +445,7 @@ impl Pool for SimPool {
             OptionalTokenSlotInput::Some(t) => {
                 if let Some(info) = encryption_info.get_info(t) {
                     match info {
-                        UnlockMechanism::KeyDesc(ref key_desc) => {
+                        UnlockMechanism::KeyDesc(key_desc) => {
                             if key_description != key_desc {
                                 return Err(StratisError::Msg(format!(
                                     "Key slot {t} is already in use by key description {}; requested {}",
@@ -603,7 +603,7 @@ impl Pool for SimPool {
             .and_then(|t| encryption_info.get_info(t).map(|mech| (t, mech)))
         {
             match info {
-                UnlockMechanism::KeyDesc(ref key) => {
+                UnlockMechanism::KeyDesc(key) => {
                     if key != new_key_desc {
                         encryption_info.set_info(token_slot, UnlockMechanism::KeyDesc(new_key_desc.to_owned()))?;
                         Ok(RenameAction::Renamed(Key))

--- a/src/engine/strat_engine/backstore/backstore/v1.rs
+++ b/src/engine/strat_engine/backstore/backstore/v1.rs
@@ -625,9 +625,7 @@ impl Backstore {
             }
         };
 
-        if let Some((_, (ref existing_pin, ref existing_info))) =
-            encryption_info.single_clevis_info()
-        {
+        if let Some((_, (existing_pin, existing_info))) = encryption_info.single_clevis_info() {
             if existing_pin.as_str() == pin
                 && CryptHandle::can_unlock(
                     self.blockdevs()

--- a/src/engine/strat_engine/backstore/backstore/v2.rs
+++ b/src/engine/strat_engine/backstore/backstore/v2.rs
@@ -1180,7 +1180,7 @@ impl Backstore {
                 // Ignore thumbprint if stratis:tang:trust_url is set in the clevis_info
                 // config.
                 let info = handle.encryption_info().get_info(k);
-                if let Some(UnlockMechanism::KeyDesc(ref kd)) = info {
+                if let Some(UnlockMechanism::KeyDesc(kd)) = info {
                     if kd == key_desc {
                         Ok(None)
                     } else {
@@ -1239,7 +1239,7 @@ impl Backstore {
             Some(t) => {
                 let info = ei.get_info(t);
                 match info {
-                    Some(UnlockMechanism::KeyDesc(ref kd)) => if kd == key_desc {
+                    Some(UnlockMechanism::KeyDesc(kd)) => if kd == key_desc {
                         Ok(Some(false))
                     } else {
                         handle.rebind_keyring(t, key_desc)?;

--- a/src/engine/strat_engine/backstore/devices.rs
+++ b/src/engine/strat_engine/backstore/devices.rs
@@ -567,7 +567,7 @@ pub fn initialize_devices_legacy(
         // which will never have a hardware ID.
         let hw_id = match (underlying_device.crypt_handle().is_some(), id_wwn) {
             (true, _) => None,
-            (_, Some(Ok(ref hw_id))) => Some(hw_id.to_owned()),
+            (_, Some(Ok(hw_id))) => Some(hw_id.to_owned()),
             (_, Some(Err(_))) => {
                 warn!("Value for ID_WWN for device {} obtained from the udev database could not be decoded; inserting device into pool with UUID {} anyway",
                       underlying_device.physical_path().display(),
@@ -815,7 +815,7 @@ pub fn initialize_devices(
         // are always represented as logical, software-based devicemapper devices
         // which will never have a hardware ID.
         let hw_id = match id_wwn {
-            Some(Ok(ref hw_id)) => Some(hw_id.to_owned()),
+            Some(Ok(hw_id)) => Some(hw_id.to_owned()),
             Some(Err(_)) => {
                 warn!("Value for ID_WWN for device {} obtained from the udev database could not be decoded; inserting device into pool with UUID {} anyway",
                       devnode.display(),

--- a/src/engine/strat_engine/cmd.rs
+++ b/src/engine/strat_engine/cmd.rs
@@ -401,7 +401,7 @@ pub fn clevis_luks_bind(
             get_persistent_keyring()?;
             execute_cmd(&mut cmd)
         }
-        Either::Right(ref key) => {
+        Either::Right(key) => {
             cmd.stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());

--- a/src/engine/strat_engine/crypt/shared.rs
+++ b/src/engine/strat_engine/crypt/shared.rs
@@ -384,7 +384,7 @@ fn sss_dispatch(json: &Value, recursion_limit: u64) -> StratisResult<Value> {
 
     let mut pin_map = Map::new();
     for jwe in jwes {
-        if let Value::String(ref s) = jwe {
+        if let Value::String(s) = jwe {
             // NOTE: Workaround for the on-disk format for Shamir secret sharing
             // as written by clevis. The base64 encoded string delimits the end
             // of the JSON blob with a period.
@@ -399,7 +399,7 @@ fn sss_dispatch(json: &Value, recursion_limit: u64) -> StratisResult<Value> {
             let value: Value = serde_json::from_slice(&json_bytes)?;
             let (pin, value) = pin_dispatch(&value, recursion_limit - 1)?;
             match pin_map.get_mut(&pin) {
-                Some(Value::Array(ref mut vec)) => vec.push(value),
+                Some(Value::Array(vec)) => vec.push(value),
                 None => {
                     pin_map.insert(pin, Value::from(vec![value]));
                 }

--- a/src/engine/strat_engine/crypt/shared.rs
+++ b/src/engine/strat_engine/crypt/shared.rs
@@ -927,7 +927,7 @@ unsafe extern "C" fn open(
             if let Ok(mut g) = guard {
                 *g = Some(e);
             }
-            -1
+            -libc::EPERM
         }
     }
 }

--- a/src/engine/strat_engine/crypt/shared.rs
+++ b/src/engine/strat_engine/crypt/shared.rs
@@ -900,12 +900,12 @@ unsafe extern "C" fn open(
     #[allow(clippy::to_string_in_format_args)]
     match res {
         Ok(pass) => {
-            let malloc_pass = libc::malloc(pass.as_ref().len());
+            let malloc_pass = unsafe { libc::malloc(pass.as_ref().len()) };
             let pass_slice =
                 unsafe { from_raw_parts_mut::<u8>(malloc_pass.cast::<u8>(), pass.as_ref().len()) };
             pass_slice.copy_from_slice(pass.as_ref());
-            *buffer = malloc_pass.cast::<libc::c_char>();
-            *buffer_len = pass.as_ref().len();
+            unsafe { *buffer = malloc_pass.cast::<libc::c_char>() };
+            unsafe { *buffer_len = pass.as_ref().len() };
             0
         }
         Err(e) => {

--- a/src/engine/strat_engine/crypt/shared.rs
+++ b/src/engine/strat_engine/crypt/shared.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::{
+    cmp::max,
     fs::OpenOptions,
     io::{self, Seek, SeekFrom, Write},
     mem::forget,
@@ -900,12 +901,21 @@ unsafe extern "C" fn open(
     #[allow(clippy::to_string_in_format_args)]
     match res {
         Ok(pass) => {
-            let malloc_pass = unsafe { libc::malloc(pass.as_ref().len()) };
+            let pass_len = pass.as_ref().len();
+            let alloc_len = max(pass_len, 1);
+            let malloc_pass = unsafe { libc::malloc(alloc_len) };
+            if malloc_pass.is_null() {
+                warn!(
+                    "malloc() returned null when allocating {} bytes for passphrase",
+                    alloc_len
+                );
+                return -libc::ENOMEM;
+            }
             let pass_slice =
-                unsafe { from_raw_parts_mut::<u8>(malloc_pass.cast::<u8>(), pass.as_ref().len()) };
+                unsafe { from_raw_parts_mut::<u8>(malloc_pass.cast::<u8>(), pass_len) };
             pass_slice.copy_from_slice(pass.as_ref());
             unsafe { *buffer = malloc_pass.cast::<libc::c_char>() };
-            unsafe { *buffer_len = pass.as_ref().len() };
+            unsafe { *buffer_len = pass_len };
             0
         }
         Err(e) => {

--- a/src/engine/strat_engine/liminal/liminal.rs
+++ b/src/engine/strat_engine/liminal/liminal.rs
@@ -143,7 +143,7 @@ impl LiminalDevices {
                 for (dev_uuid, info) in map.iter() {
                     match info {
                         LInfo::Stratis(_) => (),
-                        LInfo::Luks(ref luks_info) => {
+                        LInfo::Luks(luks_info) => {
                             match handle_luks(luks_info, token_slot, passphrase) {
                                 Ok(()) => unlocked.push(*dev_uuid),
                                 Err(e) => return Err(e),

--- a/src/engine/strat_engine/pool/inspection.rs
+++ b/src/engine/strat_engine/pool/inspection.rs
@@ -258,7 +258,7 @@ impl DataDevice {
         for (_, &(_, length)) in self
             .extents
             .iter()
-            .filter(|(_, &(used, _))| used == DataDeviceUse::IntegrityMetadata)
+            .filter(|&(_, &(used, _))| used == DataDeviceUse::IntegrityMetadata)
         {
             if length % Sectors(8) != Sectors(0) {
                 errors.push(format!(

--- a/src/engine/structures/lock.rs
+++ b/src/engine/structures/lock.rs
@@ -492,7 +492,7 @@ where
     U: AsUuid,
 {
     match lock_key {
-        PoolIdentifier::Name(ref n) => unsafe { inner.get().as_ref() }
+        PoolIdentifier::Name(n) => unsafe { inner.get().as_ref() }
             .and_then(|i| i.get_by_name(n).map(|(u, _)| (u, n.clone()))),
         PoolIdentifier::Uuid(u) => {
             unsafe { inner.get().as_ref() }.and_then(|i| i.get_by_uuid(*u).map(|(n, _)| (*u, n)))

--- a/src/engine/types/keys.rs
+++ b/src/engine/types/keys.rs
@@ -380,11 +380,11 @@ impl EncryptionInfo {
         let entry = self.encryption_infos.entry(token_slot);
         match entry {
             Entry::Occupied(mut entry) => match entry.get_mut() {
-                UnlockMechanism::KeyDesc(ref mut kd) => match mech {
+                UnlockMechanism::KeyDesc(kd) => match mech {
                     UnlockMechanism::KeyDesc(kd_set) => *kd = kd_set,
                     UnlockMechanism::ClevisInfo(_) => return Err(StratisError::Msg("Binding is a key description but provided unlock mechanism is a Clevis binding".to_string())),
                 },
-                UnlockMechanism::ClevisInfo(ref mut clevis) => match mech {
+                UnlockMechanism::ClevisInfo(clevis) => match mech {
                     UnlockMechanism::KeyDesc(_) => return Err(StratisError::Msg("Binding is a Clevis binding but provided unlock mechanism is a key description".to_string())),
                     UnlockMechanism::ClevisInfo(clevis_set) => *clevis = clevis_set,
                 },
@@ -622,7 +622,7 @@ impl PoolEncryptionInfo {
     pub fn key_description(&self) -> StratisResult<Option<&KeyDescription>> {
         match self {
             PoolEncryptionInfo::KeyDesc(kd) | PoolEncryptionInfo::Both(kd, _) => {
-                if let MaybeInconsistent::No(ref key_description) = kd {
+                if let MaybeInconsistent::No(key_description) = kd {
                     Ok(Some(key_description))
                 } else {
                     Err(StratisError::Msg(
@@ -637,7 +637,7 @@ impl PoolEncryptionInfo {
     pub fn clevis_info(&self) -> StratisResult<Option<&ClevisInfo>> {
         match self {
             PoolEncryptionInfo::ClevisInfo(ci) | PoolEncryptionInfo::Both(_, ci) => {
-                if let MaybeInconsistent::No(ref clevis_info) = ci {
+                if let MaybeInconsistent::No(clevis_info) = ci {
                     Ok(Some(clevis_info))
                 } else {
                     Err(StratisError::Msg(

--- a/stratisd_proc_macros/src/lib.rs
+++ b/stratisd_proc_macros/src/lib.rs
@@ -255,7 +255,7 @@ fn process_item(mut item: Item) -> Item {
     };
 
     for impl_item in i.items.iter_mut() {
-        if let ImplItem::Fn(ref mut f) = impl_item {
+        if let ImplItem::Fn(f) = impl_item {
             if let Some(level) = get_attr_level(&mut f.attrs) {
                 add_method_guards(f, level);
             }


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/843

Continue to allow if-let-rescope lint and edition-2024-expr-fragment-specifier lint. Neither of these lints expose any worrisome patterns. However, if we do not allow them and continue to deny or warn on rust-2024-compatibility lints we will be flooded with annoying messages.

Continue to allow tail-expr-drop-order lint. This lint is the difficult one and probably every instance where a suspicious pattern is reported will have to be manually checked, because drop order of temporaries changes in edition 2024 and that can change the semantics.