### PR TITLE
Issue stratisd 3467: Support for filesystem sizes and filesystem size limits in early boot

### DIFF
--- a/src/bin/stratis-min/stratis-min.rs
+++ b/src/bin/stratis-min/stratis-min.rs
@@ -191,7 +191,9 @@ fn parse_args() -> Command {
             Command::new("filesystem").subcommands(vec![
                 Command::new("create")
                     .arg(Arg::new("pool_name").required(true))
-                    .arg(Arg::new("fs_name").required(true)),
+                    .arg(Arg::new("fs_name").required(true))
+                    .arg(Arg::new("size").long("size").num_args(1))
+                    .arg(Arg::new("size_limit").long("size-limit").num_args(1)),
                 Command::new("destroy")
                     .arg(Arg::new("pool_name").required(true))
                     .arg(Arg::new("fs_name").required(true)),
@@ -202,6 +204,10 @@ fn parse_args() -> Command {
                 Command::new("origin")
                     .arg(Arg::new("pool_name").required(true))
                     .arg(Arg::new("fs_name").required(true)),
+                Command::new("set-size-limit")
+                    .arg(Arg::new("pool_name").required(true))
+                    .arg(Arg::new("fs_name").required(true))
+                    .arg(Arg::new("size_limit").long("size-limit").num_args(1)),
             ]),
             Command::new("report"),
         ])
@@ -660,6 +666,14 @@ fn main() -> Result<(), String> {
             }
         } else if let Some(subcommand) = args.subcommand_matches("filesystem") {
             if let Some(args) = subcommand.subcommand_matches("create") {
+                let size = args
+                    .get_one::<String>("size")
+                    .map(|s| s.parse::<u128>())
+                    .transpose()?;
+                let size_limit = args
+                    .get_one::<String>("size_limit")
+                    .map(|s| s.parse::<u128>())
+                    .transpose()?;
                 filesystem::filesystem_create(
                     args.get_one::<String>("pool_name")
                         .expect("required")
@@ -667,6 +681,8 @@ fn main() -> Result<(), String> {
                     args.get_one::<String>("fs_name")
                         .expect("required")
                         .to_owned(),
+                    size,
+                    size_limit,
                 )?;
                 Ok(())
             } else if let Some(args) = subcommand.subcommand_matches("destroy") {
@@ -704,6 +720,21 @@ fn main() -> Result<(), String> {
                 .map(|origin| {
                     println!("{origin}");
                 })?;
+                Ok(())
+            } else if let Some(args) = subcommand.subcommand_matches("set-size-limit") {
+                let size_limit = args
+                    .get_one::<String>("size_limit")
+                    .map(|s| s.parse::<u128>())
+                    .transpose()?;
+                filesystem::filesystem_set_size_limit(
+                    args.get_one::<String>("pool_name")
+                        .expect("required")
+                        .to_owned(),
+                    args.get_one::<String>("fs_name")
+                        .expect("required")
+                        .to_owned(),
+                    size_limit,
+                )?;
                 Ok(())
             } else {
                 filesystem::filesystem_list()?;

--- a/src/jsonrpc/client/filesystem.rs
+++ b/src/jsonrpc/client/filesystem.rs
@@ -8,8 +8,13 @@ use crate::{
 };
 
 // stratis-min filesystem create
-pub fn filesystem_create(pool_name: String, filesystem_name: String) -> StratisResult<()> {
-    do_request_standard!(FsCreate, pool_name, filesystem_name)
+pub fn filesystem_create(
+    pool_name: String,
+    filesystem_name: String,
+    size: Option<u128>,
+    size_limit: Option<u128>,
+) -> StratisResult<()> {
+    do_request_standard!(FsCreate, pool_name, filesystem_name, size, size_limit)
 }
 
 // stratis-min filesystem [list]
@@ -58,4 +63,13 @@ pub fn filesystem_origin(pool_name: String, filesystem_name: String) -> StratisR
     } else {
         Ok(origin.unwrap_or_else(|| "None".to_string()))
     }
+}
+
+// stratis-min filesystem set-size-limit
+pub fn filesystem_set_size_limit(
+    pool_name: String,
+    filesystem_name: String,
+    size_limit: Option<u128>,
+) -> StratisResult<()> {
+    do_request_standard!(FsSetSizeLimit, pool_name, filesystem_name, size_limit)
 }

--- a/src/jsonrpc/interface.rs
+++ b/src/jsonrpc/interface.rs
@@ -64,10 +64,11 @@ pub enum StratisParamType {
     PoolIsStopped(PoolIdentifier<PoolUuid>),
     PoolHasPassphrase(PoolIdentifier<PoolUuid>),
     PoolIsBound(PoolIdentifier<PoolUuid>),
-    FsCreate(String, String),
+    FsCreate(String, String, Option<u128>, Option<u128>),
     FsDestroy(String, String),
     FsRename(String, String, String),
     FsOrigin(String, String),
+    FsSetSizeLimit(String, String, Option<u128>),
     FsList,
     Report,
 }
@@ -108,5 +109,6 @@ pub enum StratisRet {
     FsDestroy((bool, u16, String)),
     FsRename((bool, u16, String)),
     FsOrigin((Option<String>, u16, String)),
+    FsSetSizeLimit((bool, u16, String)),
     Report(Value),
 }

--- a/src/jsonrpc/server/filesystem.rs
+++ b/src/jsonrpc/server/filesystem.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use chrono::SecondsFormat;
 use tokio::task::block_in_place;
 
+use devicemapper::Bytes;
+
 use crate::{
     engine::{Engine, EngineAction, Name, PoolIdentifier},
     jsonrpc::interface::FsListType,
@@ -18,6 +20,8 @@ pub async fn filesystem_create<'a>(
     engine: Arc<dyn Engine>,
     pool_name: &'a str,
     name: &'a str,
+    size: Option<u128>,
+    size_limit: Option<u128>,
 ) -> StratisResult<bool> {
     let mut guard = engine
         .get_mut_pool(PoolIdentifier::Name(Name::new(pool_name.to_owned())))
@@ -26,7 +30,11 @@ pub async fn filesystem_create<'a>(
     let (_, pool_uuid, pool) = guard.as_mut_tuple();
     block_in_place(|| {
         Ok(pool
-            .create_filesystems(pool_name, pool_uuid, &[(name, None, None)])?
+            .create_filesystems(
+                pool_name,
+                pool_uuid,
+                &[(name, size.map(Bytes), size_limit.map(Bytes))],
+            )?
             .is_changed())
     })
 }
@@ -113,4 +121,25 @@ pub async fn filesystem_origin<'a>(
         .get_filesystem_by_name(&Name::new(fs_name.to_string()))
         .ok_or_else(|| StratisError::Msg(format!("No filesystem named {fs_name} found")))?;
     Ok(fs.origin().map(|u| u.as_simple().to_string()))
+}
+
+// stratis-min filesystem set-size-limit
+pub async fn filesystem_set_size_limit<'a>(
+    engine: Arc<dyn Engine>,
+    pool_name: &'a str,
+    fs_name: &'a str,
+    size_limit: Option<u128>,
+) -> StratisResult<bool> {
+    let mut pool = engine
+        .get_mut_pool(PoolIdentifier::Name(Name::new(pool_name.to_owned())))
+        .await
+        .ok_or_else(|| StratisError::Msg(format!("No pool named {pool_name} found")))?;
+    let (uuid, _) = pool
+        .get_filesystem_by_name(&Name::new(fs_name.to_string()))
+        .ok_or_else(|| StratisError::Msg(format!("No filesystem named {fs_name} found")))?;
+    block_in_place(|| {
+        Ok(pool
+            .set_fs_size_limit(uuid, size_limit.map(Bytes))?
+            .is_changed())
+    })
 }

--- a/src/jsonrpc/server/server.rs
+++ b/src/jsonrpc/server/server.rs
@@ -208,10 +208,11 @@ impl StratisParams {
                     false,
                 )))
             }
-            StratisParamType::FsCreate(pool_name, fs_name) => {
+            StratisParamType::FsCreate(pool_name, fs_name, size, size_limit) => {
                 expects_fd!(self.fd_opt, false);
                 Ok(StratisRet::FsCreate(stratis_result_to_return(
-                    filesystem::filesystem_create(engine, &pool_name, &fs_name).await,
+                    filesystem::filesystem_create(engine, &pool_name, &fs_name, size, size_limit)
+                        .await,
                     false,
                 )))
             }
@@ -240,6 +241,14 @@ impl StratisParams {
                 Ok(StratisRet::FsOrigin(stratis_result_to_return(
                     filesystem::filesystem_origin(engine, &pool_name, &fs_name).await,
                     None,
+                )))
+            }
+            StratisParamType::FsSetSizeLimit(pool_name, fs_name, size_limit) => {
+                expects_fd!(self.fd_opt, false);
+                Ok(StratisRet::FsSetSizeLimit(stratis_result_to_return(
+                    filesystem::filesystem_set_size_limit(engine, &pool_name, &fs_name, size_limit)
+                        .await,
+                    false,
                 )))
             }
             StratisParamType::Report => {


### PR DESCRIPTION
## Summary
Closes #3467

- Add optional `--size` and `--size-limit` parameters to `stratis-min filesystem create`
- Add new `stratis-min filesystem set-size-limit` subcommand
- Thread size and size_limit through all JSON-RPC IPC layers: wire protocol, server handler, server dispatch, client, and CLI

Changes bring early boot JSON-RPC interface to parity with the D-Bus API for filesystem size and size limit support

## Files changed

- `src/jsonrpc/interface.rs` — Add size/size_limit fields to `FsCreate`, add `FsSetSizeLimit` to `StratisParamType` and `StratisRet`
- `src/jsonrpc/server/filesystem.rs`: Accept size params in `filesystem_create`, add `filesystem_set_size_limit` handler
- `src/jsonrpc/server/server.rs`: Route new parameters and `FsSetSizeLimit` to handlers
- `src/jsonrpc/client/filesystem.rs`: Pass size params in `filesystem_create`, add `filesystem_set_size_limit` client function
- `src/bin/stratis-min/stratis-min.rs`: Add `--size`/`--size-limit` CLI args and `set-size-limit` subcommand


@jbaublitz @mulkieran 