### PR TITLE
Increase devicemapper dependency lower bound to 0.34.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ version = "2.3.0"
 optional = true
 
 [dependencies.devicemapper]
-version = "0.34.4"
+version = "0.34.6"
 optional = true
 
 [dependencies.either]


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/889